### PR TITLE
Rename type-metadata -> scale-info and delete lockfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "type-metadata"
+name = "scale-info"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
@@ -10,7 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-type-metadata-derive = { version = "0.1.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "0.1.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 
@@ -20,7 +20,7 @@ std = [
     "serde/std",
 ]
 derive = [
-    "type-metadata-derive"
+    "scale-info-derive"
 ]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# type-metadata
+# scale-info
 
-Compactly serialize meta information about types in your crate.
+Info about [SCALE](https://github.com/paritytech/parity-scale-codec) encodable Rust types.
 
 ## Design
 
@@ -10,7 +10,7 @@ Compactly serialize meta information about types in your crate.
 
 ## Overview
 
-Types are describes by their identification (ID) and their structure or definition.
+Types are described by their identification (ID) and their structure or definition.
 The ID stores information about the name of the type, where the type has been defined and generic types communicate their generic arguments.
 The definition communicates the underlying serialization and deserialization structure of the type,
 possibly revealing internal fields etc.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "type-metadata-derive"
+name = "scale-info-derive"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"

--- a/derive/src/impl_wrapper.rs
+++ b/derive/src/impl_wrapper.rs
@@ -32,7 +32,7 @@ pub fn wrap(ident: &Ident, trait_name: &'static str, impl_quote: TokenStream2) -
 			#[allow(unknown_lints)]
 			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
 			#[allow(rust_2018_idioms)]
-			use type_metadata as _type_metadata;
+			use scale_info as _scale_info;
 
 			#[cfg(not(feature = "std"))]
 			extern crate alloc;

--- a/derive/src/type_def.rs
+++ b/derive/src/type_def.rs
@@ -34,7 +34,7 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	let mut ast: DeriveInput = syn::parse2(input)?;
 
 	ast.generics.type_params_mut().for_each(|p| {
-		p.bounds.push(parse_quote!(_type_metadata::Metadata));
+		p.bounds.push(parse_quote!(_scale_info::Metadata));
 		p.bounds.push(parse_quote!('static));
 	});
 
@@ -48,8 +48,8 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	};
 
 	let has_type_def_impl = quote! {
-		impl #impl_generics _type_metadata::HasTypeDef for #ident #ty_generics #where_clause {
-			fn type_def() -> _type_metadata::TypeDef {
+		impl #impl_generics _scale_info::HasTypeDef for #ident #ty_generics #where_clause {
+			fn type_def() -> _scale_info::TypeDef {
 				#def.into()
 			}
 		}
@@ -64,15 +64,15 @@ fn generate_fields_def(fields: &FieldsList) -> TokenStream2 {
 	let fields_def = fields.iter().map(|f| {
 		let (ty, ident) = (&f.ty, &f.ident);
 		let meta_type = quote! {
-			<#ty as _type_metadata::Metadata>::meta_type()
+			<#ty as _scale_info::Metadata>::meta_type()
 		};
 		if let Some(i) = ident {
 			quote! {
-				_type_metadata::NamedField::new(stringify!(#i), #meta_type)
+				_scale_info::NamedField::new(stringify!(#i), #meta_type)
 			}
 		} else {
 			quote! {
-				_type_metadata::UnnamedField::new(#meta_type)
+				_scale_info::UnnamedField::new(#meta_type)
 			}
 		}
 	});
@@ -84,17 +84,17 @@ fn generate_struct_def(data_struct: &DataStruct) -> TokenStream2 {
 		Fields::Named(ref fs) => {
 			let fields = generate_fields_def(&fs.named);
 			quote! {
-				_type_metadata::TypeDefStruct::new(#fields)
+				_scale_info::TypeDefStruct::new(#fields)
 			}
 		}
 		Fields::Unnamed(ref fs) => {
 			let fields = generate_fields_def(&fs.unnamed);
 			quote! {
-				_type_metadata::TypeDefTupleStruct::new(#fields)
+				_scale_info::TypeDefTupleStruct::new(#fields)
 			}
 		}
 		Fields::Unit => quote! {
-			_type_metadata::TypeDefTupleStruct::unit()
+			_scale_info::TypeDefTupleStruct::unit()
 		},
 	}
 }
@@ -119,11 +119,11 @@ fn generate_c_like_enum_def(variants: &VariantList) -> TokenStream2 {
 			i as u64
 		};
 		quote! {
-			_type_metadata::ClikeEnumVariant::new(stringify!(#name), #discriminant)
+			_scale_info::ClikeEnumVariant::new(stringify!(#name), #discriminant)
 		}
 	});
 	quote! {
-		_type_metadata::TypeDefClikeEnum::new(__core::vec![#( #variants_def, )*])
+		_scale_info::TypeDefClikeEnum::new(__core::vec![#( #variants_def, )*])
 	}
 }
 
@@ -151,28 +151,28 @@ fn generate_enum_def(data_enum: &DataEnum) -> TokenStream2 {
 			Fields::Named(ref fs) => {
 				let fields = generate_fields_def(&fs.named);
 				quote! {
-					_type_metadata::EnumVariantStruct::new(#v_name, #fields).into()
+					_scale_info::EnumVariantStruct::new(#v_name, #fields).into()
 				}
 			}
 			Fields::Unnamed(ref fs) => {
 				let fields = generate_fields_def(&fs.unnamed);
 				quote! {
-					_type_metadata::EnumVariantTupleStruct::new(#v_name, #fields).into()
+					_scale_info::EnumVariantTupleStruct::new(#v_name, #fields).into()
 				}
 			}
 			Fields::Unit => quote! {
-				_type_metadata::EnumVariantUnit::new(#v_name).into()
+				_scale_info::EnumVariantUnit::new(#v_name).into()
 			},
 		}
 	});
 	quote! {
-		_type_metadata::TypeDefEnum::new(__core::vec![#( #variants_def, )*])
+		_scale_info::TypeDefEnum::new(__core::vec![#( #variants_def, )*])
 	}
 }
 
 fn generate_union_def(data_union: &DataUnion) -> TokenStream2 {
 	let fields = generate_fields_def(&data_union.fields.named);
 	quote! {
-		_type_metadata::TypeDefUnion::new(#fields)
+		_scale_info::TypeDefUnion::new(#fields)
 	}
 }

--- a/derive/src/type_id.rs
+++ b/derive/src/type_id.rs
@@ -31,7 +31,7 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	let mut ast: DeriveInput = syn::parse2(input)?;
 
 	ast.generics.type_params_mut().for_each(|p| {
-		p.bounds.push(parse_quote!(_type_metadata::Metadata));
+		p.bounds.push(parse_quote!(_scale_info::Metadata));
 		p.bounds.push(parse_quote!('static));
 	});
 
@@ -40,15 +40,15 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	let generic_type_ids = ast.generics.type_params().map(|ty| {
 		let ty_ident = &ty.ident;
 		quote! {
-			<#ty_ident as _type_metadata::Metadata>::meta_type()
+			<#ty_ident as _scale_info::Metadata>::meta_type()
 		}
 	});
 	let has_type_id_impl = quote! {
-		impl #impl_generics _type_metadata::HasTypeId for #ident #ty_generics #where_clause {
-			fn type_id() -> _type_metadata::TypeId {
-				_type_metadata::TypeIdCustom::new(
+		impl #impl_generics _scale_info::HasTypeId for #ident #ty_generics #where_clause {
+			fn type_id() -> _scale_info::TypeId {
+				_scale_info::TypeIdCustom::new(
 					stringify!(#ident),
-					_type_metadata::Namespace::from_module_path(module_path!())
+					_scale_info::Namespace::from_module_path(module_path!())
 						.expect("namespace from module path cannot fail"),
 					__core::vec![ #( #generic_type_ids ),* ],
 				).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,11 @@ extern crate alloc;
 /// # Example
 ///
 /// ```
-/// # use type_metadata::tuple_meta_type;
+/// # use scale_info::tuple_meta_type;
 /// assert_eq!(
 /// 	tuple_meta_type!(i32, [u8; 32], String),
 /// 	{
-/// 		use type_metadata::MetaType;
+/// 		use scale_info::MetaType;
 /// 		let mut vec = Vec::new();
 /// 		vec.push(MetaType::new::<i32>());
 /// 		vec.push(MetaType::new::<[u8; 32]>());
@@ -131,7 +131,7 @@ pub use self::{
 };
 
 #[cfg(feature = "derive")]
-pub use type_metadata_derive::{Metadata, TypeDef, TypeId};
+pub use scale_info_derive::{Metadata, TypeDef, TypeId};
 
 /// A super trait that shall be implemented by all types implementing
 /// `HasTypeId` and `HasTypedef` in order to more easily manage them.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -128,7 +128,7 @@ fn struct_with_generics() {
 	// Normal struct
 	let struct_bool_id = TypeIdCustom::new(
 		"MyStruct",
-		Namespace::new(vec!["type_metadata", "tests"]).unwrap(),
+		Namespace::new(vec!["scale_info", "tests"]).unwrap(),
 		tuple_meta_type!(bool),
 	);
 	assert_type_id!(MyStruct<bool>, struct_bool_id.clone());
@@ -140,7 +140,7 @@ fn struct_with_generics() {
 	type SelfTyped = MyStruct<Box<MyStruct<bool>>>;
 	let expected_type_id = TypeIdCustom::new(
 		"MyStruct",
-		Namespace::new(vec!["type_metadata", "tests"]).unwrap(),
+		Namespace::new(vec!["scale_info", "tests"]).unwrap(),
 		vec![<Box<MyStruct<bool>>>::meta_type()],
 	);
 	assert_type_id!(SelfTyped, expected_type_id);

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "type-metadata-test-suite"
+name = "scale-info-test-suite"
 version = "0.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-type-metadata = { path = "..", features = ["derive"] }
+scale-info = { path = "..", features = ["derive"] }
 
 serde = "1.0"
 serde_json = "1.0"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "type-metadata-derive-tests-no-std"
+name = "scale-info-derive-tests-no-std"
 version = "0.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-type-metadata = { path = "../..", default-features = false, features = ["derive"] }
+scale-info = { path = "../..", default-features = false, features = ["derive"] }
 
 libc = { version = "0.2", default-features = false }
 

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -58,7 +58,7 @@ unsafe impl GlobalAlloc for Allocator {
 	}
 }
 
-use type_metadata::Metadata;
+use scale_info::Metadata;
 
 #[allow(unused)]
 #[derive(Metadata)]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -22,7 +22,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, vec};
 
-use type_metadata::{
+use scale_info::{
 	tuple_meta_type, ClikeEnumVariant, EnumVariantStruct, EnumVariantTupleStruct, EnumVariantUnit, HasTypeDef,
 	HasTypeId, MetaType, Metadata, NamedField, Namespace, TypeDefClikeEnum, TypeDefEnum, TypeDefStruct,
 	TypeDefTupleStruct, TypeDefUnion, TypeId, TypeIdCustom, UnnamedField,

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -24,7 +24,7 @@ use alloc::{vec, vec::Vec};
 
 use serde::Serialize;
 use serde_json::json;
-use type_metadata::{form::CompactForm, IntoCompact as _, Metadata, Registry, TypeDef, TypeId};
+use scale_info::{form::CompactForm, IntoCompact as _, Metadata, Registry, TypeDef, TypeId};
 
 #[derive(Serialize)]
 struct TypeIdDef {


### PR DESCRIPTION
Repo copied from https://github.com/type-metadata/type-metadata, just doing some renames.

Also deletes `Cargo.lock` because this is a library.