### PR TITLE
Remove Metadata supertrait

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ struct Foo<T> {
 
 impl<T> TypeInfo for Foo<T>
 where
-    T: Metadata + 'static,
+    T: TypeInfo + 'static,
 {
     fn type_info() -> Type {
         Type::builder()
@@ -141,7 +141,7 @@ enum Foo<T>{
 
 impl<T> TypeInfo for Foo<T>
 where
-    T: Metadata + 'static,
+    T: TypeInfo + 'static,
 {
     fn type_info() -> Type {
         Type::builder()

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,8 +30,8 @@ use syn::{
 	Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Variant,
 };
 
-#[proc_macro_derive(Metadata)]
-pub fn metadata(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(TypeInfo)]
+pub fn type_info(input: TokenStream) -> TokenStream {
 	match generate(input.into()) {
 		Ok(output) => output.into(),
 		Err(err) => err.to_compile_error().into(),
@@ -48,7 +48,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
 	let mut ast: DeriveInput = syn::parse2(input.clone())?;
 
 	ast.generics.type_params_mut().for_each(|p| {
-		p.bounds.push(parse_quote!(_scale_info::Metadata));
+		p.bounds.push(parse_quote!(_scale_info::TypeInfo));
 		p.bounds.push(parse_quote!('static));
 	});
 
@@ -57,7 +57,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
 	let generic_type_ids = ast.generics.type_params().map(|ty| {
 		let ty_ident = &ty.ident;
 		quote! {
-			<#ty_ident as _scale_info::Metadata>::meta_type()
+			_scale_info::meta_type::<#ty_ident>()
 		}
 	});
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Generic struct
 //! ```
-//! # use scale_info::{build::Fields, Metadata, MetaType, Path, Type, TypeInfo};
+//! # use scale_info::{build::Fields, MetaType, Path, Type, TypeInfo};
 //! struct Foo<T> {
 //!     bar: T,
 //!     data: u64,
@@ -30,7 +30,7 @@
 //!
 //! impl<T> TypeInfo for Foo<T>
 //! where
-//!     T: Metadata + 'static,
+//!     T: TypeInfo + 'static,
 //! {
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -45,7 +45,7 @@
 //! ```
 //! ## Tuple struct
 //! ```
-//! # use scale_info::{build::Fields, Metadata, MetaType, Path, Type, TypeInfo};
+//! # use scale_info::{build::Fields, MetaType, Path, Type, TypeInfo};
 //! struct Foo(u32, bool);
 //!
 //! impl TypeInfo for Foo {
@@ -61,7 +61,7 @@
 //! ```
 //! ## Enum with fields
 //! ```
-//! # use scale_info::{build::{Fields, Variants}, Metadata, MetaType, Path, Type, TypeInfo};
+//! # use scale_info::{build::{Fields, Variants}, MetaType, Path, Type, TypeInfo};
 //! enum Foo<T>{
 //!     A(T),
 //!     B { f: u32 },
@@ -70,7 +70,7 @@
 //!
 //! impl<T> TypeInfo for Foo<T>
 //! where
-//!     T: Metadata + 'static,
+//!     T: TypeInfo + 'static,
 //! {
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -87,7 +87,7 @@
 //! ```
 //! ## Enum without fields
 //! ```
-//! # use scale_info::{build::{Fields, Variants}, Metadata, MetaType, Path, Type, TypeInfo};
+//! # use scale_info::{build::{Fields, Variants}, MetaType, Path, Type, TypeInfo};
 //! enum Foo {
 //!     A,
 //!     B,
@@ -111,7 +111,7 @@
 use crate::{
 	form::{Form, MetaForm},
 	tm_std::*,
-	Field, MetaType, Metadata, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, Variant,
+	Field, MetaType, Path, Type, TypeInfo, TypeDef, TypeDefComposite, TypeDefVariant, Variant,
 };
 
 /// State types for type builders which require a Path
@@ -240,7 +240,7 @@ impl FieldsBuilder<NamedFields> {
 	/// Add a named field with the type of the type parameter `T`
 	pub fn field_of<T>(mut self, name: &'static str) -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		self.fields.push(Field::named_of::<T>(name));
 		self
@@ -257,7 +257,7 @@ impl FieldsBuilder<UnnamedFields> {
 	/// Add an unnamed field with the type of the type parameter `T`
 	pub fn field_of<T>(mut self) -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		self.fields.push(Field::unnamed_of::<T>());
 		self

--- a/src/build.rs
+++ b/src/build.rs
@@ -111,7 +111,7 @@
 use crate::{
 	form::{Form, MetaForm},
 	tm_std::*,
-	Field, MetaType, Path, Type, TypeInfo, TypeDef, TypeDefComposite, TypeDefVariant, Variant,
+	Field, MetaType, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, TypeInfo, Variant,
 };
 
 /// State types for type builders which require a Path

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -117,7 +117,7 @@ where
 impl<T, E> TypeInfo for Result<T, E>
 where
 	T: TypeInfo + 'static,
-	E: TypeInfo+ 'static,
+	E: TypeInfo + 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()
@@ -133,8 +133,8 @@ where
 
 impl<K, V> TypeInfo for BTreeMap<K, V>
 where
-	K: TypeInfo+ 'static,
-	V: TypeInfo+ 'static,
+	K: TypeInfo + 'static,
+	V: TypeInfo + 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -44,7 +44,7 @@ impl_metadata_for_primitives!(
 macro_rules! impl_metadata_for_array {
 	( $( $n:expr )* ) => {
 		$(
-			impl<T: Metadata + 'static> TypeInfo for [T; $n] {
+			impl<T: TypeInfo + 'static> TypeInfo for [T; $n] {
 				fn type_info() -> Type {
 					TypeDefArray::new($n, MetaType::new::<T>()).into()
 				}
@@ -67,7 +67,7 @@ macro_rules! impl_metadata_for_tuple {
 		impl<$($ty),*> TypeInfo for ($($ty,)*)
 		where
 			$(
-				$ty: Metadata + 'static,
+				$ty: TypeInfo+ 'static,
 			)*
 		{
 			fn type_info() -> Type {
@@ -91,7 +91,7 @@ impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J);
 
 impl<T> TypeInfo for Vec<T>
 where
-	T: Metadata + 'static,
+	T: TypeInfo + 'static,
 {
 	fn type_info() -> Type {
 		<[T] as TypeInfo>::type_info()
@@ -100,7 +100,7 @@ where
 
 impl<T> TypeInfo for Option<T>
 where
-	T: Metadata + 'static,
+	T: TypeInfo + 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()
@@ -116,8 +116,8 @@ where
 
 impl<T, E> TypeInfo for Result<T, E>
 where
-	T: Metadata + 'static,
-	E: Metadata + 'static,
+	T: TypeInfo + 'static,
+	E: TypeInfo+ 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()
@@ -133,8 +133,8 @@ where
 
 impl<K, V> TypeInfo for BTreeMap<K, V>
 where
-	K: Metadata + 'static,
-	V: Metadata + 'static,
+	K: TypeInfo+ 'static,
+	V: TypeInfo+ 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()
@@ -173,7 +173,7 @@ where
 
 impl<T> TypeInfo for [T]
 where
-	T: Metadata + 'static,
+	T: TypeInfo + 'static,
 {
 	fn type_info() -> Type {
 		TypeDefSequence::of::<T>().into()
@@ -194,12 +194,12 @@ impl TypeInfo for String {
 
 impl<T> TypeInfo for PhantomData<T>
 where
-	T: Metadata + ?Sized,
+	T: TypeInfo + ?Sized + 'static,
 {
 	fn type_info() -> Type {
 		Type::builder()
 			.path(Path::prelude("PhantomData"))
-			.type_params(vec![T::meta_type()])
+			.type_params(vec![meta_type::<T>()])
 			.composite(Fields::unit())
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,17 +130,7 @@ pub use self::{
 };
 
 #[cfg(feature = "derive")]
-pub use scale_info_derive::Metadata;
-
-/// A super trait that shall be implemented by all types implementing [`TypeInfo`](`crate::TypeInfo`)
-///
-/// This trait is automatically implemented for all `'static` types that also
-/// implement [`TypeInfo`](`crate::TypeInfo`). Users of this library should use this trait directly
-/// instead of using the [`TypeInfo`](`crate::TypeInfo`) trait.
-pub trait Metadata: TypeInfo {
-	/// Returns the runtime bridge to the types compile-time type information.
-	fn meta_type() -> MetaType;
-}
+pub use scale_info_derive::TypeInfo;
 
 /// Implementors return their meta type information.
 pub trait TypeInfo {
@@ -148,11 +138,10 @@ pub trait TypeInfo {
 	fn type_info() -> Type;
 }
 
-impl<T> Metadata for T
+/// Returns the runtime bridge to the types compile-time type information.
+pub fn meta_type<T>() -> MetaType
 where
 	T: ?Sized + TypeInfo + 'static,
 {
-	fn meta_type() -> MetaType {
-		MetaType::new::<T>()
-	}
+	MetaType::new::<T>()
 }

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::tm_std::*;
-use crate::{form::MetaForm, Metadata, Type, TypeInfo};
+use crate::{form::MetaForm, Type, TypeInfo};
 
 /// A metatype abstraction.
 ///
@@ -71,7 +71,7 @@ impl MetaType {
 	/// Creates a new meta type from the given compile-time known type.
 	pub fn new<T>() -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		Self {
 			fn_type_info: <T as TypeInfo>::type_info,
@@ -82,7 +82,7 @@ impl MetaType {
 	/// Creates a new meta types from the type of the given reference.
 	pub fn of<T>(_elem: &T) -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		Self::new::<T>()
 	}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,7 @@ fn primitives() {
 	assert_type!(&str, TypeDefPrimitive::Str);
 	assert_type!(i8, TypeDefPrimitive::I8);
 
-	assert_type!([bool], TypeDefSequence::new(bool::meta_type()));
+	assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
 }
 
 #[test]
@@ -91,20 +91,20 @@ fn tuple_primitives() {
 	// nested tuple
 	assert_type!(
 		((i8, i16), (u32, u64)),
-		TypeDefTuple::new(vec![<(i8, i16)>::meta_type(), <(u32, u64)>::meta_type(),])
+		TypeDefTuple::new(vec![meta_type::<(i8, i16)>(), meta_type::<(u32, u64)>(),])
 	);
 }
 
 #[test]
 fn array_primitives() {
 	// array
-	assert_type!([bool; 3], TypeDefArray::new(3, bool::meta_type()));
+	assert_type!([bool; 3], TypeDefArray::new(3, meta_type::<bool>()));
 	// nested
-	assert_type!([[i32; 5]; 5], TypeDefArray::new(5, <[i32; 5]>::meta_type()));
+	assert_type!([[i32; 5]; 5], TypeDefArray::new(5, meta_type::<[i32; 5]>()));
 	// sequence
-	assert_type!([bool], TypeDefSequence::new(bool::meta_type()));
+	assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
 	// vec
-	assert_type!(Vec<bool>, TypeDefSequence::new(bool::meta_type()));
+	assert_type!(Vec<bool>, TypeDefSequence::new(meta_type::<bool>()));
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn struct_with_generics() {
 
 	impl<T> TypeInfo for MyStruct<T>
 	where
-		T: Metadata + 'static,
+		T: TypeInfo + 'static,
 	{
 		fn type_info() -> Type {
 			Type::builder()

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -16,7 +16,7 @@ use crate::tm_std::*;
 
 use crate::{
 	form::{CompactForm, Form, MetaForm},
-	IntoCompact, MetaType, Metadata, Registry,
+	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use serde::Serialize;
 
@@ -66,7 +66,7 @@ impl Field {
 	/// compile-time type.
 	pub fn named_of<T>(name: <MetaForm as Form>::String) -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		Self::new(Some(name), MetaType::new::<T>())
 	}
@@ -85,7 +85,7 @@ impl Field {
 	/// given compile-time type.
 	pub fn unnamed_of<T>() -> Self
 	where
-		T: Metadata + ?Sized + 'static,
+		T: TypeInfo + ?Sized + 'static,
 	{
 		Self::new(None, MetaType::new::<T>())
 	}

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -17,7 +17,7 @@ use crate::tm_std::*;
 use crate::{
 	build::TypeBuilder,
 	form::{CompactForm, Form, MetaForm},
-	IntoCompact, MetaType, Metadata, Registry,
+	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use derive_more::From;
 use serde::Serialize;
@@ -263,7 +263,7 @@ impl TypeDefSequence {
 	/// compile-time type.
 	pub fn of<T>() -> Self
 	where
-		T: Metadata + 'static,
+		T: TypeInfo + 'static,
 	{
 		Self::new(MetaType::new::<T>())
 	}

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -57,24 +57,24 @@ unsafe impl GlobalAlloc for Allocator {
 	}
 }
 
-use scale_info::Metadata;
+use scale_info::TypeInfo;
 
 #[allow(unused)]
-#[derive(Metadata)]
+#[derive(TypeInfo)]
 struct UnitStruct;
 
 #[allow(unused)]
-#[derive(Metadata)]
+#[derive(TypeInfo)]
 struct TupleStruct(u128, bool);
 
 #[allow(unused)]
-#[derive(Metadata)]
+#[derive(TypeInfo)]
 struct Struct<T> {
 	t: T,
 }
 
 #[allow(unused)]
-#[derive(Metadata)]
+#[derive(TypeInfo)]
 enum CLike {
 	A,
 	B,
@@ -82,7 +82,7 @@ enum CLike {
 }
 
 #[allow(unused)]
-#[derive(Metadata)]
+#[derive(TypeInfo)]
 enum E<T> {
 	A(T),
 	B { b: T },

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::build::*;
-use scale_info::{tuple_meta_type, Metadata, Path, Type, TypeInfo};
+use scale_info::{tuple_meta_type, TypeInfo, Path, Type};
 
 fn assert_type<T, E>(expected: E)
 where
@@ -41,7 +41,7 @@ macro_rules! assert_type {
 #[test]
 fn struct_derive() {
 	#[allow(unused)]
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct S<T, U> {
 		pub t: T,
 		pub u: U,
@@ -68,7 +68,7 @@ fn struct_derive() {
 #[test]
 fn tuple_struct_derive() {
 	#[allow(unused)]
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct S<T>(T);
 
 	let ty = Type::builder()
@@ -82,7 +82,7 @@ fn tuple_struct_derive() {
 #[test]
 fn unit_struct_derive() {
 	#[allow(unused)]
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct S;
 
 	let ty = Type::builder().path(Path::new("S", "derive")).composite(Fields::unit());
@@ -93,7 +93,7 @@ fn unit_struct_derive() {
 #[test]
 fn c_like_enum_derive() {
 	#[allow(unused)]
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum E {
 		A,
 		B = 10,
@@ -109,7 +109,7 @@ fn c_like_enum_derive() {
 #[test]
 fn enum_derive() {
 	#[allow(unused)]
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum E<T> {
 		A(T),
 		B { b: T },

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::build::*;
-use scale_info::{tuple_meta_type, TypeInfo, Path, Type};
+use scale_info::{tuple_meta_type, Path, Type, TypeInfo};
 
 fn assert_type<T, E>(expected: E)
 where

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -23,7 +23,7 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 
 use pretty_assertions::{assert_eq, assert_ne};
-use scale_info::{form::CompactForm, IntoCompact as _, TypeInfo, Registry, meta_type};
+use scale_info::{form::CompactForm, meta_type, IntoCompact as _, Registry, TypeInfo};
 use serde_json::json;
 
 fn assert_json_for_type<T>(expected_json: serde_json::Value)

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -23,12 +23,12 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 
 use pretty_assertions::{assert_eq, assert_ne};
-use scale_info::{form::CompactForm, IntoCompact as _, Metadata, Registry};
+use scale_info::{form::CompactForm, IntoCompact as _, TypeInfo, Registry, meta_type};
 use serde_json::json;
 
 fn assert_json_for_type<T>(expected_json: serde_json::Value)
 where
-	T: Metadata + ?Sized,
+	T: TypeInfo + ?Sized,
 {
 	let mut registry = Registry::new();
 
@@ -125,7 +125,7 @@ fn test_builtins() {
 
 #[test]
 fn test_unit_struct() {
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct UnitStruct;
 
 	assert_json_for_type::<UnitStruct>(json!({
@@ -138,7 +138,7 @@ fn test_unit_struct() {
 
 #[test]
 fn test_tuplestruct() {
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct TupleStruct(i32, [u8; 32], bool);
 
 	assert_json_for_type::<TupleStruct>(json!({
@@ -157,7 +157,7 @@ fn test_tuplestruct() {
 
 #[test]
 fn test_struct() {
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct Struct {
 		a: i32,
 		b: [u8; 32],
@@ -183,7 +183,7 @@ fn test_struct() {
 
 #[test]
 fn test_clike_enum() {
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum ClikeEnum {
 		A,
 		B = 42,
@@ -206,7 +206,7 @@ fn test_clike_enum() {
 
 #[test]
 fn test_enum() {
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum Enum {
 		ClikeVariant,
 		TupleStructVariant(u32, bool),
@@ -244,39 +244,39 @@ fn test_enum() {
 fn test_registry() {
 	let mut registry = Registry::new();
 
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct UnitStruct;
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct TupleStruct(u8, u32);
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct Struct {
 		a: u8,
 		b: u32,
 		c: [u8; 32],
 	}
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	struct RecursiveStruct {
 		rec: Vec<RecursiveStruct>,
 	}
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum ClikeEnum {
 		A,
 		B,
 		C,
 	}
-	#[derive(Metadata)]
+	#[derive(TypeInfo)]
 	enum RustEnum {
 		A,
 		B(u8, u32),
 		C { a: u8, b: u32, c: [u8; 32] },
 	}
 
-	registry.register_type(&UnitStruct::meta_type());
-	registry.register_type(&TupleStruct::meta_type());
-	registry.register_type(&Struct::meta_type());
-	registry.register_type(&RecursiveStruct::meta_type());
-	registry.register_type(&ClikeEnum::meta_type());
-	registry.register_type(&RustEnum::meta_type());
+	registry.register_type(&meta_type::<UnitStruct>());
+	registry.register_type(&meta_type::<TupleStruct>());
+	registry.register_type(&meta_type::<Struct>());
+	registry.register_type(&meta_type::<RecursiveStruct>());
+	registry.register_type(&meta_type::<ClikeEnum>());
+	registry.register_type(&meta_type::<RustEnum>());
 
 	let expected_json = json!({
 		"strings": [


### PR DESCRIPTION
Since multiple traits for id and def were removed, the `Metadata` supertrait has become redundant. The default impl has been replaced by a free function.