### PR TITLE
Remove string table, inline strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,6 @@ After compactification all type definitions are stored in the type registry.
 Note that the type registry should be serialized as part of the metadata structure where the
 registered types are utilized to allow consumers to resolve the types.
 
-As a minor additional compaction step non-documentation strings are also compacted by the same
-mechanics.
-
 ## Serialization
 
 Currently the only supported serialization format is JSON, an example of which can be found

--- a/src/build.rs
+++ b/src/build.rs
@@ -109,7 +109,7 @@
 //! ```
 
 use crate::{
-	form::{Form, MetaForm},
+	form::MetaForm,
 	tm_std::*,
 	Field, MetaType, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, TypeInfo, Variant,
 };
@@ -297,20 +297,20 @@ pub struct VariantsBuilder<T> {
 
 impl VariantsBuilder<VariantFields> {
 	/// Add a variant with fields constructed by the supplied [`FieldsBuilder`](`crate::build::FieldsBuilder`)
-	pub fn variant<F>(mut self, name: <MetaForm as Form>::String, fields: FieldsBuilder<F>) -> Self {
+	pub fn variant<F>(mut self, name: &'static str, fields: FieldsBuilder<F>) -> Self {
 		self.variants.push(Variant::with_fields(name, fields));
 		self
 	}
 
 	/// Add a variant with no fields i.e. a unit variant
-	pub fn variant_unit(self, name: <MetaForm as Form>::String) -> Self {
+	pub fn variant_unit(self, name: &'static str) -> Self {
 		self.variant::<NoFields>(name, Fields::unit())
 	}
 }
 
 impl VariantsBuilder<Fieldless> {
 	/// Add a fieldless variant, explicitly setting the discriminant
-	pub fn variant(mut self, name: <MetaForm as Form>::String, discriminant: u64) -> Self {
+	pub fn variant(mut self, name: &'static str, discriminant: u64) -> Self {
 		self.variants.push(Variant::with_discriminant(name, discriminant));
 		self
 	}

--- a/src/build.rs
+++ b/src/build.rs
@@ -109,9 +109,8 @@
 //! ```
 
 use crate::{
-	form::MetaForm,
-	tm_std::*,
-	Field, MetaType, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, TypeInfo, Variant,
+	form::MetaForm, tm_std::*, Field, MetaType, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, TypeInfo,
+	Variant,
 };
 
 /// State types for type builders which require a Path

--- a/src/form.rs
+++ b/src/form.rs
@@ -34,15 +34,12 @@ use crate::tm_std::*;
 use crate::{interner::UntrackedSymbol, meta_type::MetaType};
 use serde::Serialize;
 
-/// Trait to control the internal structures of type identifiers and
-/// definitions.
+/// Trait to control the internal structures of type definitions.
 ///
 /// This allows for type-level separation between free forms that can be
 /// instantiated out of the flux and compact forms that require some sort of
 /// interning data structures.
 pub trait Form {
-	/// The string type.
-	type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 	/// The type identifier type.
 	type TypeId: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 }
@@ -55,7 +52,6 @@ pub trait Form {
 pub enum MetaForm {}
 
 impl Form for MetaForm {
-	type String = &'static str;
 	type TypeId = MetaType;
 }
 
@@ -70,6 +66,5 @@ impl Form for MetaForm {
 pub enum CompactForm {}
 
 impl Form for CompactForm {
-	type String = UntrackedSymbol<&'static str>;
 	type TypeId = UntrackedSymbol<TypeId>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //! # Registry
 //!
 //! At the heart of its functionality is the [`Registry`](`crate::Registry`) that acts as cache for
-//! known strings and types in order to efficiently deduplicate them and thus
-//! compactify the overall serialization.
+//! known types in order to efficiently deduplicate them and thus compactify the overall
+//! serialization.
 //!
 //! # Type Information
 //!
@@ -38,20 +38,20 @@
 //!
 //! # Compaction Forms
 //!
-//! There is an uncompact form, called [`MetaForm`](`crate::form::MetaForm`) that acts as a bridge from
-//! compile-time type information at runtime in order to easily retrieve all
-//! information needed to uniquely identify types.
-//! The compact form is retrieved by the [`IntoCompact`](`crate::IntoCompact`) trait and internally used
-//! by the [`Registry`](`crate::Registry`) in order to convert the uncompact strings and types into
-//! their compact form.
+//! There is an uncompact form, called [`MetaForm`](`crate::form::MetaForm`) that acts as a bridge
+//! from compile-time type information at runtime in order to easily retrieve all information needed
+//! to uniquely identify types.
+//!
+//! The compact form is retrieved by the [`IntoCompact`](`crate::IntoCompact`) trait and internally
+//! used by the [`Registry`](`crate::Registry`) in order to convert the uncompact strings and types
+//! into their compact form.
 //!
 //! # Symbols and Namespaces
 //!
-//! Since symbol names are often shared across type boundaries the [`Registry`](`crate::Registry`)
-//! also deduplicates them. To differentiate two types sharing the same name
-//! namespaces are used. Commonly the namespace is equal to the one where the
-//! type has been defined in. For Rust prelude types such as [`Option`](`std::option::Option`) and
-//! [`Result`](`std::result::Result`)  the root namespace (empty namespace) is used.
+//! To differentiate two types sharing the same name namespaces are used.
+//! Commonly the namespace is equal to the one where the ype has been defined in. For Rust prelude
+//! types such as [`Option`](`std::option::Option`) and [`Result`](`std::result::Result`) the root
+//! namespace (empty namespace) is used.
 //!
 //! To use this library simply use the [`MetaForm`](`crate::form::MetaForm`) initially with your own data
 //! structures and at best make them generic over the [`Form`](`crate::form::Form`) trait just as has
@@ -140,8 +140,8 @@ pub trait TypeInfo {
 
 /// Returns the runtime bridge to the types compile-time type information.
 pub fn meta_type<T>() -> MetaType
-where
-	T: ?Sized + TypeInfo + 'static,
+	where
+		T: ?Sized + TypeInfo + 'static,
 {
 	MetaType::new::<T>()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,13 @@
 //! to uniquely identify types.
 //!
 //! The compact form is retrieved by the [`IntoCompact`](`crate::IntoCompact`) trait and internally
-//! used by the [`Registry`](`crate::Registry`) in order to convert the uncompact strings and types
+//! used by the [`Registry`](`crate::Registry`) in order to convert the uncompact types
 //! into their compact form.
 //!
 //! # Symbols and Namespaces
 //!
 //! To differentiate two types sharing the same name namespaces are used.
-//! Commonly the namespace is equal to the one where the ype has been defined in. For Rust prelude
+//! Commonly the namespace is equal to the one where the type has been defined in. For Rust prelude
 //! types such as [`Option`](`std::option::Option`) and [`Result`](`std::result::Result`) the root
 //! namespace (empty namespace) is used.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,8 @@ pub trait TypeInfo {
 
 /// Returns the runtime bridge to the types compile-time type information.
 pub fn meta_type<T>() -> MetaType
-	where
-		T: ?Sized + TypeInfo + 'static,
+where
+	T: ?Sized + TypeInfo + 'static,
 {
 	MetaType::new::<T>()
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,22 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The registry has the purpose to compactify types and strings found in type
-//! definitions and identifiers such as symbol names.
+//! The registry has the purpose to compactify types found in type definitions.
 //!
-//! This is done by deduplicating common strings and types in order to reuse
+//! This is done by deduplicating common types in order to reuse
 //! their definitions which can grow arbitrarily large. A type is uniquely
 //! identified by its type identifier that is therefore used to refer to types
 //! and their definitions.
 //!
-//! Since symbol names etc. are often shared between different types they are
-//! as well deduplicated.
-//!
 //! Types with the same name are uniquely identifiable by introducing
 //! namespaces. For this the normal Rust namespace of a type is used where it
-//! has been defined it. Rust prelude types live within the so-called root
-//! namespace that is just empty. In general namespaces are ordered sequences of
-//! symbols and thus also profit from string deduplication.
+//! has been defined. Rust prelude types live within the so-called root
+//! namespace that is just empty.
 
 use crate::tm_std::*;
 use crate::{

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -49,8 +49,7 @@ pub trait IntoCompact {
 
 /// The registry for compaction of type identifiers and definitions.
 ///
-/// The registry consists of a cache for strings such as symbol names
-/// and a cache for already compactified type identifiers and definitions.
+/// The registry consists of a cache for already compactified type identifiers and definitions.
 ///
 /// Whenever using the registry to compact a type all of its sub-types
 /// are going to be registered recursively as well. A type is a sub-type
@@ -62,9 +61,6 @@ pub trait IntoCompact {
 /// mechanism to stop recursion before going into an infinite loop.
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Registry {
-	/// The cache for already registered strings.
-	#[serde(rename = "strings")]
-	string_table: Interner<&'static str>,
 	/// The cache for already registered types.
 	///
 	/// This is just an accessor to the actual database
@@ -101,16 +97,9 @@ impl Registry {
 	/// Creates a new empty registry.
 	pub fn new() -> Self {
 		Self {
-			string_table: Interner::new(),
 			type_table: Interner::new(),
 			types: BTreeMap::new(),
 		}
-	}
-
-	/// Registers the given string into the registry and returns
-	/// its respective associated string symbol.
-	pub fn register_string(&mut self, string: &'static str) -> UntrackedSymbol<&'static str> {
-		self.string_table.intern_or_get(string).1.into_untracked()
 	}
 
 	/// Registers the given type ID into the registry.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -30,7 +30,7 @@ use serde::Serialize;
 pub struct Field<F: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	name: Option<F::String>,
+	name: Option<&'static str>,
 	/// The type of the field.
 	#[serde(rename = "type")]
 	ty: F::TypeId,
@@ -41,7 +41,7 @@ impl IntoCompact for Field {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Field {
-			name: self.name.map(|name| registry.register_string(name)),
+			name: self.name,
 			ty: registry.register_type(&self.ty),
 		}
 	}
@@ -51,12 +51,12 @@ impl Field {
 	/// Creates a new field.
 	///
 	/// Use this constructor if you want to instantiate from a given meta type.
-	pub fn new(name: Option<<MetaForm as Form>::String>, ty: MetaType) -> Self {
+	pub fn new(name: Option<&'static str>, ty: MetaType) -> Self {
 		Self { name, ty }
 	}
 
 	/// Creates a new named field
-	pub fn named(name: <MetaForm as Form>::String, ty: MetaType) -> Self {
+	pub fn named(name: &'static str, ty: MetaType) -> Self {
 		Self::new(Some(name), ty)
 	}
 
@@ -64,7 +64,7 @@ impl Field {
 	///
 	/// Use this constructor if you want to instantiate from a given
 	/// compile-time type.
-	pub fn named_of<T>(name: <MetaForm as Form>::String) -> Self
+	pub fn named_of<T>(name: &'static str) -> Self
 	where
 		T: TypeInfo + ?Sized + 'static,
 	{

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -35,7 +35,7 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 pub struct Type<F: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty")]
-	path: Path<F>,
+	path: Path,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty")]
 	type_params: Vec<F::TypeId>,
@@ -49,7 +49,7 @@ impl IntoCompact for Type {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Type {
-			path: self.path.into_compact(registry),
+			path: self.path,
 			type_params: registry.register_types(self.type_params),
 			type_def: self.type_def.into_compact(registry),
 		}

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -93,7 +93,7 @@ impl Path {
 
 	/// Get the ident segment of the Path
 	pub fn ident(&self) -> Option<&str> {
-		self.segments.iter().last().map(|ident| *ident)
+		self.segments.iter().last().copied()
 	}
 
 	/// Get the namespace segments of the Path

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -15,9 +15,7 @@
 use crate::tm_std::*;
 
 use crate::{
-	form::{CompactForm, Form, MetaForm},
 	utils::is_rust_identifier,
-	IntoCompact, Registry,
 };
 use serde::Serialize;
 
@@ -30,32 +28,14 @@ use serde::Serialize;
 /// Rust prelude type may have an empty namespace definition.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(transparent)]
-pub struct Path<F: Form = MetaForm> {
+pub struct Path {
 	/// The segments of the namespace.
-	segments: Vec<F::String>,
+	segments: Vec<&'static str>,
 }
 
-impl<F> Default for Path<F>
-where
-	F: Form,
-{
+impl Default for Path {
 	fn default() -> Self {
 		Path { segments: Vec::new() }
-	}
-}
-
-impl IntoCompact for Path {
-	type Output = Path<CompactForm>;
-
-	/// Compacts this path using the given registry.
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		Path {
-			segments: self
-				.segments
-				.into_iter()
-				.map(|seg| registry.register_string(seg))
-				.collect::<Vec<_>>(),
-		}
 	}
 }
 
@@ -65,7 +45,7 @@ impl Path {
 	/// # Panics
 	///
 	/// - If the type identifier or module path contain invalid Rust identifiers
-	pub fn new(ident: <MetaForm as Form>::String, module_path: <MetaForm as Form>::String) -> Path {
+	pub fn new(ident: &'static str, module_path: &'static str) -> Path {
 		let mut segments = module_path.split("::").collect::<Vec<_>>();
 		segments.push(ident);
 		Self::from_segments(segments).expect("All path segments should be valid Rust identifiers")
@@ -82,7 +62,7 @@ impl Path {
 	/// # Panics
 	///
 	/// - If the supplied ident is not a valid Rust identifier
-	pub(crate) fn prelude(ident: <MetaForm as Form>::String) -> Path {
+	pub(crate) fn prelude(ident: &'static str) -> Path {
 		Self::from_segments(vec![ident]).unwrap_or_else(|_| panic!("{} is not a valid Rust identifier", ident))
 	}
 
@@ -94,7 +74,7 @@ impl Path {
 	/// - If any of the segments are invalid Rust identifiers
 	pub fn from_segments<I>(segments: I) -> Result<Path, PathError>
 	where
-		I: IntoIterator<Item = <MetaForm as Form>::String>,
+		I: IntoIterator<Item = &'static str>,
 	{
 		let segments = segments.into_iter().collect::<Vec<_>>();
 		if segments.is_empty() {
@@ -107,22 +87,19 @@ impl Path {
 	}
 }
 
-impl<F> Path<F>
-where
-	F: Form,
-{
+impl Path {
 	/// Returns `true` if the path is empty
 	pub fn is_empty(&self) -> bool {
 		self.segments.is_empty()
 	}
 
 	/// Get the ident segment of the Path
-	pub fn ident(&self) -> Option<&F::String> {
-		self.segments.iter().last()
+	pub fn ident(&self) -> Option<&str> {
+		self.segments.iter().last().map(|ident| *ident)
 	}
 
 	/// Get the namespace segments of the Path
-	pub fn namespace(&self) -> &[F::String] {
+	pub fn namespace(&self) -> &[&'static str] {
 		self.segments.split_last().map(|(_, ns)| ns).unwrap_or(&[])
 	}
 }
@@ -195,7 +172,7 @@ mod tests {
 	fn path_get_namespace_and_ident() {
 		let path = Path::new("Planet", "hello::world");
 		assert_eq!(path.namespace(), &["hello", "world"]);
-		assert_eq!(path.ident(), Some(&"Planet"));
+		assert_eq!(path.ident(), Some("Planet"));
 	}
 
 	#[test]

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -14,9 +14,7 @@
 
 use crate::tm_std::*;
 
-use crate::{
-	utils::is_rust_identifier,
-};
+use crate::utils::is_rust_identifier;
 use serde::Serialize;
 
 /// Represents the path of a type definition.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -109,7 +109,7 @@ impl TypeDefVariant {
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct Variant<F: Form = MetaForm> {
 	/// The name of the struct variant.
-	name: F::String,
+	name: &'static str,
 	/// The fields of the struct variant.
 	#[serde(skip_serializing_if = "Vec::is_empty")]
 	fields: Vec<Field<F>>,
@@ -129,7 +129,7 @@ impl IntoCompact for Variant {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Variant {
-			name: registry.register_string(self.name),
+			name: self.name,
 			fields: registry.map_into_compact(self.fields),
 			discriminant: self.discriminant,
 		}
@@ -138,7 +138,7 @@ impl IntoCompact for Variant {
 
 impl Variant {
 	/// Creates a new variant with the given fields.
-	pub fn with_fields<F>(name: <MetaForm as Form>::String, fields: FieldsBuilder<F>) -> Self {
+	pub fn with_fields<F>(name: &'static str, fields: FieldsBuilder<F>) -> Self {
 		Self {
 			name,
 			fields: fields.done(),
@@ -147,7 +147,7 @@ impl Variant {
 	}
 
 	/// Creates a new variant with the given discriminant.
-	pub fn with_discriminant(name: <MetaForm as Form>::String, discriminant: u64) -> Self {
+	pub fn with_discriminant(name: &'static str, discriminant: u64) -> Self {
 		Self {
 			name,
 			fields: Vec::new(),

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -72,16 +72,16 @@ fn test_builtins() {
 	assert_json_for_type::<Vec<bool>>(json!({ "def": { "sequence": { "type": 1 } } }));
 	// complex types
 	assert_json_for_type::<Option<&str>>(json!({
-		"path": [1],
+		"path": ["Option"],
 		"params": [1],
 		"def": {
 			"variant": {
 				"variants": [
 					{
-						"name": 2,
+						"name": "None",
 					},
 					{
-						"name": 3,
+						"name": "Some",
 						"fields": [ { "type": 1 } ]
 					},
 				]
@@ -89,17 +89,17 @@ fn test_builtins() {
 		}
 	}));
 	assert_json_for_type::<Result<u32, u64>>(json!({
-		"path": [1],
+		"path": ["Result"],
 		"params": [1, 2],
 		"def": {
 			"variant": {
 				"variants": [
 					{
-						"name": 2,
+						"name": "Ok",
 						"fields": [ { "type": 1 } ]
 					},
 					{
-						"name": 3,
+						"name": "Err",
 						"fields": [ { "type": 2 } ]
 					}
 				]
@@ -115,7 +115,7 @@ fn test_builtins() {
 	assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
 	// PhantomData
 	assert_json_for_type::<core::marker::PhantomData<bool>>(json!({
-		"path": [1],
+		"path": ["PhantomData"],
 		"params": [1],
 		"def": {
 			"composite": {},
@@ -129,7 +129,7 @@ fn test_unit_struct() {
 	struct UnitStruct;
 
 	assert_json_for_type::<UnitStruct>(json!({
-		"path": [1, 2],
+		"path": ["json", "UnitStruct"],
 		"def": {
 			"composite": {},
 		}
@@ -142,7 +142,7 @@ fn test_tuplestruct() {
 	struct TupleStruct(i32, [u8; 32], bool);
 
 	assert_json_for_type::<TupleStruct>(json!({
-		"path": [1, 2],
+		"path": ["json", "TupleStruct"],
 		"def": {
 			"composite": {
 				"fields": [
@@ -165,16 +165,13 @@ fn test_struct() {
 	}
 
 	assert_json_for_type::<Struct>(json!({
-		"path": [1, 2],
-		"def": {
-
-		},
+		"path": ["json", "Struct"],
 		"def": {
 			"composite": {
 				"fields": [
-					{ "name": 3, "type": 1, },
-					{ "name": 4, "type": 2, },
-					{ "name": 5, "type": 4, },
+					{ "name": "a", "type": 1, },
+					{ "name": "b", "type": 2, },
+					{ "name": "c", "type": 4, },
 				],
 			},
 		}
@@ -191,13 +188,13 @@ fn test_clike_enum() {
 	}
 
 	assert_json_for_type::<ClikeEnum>(json!({
-		"path": [1, 2],
+		"path": ["json", "ClikeEnum"],
 		"def": {
 			"variant": {
 				"variants": [
-					{ "name": 3, "discriminant": 0, },
-					{ "name": 4, "discriminant": 42, },
-					{ "name": 5, "discriminant": 2, },
+					{ "name": "A", "discriminant": 0, },
+					{ "name": "B", "discriminant": 42, },
+					{ "name": "C", "discriminant": 2, },
 				],
 			},
 		}
@@ -214,24 +211,24 @@ fn test_enum() {
 	}
 
 	assert_json_for_type::<Enum>(json!({
-		"path": [1, 2],
+		"path": ["json", "Enum"],
 		"def": {
 			"variant": {
 				"variants": [
-					{ "name": 3 },
+					{ "name": "ClikeVariant" },
 					{
-						"name": 4,
+						"name": "TupleStructVariant",
 						"fields": [
 							{ "type": 1 },
 							{ "type": 2 },
 						],
 					},
 					{
-						"name": 5,
+						"name": "StructVariant",
 						"fields": [
-							{ "name": 6, "type": 1, },
-							{ "name": 7, "type": 3, },
-							{ "name": 8, "type": 5, },
+							{ "name": "a", "type": 1, },
+							{ "name": "b", "type": 3, },
+							{ "name": "c", "type": 5, },
 						],
 					}
 				],
@@ -279,27 +276,11 @@ fn test_registry() {
 	registry.register_type(&meta_type::<RustEnum>());
 
 	let expected_json = json!({
-		"strings": [
-			"json",      	   //  1
-			"UnitStruct",      //  2
-			"TupleStruct",     //  3
-			"Struct",          //  4
-			"a",               //  5
-			"b",               //  6
-			"c",               //  7
-			"RecursiveStruct", //  8
-			"rec",             //  9
-			"ClikeEnum",       // 10
-			"A",               // 11
-			"B",               // 12
-			"C",               // 13
-			"RustEnum",        // 14
-		],
 		"types": [
 			{ // type 1
 				"path": [
-					1, // json
-					2, // UnitStruct
+					"json",
+					"UnitStruct",
 				],
 				"def": {
 					"composite": {},
@@ -307,8 +288,8 @@ fn test_registry() {
 			},
 			{ // type 2
 				"path": [
-					1, // json
-					3, // TupleStruct
+					"json",
+					"TupleStruct",
 				],
 				"def": {
 					"composite": {
@@ -327,22 +308,22 @@ fn test_registry() {
 			},
 			{ // type 5
 				"path": [
-					1, // json
-					4, // Struct
+					"json",
+					"Struct",
 				],
 				"def": {
 					"composite": {
 						"fields": [
 							{
-								"name": 5, // a
+								"name": "a",
 								"type": 3, // u8
 							},
 							{
-								"name": 6, // b
+								"name": "b",
 								"type": 4, // u32
 							},
 							{
-								"name": 7, // c
+								"name": "c",
 								"type": 6, // [u8; 32]
 							}
 						]
@@ -359,14 +340,14 @@ fn test_registry() {
 			},
 			{ // type 7
 				"path": [
-					1, // json
-					8, // RecursiveStruct
+					"json",
+					"RecursiveStruct",
 				],
 				"def": {
 					"composite": {
 						"fields": [
 							{
-								"name": 9, // rec
+								"name": "rec",
 								"type": 8, // Vec<RecursiveStruct>
 							}
 						]
@@ -382,22 +363,22 @@ fn test_registry() {
 			},
 			{ // type 9
 				"path": [
-					1, 	// json
-					10, // CLikeEnum
+					"json",
+					"ClikeEnum",
 				],
 				"def": {
 					"variant": {
 						"variants": [
 							{
-								"name": 11, // A
+								"name": "A",
 								"discriminant": 0,
 							},
 							{
-								"name": 12, // B
+								"name": "B",
 								"discriminant": 1,
 							},
 							{
-								"name": 13, // C
+								"name": "C",
 								"discriminant": 2,
 							},
 						]
@@ -406,35 +387,35 @@ fn test_registry() {
 			},
 			{ // type 10
 				"path": [
-					1, 	// json
-					14, // RustEnum
+					"json",
+					"RustEnum"
 				],
 				"def": {
 					"variant": {
 						"variants": [
 							{
-								"name": 11, // A
+								"name": "A"
 							},
 							{
-								"name": 12, // B
+								"name": "B",
 								"fields": [
 									{ "type": 3 }, // u8
 									{ "type": 4 }, // u32
 								]
 							},
 							{
-								"name": 13, // C
+								"name": "C",
 								"fields": [
 									{
-										"name": 5, // a
+										"name": "a",
 										"type": 3, // u8
 									},
 									{
-										"name": 6, // b
+										"name": "b",
 										"type": 4, // u32
 									},
 									{
-										"name": 7, // c
+										"name": "c",
 										"type": 6, // [u8; 32]
 									}
 								]


### PR DESCRIPTION
Removes the string table following a suggestion from @seanyoung.

Improves human readability, but does increase the resulting raw serialized file size. However if file sizes become a problem we could reduce it with a generic compression tool.

Rel: https://github.com/paritytech/ink/issues/299