### PR TITLE
Implement SCALE encoding and serde deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ std = [
 	"scale/std"
 ]
 derive = [
-    "scale-info-derive"
+	"scale-info-derive"
 ]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ scale = { package = "parity-scale-codec", version = "1.3.4", default-features = 
 [features]
 default = ["std"]
 std = [
-    "serde/std",
+	"serde/std",
 	"scale/std"
 ]
 derive = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 scale-info-derive = { version = "0.2.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
+scale = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = [
     "serde/std",
+	"scale/std"
 ]
 derive = [
     "scale-info-derive"

--- a/README.md
+++ b/README.md
@@ -22,28 +22,28 @@ pub trait TypeInfo {
 Types implementing this trait build up and return a `Type` struct:
 
 ```rust
-pub struct Type<F: Form = MetaForm> {
+pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
-	path: Path<F>,
+	path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
-	type_params: Vec<F::TypeId>,
+	type_params: Vec<T::TypeId>,
 	/// The actual type definition
-	type_def: TypeDef<F>,
+	type_def: TypeDef<T>,
 }
 ```
 Types are defined as one of the following variants:
 ```rust
-pub enum TypeDef<F: Form = MetaForm> {
+pub enum TypeDef<T: Form = MetaForm> {
 	/// A composite type (e.g. a struct or a tuple)
-	Composite(TypeDefComposite<F>),
+	Composite(TypeDefComposite<T>),
 	/// A variant type (e.g. an enum)
-	Variant(TypeDefVariant<F>),
+	Variant(TypeDefVariant<T>),
 	/// A sequence type with runtime known length.
-	Sequence(TypeDefSequence<F>),
+	Sequence(TypeDefSequence<T>),
 	/// An array type with compile-time known length.
-	Array(TypeDefArray<F>),
+	Array(TypeDefArray<T>),
 	/// A tuple type.
-	Tuple(TypeDefTuple<F>),
+	Tuple(TypeDefTuple<T>),
 	/// A Rust primitive type.
 	Primitive(TypeDefPrimitive),
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -72,16 +72,5 @@ pub enum CompactForm {}
 
 impl Form for CompactForm {
 	type TypeId = UntrackedSymbol<TypeId>;
-	type String = &'static str;
-}
-
-/// Owned form for decoding
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
-pub enum OwnedForm {}
-
-impl Form for OwnedForm {
-	/// For correctness should be [`NonZeroU32`](`core::num::NonZeroU32`), but the current
-	/// (`1.3.x`) release of `parity-scale-codec` does not include the `NoneZero*` Decode impls.
-	type TypeId = u32;
 	type String = String;
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -80,6 +80,8 @@ impl Form for CompactForm {
 pub enum OwnedForm {}
 
 impl Form for OwnedForm {
-	type TypeId = UntrackedSymbol<TypeId>;
+	/// For correctness should be [`NonZeroU32`](`core::num::NonZeroU32`), but the current
+	/// (`1.3.x`) release of `parity-scale-codec` does not include the `NoneZero*` Decode impls.
+	type TypeId = u32;
 	type String = String;
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -42,6 +42,8 @@ use serde::Serialize;
 pub trait Form {
 	/// The type identifier type.
 	type TypeId: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+	/// The string type.
+	type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 }
 
 /// A meta meta-type.
@@ -53,6 +55,7 @@ pub enum MetaForm {}
 
 impl Form for MetaForm {
 	type TypeId = MetaType;
+	type String = &'static str;
 }
 
 /// Compact form that has its lifetime untracked in association to its interner.
@@ -62,9 +65,21 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
+///
+/// `type String` is owned in order to enable decoding
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
 pub enum CompactForm {}
 
 impl Form for CompactForm {
 	type TypeId = UntrackedSymbol<TypeId>;
+	type String = &'static str;
+}
+
+/// Owned form for decoding
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
+pub enum OwnedForm {}
+
+impl Form for OwnedForm {
+	type TypeId = UntrackedSymbol<TypeId>;
+	type String = String;
 }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,18 +22,23 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::tm_std::*;
-use serde::Serialize;
+use scale::Encode;
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 /// A symbol that is not lifetime tracked.
 ///
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UntrackedSymbol<T> {
 	id: NonZeroU32,
 	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Encode for UntrackedSymbol<T> {
+
 }
 
 /// A symbol from an interner.

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,7 +22,7 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::tm_std::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// A symbol that is not lifetime tracked.
 ///
@@ -48,8 +48,11 @@ impl<T> scale::Decode for UntrackedSymbol<T> {
 		if id < 1 {
 			return Err("UntrackedSymbol::id should be a non-zero unsigned integer".into());
 		}
-		let id =  NonZeroU32::new(id).expect("ID is non zero");
-		Ok(UntrackedSymbol { id, marker: Default::default() })
+		let id = NonZeroU32::new(id).expect("ID is non zero");
+		Ok(UntrackedSymbol {
+			id,
+			marker: Default::default(),
+		})
 	}
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,22 +22,34 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::tm_std::*;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 /// A symbol that is not lifetime tracked.
 ///
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UntrackedSymbol<T> {
 	id: NonZeroU32,
 	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
 }
+
 impl<T> scale::Encode for UntrackedSymbol<T> {
 	fn encode_to<W: scale::Output>(&self, dest: &mut W) {
 		self.id.get().encode_to(dest)
+	}
+}
+
+impl<T> scale::Decode for UntrackedSymbol<T> {
+	fn decode<I: scale::Input>(value: &mut I) -> Result<Self, scale::Error> {
+		let id = <u32 as scale::Decode>::decode(value)?;
+		if id < 1 {
+			return Err("UntrackedSymbol::id should be a non-zero unsigned integer".into());
+		}
+		let id =  NonZeroU32::new(id).expect("ID is non zero");
+		Ok(UntrackedSymbol { id, marker: Default::default() })
 	}
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -23,22 +23,18 @@
 
 use crate::tm_std::*;
 use scale::Encode;
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use serde::Serialize;
 
 /// A symbol that is not lifetime tracked.
 ///
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub struct UntrackedSymbol<T> {
 	id: NonZeroU32,
 	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
-}
-
-impl<T> Encode for UntrackedSymbol<T> {
-
 }
 
 /// A symbol from an interner.

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,7 +22,6 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::tm_std::*;
-use scale::Encode;
 use serde::Serialize;
 
 /// A symbol that is not lifetime tracked.
@@ -35,6 +34,11 @@ pub struct UntrackedSymbol<T> {
 	id: NonZeroU32,
 	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
+}
+impl<T> scale::Encode for UntrackedSymbol<T> {
+	fn encode_to<W: scale::Output>(&self, dest: &mut W) {
+		self.id.get().encode_to(dest)
+	}
 }
 
 /// A symbol from an interner.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ mod tests;
 
 pub use self::{
 	meta_type::MetaType,
-	registry::{IntoCompact, Registry},
+	registry::{IntoCompact, Registry, RegistryReadOnly},
 	ty::*,
 };
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -31,7 +31,7 @@ use crate::{
 	meta_type::MetaType,
 	Type,
 };
-use scale::{Encode, Decode};
+use scale::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 /// Compacts the implementor using a registry.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -184,7 +184,6 @@ pub struct RegistryReadOnly {
 impl RegistryReadOnly {
 	/// Returns the type definition for the given identifier, `None` if no type found for that ID.
 	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
-		self.types.get((id.get() - 1) as usize);
-		None
+		self.types.get((id.get() - 1) as usize)
 	}
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -31,6 +31,7 @@ use crate::{
 	meta_type::MetaType,
 	Type,
 };
+use scale::{Encode, Decode};
 use serde::{Deserialize, Serialize};
 
 /// Compacts the implementor using a registry.
@@ -88,7 +89,7 @@ impl Default for Registry {
 	}
 }
 
-impl scale::Encode for Registry {
+impl Encode for Registry {
 	fn size_hint(&self) -> usize {
 		mem::size_of::<u32>() + mem::size_of::<Type<CompactForm>>() * self.types.len()
 	}
@@ -167,7 +168,7 @@ impl Registry {
 }
 
 /// A read-only registry, to be used for decoding/deserializing
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, scale::Decode)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Decode)]
 pub struct RegistryReadOnly {
 	types: Vec<Type<OwnedForm>>,
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -26,7 +26,7 @@
 
 use crate::tm_std::*;
 use crate::{
-	form::{CompactForm, OwnedForm},
+	form::{CompactForm, Form},
 	interner::{Interner, UntrackedSymbol},
 	meta_type::MetaType,
 	Type,
@@ -41,6 +41,14 @@ pub trait IntoCompact {
 
 	/// Compacts `self` by using the registry for caching and compaction.
 	fn into_compact(self, registry: &mut Registry) -> Self::Output;
+}
+
+impl IntoCompact for &'static str {
+	type Output = <CompactForm as Form>::String;
+
+	fn into_compact(self, _registry: &mut Registry) -> Self::Output {
+		self.to_owned()
+	}
 }
 
 /// The registry for compaction of type identifiers and definitions.
@@ -170,12 +178,12 @@ impl Registry {
 /// A read-only registry, to be used for decoding/deserializing
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Decode)]
 pub struct RegistryReadOnly {
-	types: Vec<Type<OwnedForm>>,
+	types: Vec<Type<CompactForm>>,
 }
 
 impl RegistryReadOnly {
 	/// Returns the type definition for the given identifier, `None` if no type found for that ID.
-	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<OwnedForm>> {
+	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
 		self.types.get((id.get() - 1) as usize);
 		None
 	}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -26,7 +26,7 @@
 
 use crate::tm_std::*;
 use crate::{
-	form::CompactForm,
+	form::{CompactForm, OwnedForm},
 	interner::{Interner, UntrackedSymbol},
 	meta_type::MetaType,
 	Type,
@@ -146,5 +146,20 @@ impl Registry {
 		T: IntoCompact,
 	{
 		iter.into_iter().map(|i| i.into_compact(self)).collect::<Vec<_>>()
+	}
+}
+
+/// A read-only registry, to be used for decoding/deserializing
+#[derive(Debug, PartialEq, Eq, scale::Decode)]
+struct RegistryReadOnly {
+	ty: Type<OwnedForm>,
+	types: Vec<Type<OwnedForm>>,
+}
+
+impl RegistryReadOnly {
+	// Returns the type definition for the given identifier.
+	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<OwnedForm>> {
+		self.types.get((id.get() - 1) as usize);
+		None
 	}
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -47,7 +47,7 @@ impl IntoCompact for &'static str {
 	type Output = <CompactForm as Form>::String;
 
 	fn into_compact(self, _registry: &mut Registry) -> Self::Output {
-		self.to_owned()
+		self.to_string()
 	}
 }
 

--- a/src/tm_std.rs
+++ b/src/tm_std.rs
@@ -40,6 +40,7 @@ pub use self::core::{
 	fmt::{Debug, Error as FmtError, Formatter},
 	hash::{Hash, Hasher},
 	iter,
+	mem,
 };
 
 mod alloc {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -47,7 +47,7 @@ use serde::Serialize;
 /// ```
 /// struct JustAMarker;
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<F: Form = MetaForm> {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -48,11 +48,11 @@ use serde::Serialize;
 /// struct JustAMarker;
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
+#[serde(bound = "T::TypeId: Serialize")]
 #[serde(rename_all = "lowercase")]
-pub struct TypeDefComposite<F: Form = MetaForm> {
+pub struct TypeDefComposite<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]
-	fields: Vec<Field<F>>,
+	fields: Vec<Field<T>>,
 }
 
 impl IntoCompact for TypeDefComposite {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -19,8 +19,8 @@ use crate::{
 	Field, IntoCompact, Registry,
 };
 use derive_more::From;
-use scale::{Encode, Decode};
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use scale::{Decode, Encode};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A composite type, consisting of either named (struct) or unnamed (tuple
 /// struct) fields

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -19,7 +19,8 @@ use crate::{
 	Field, IntoCompact, Registry,
 };
 use derive_more::From;
-use serde::Serialize;
+use scale::{Encode, Decode};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 /// A composite type, consisting of either named (struct) or unnamed (tuple
 /// struct) fields
@@ -47,8 +48,8 @@ use serde::Serialize;
 /// ```
 /// struct JustAMarker;
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -49,7 +49,10 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 /// struct JustAMarker;
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -55,7 +55,7 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {
-	#[serde(skip_serializing_if = "Vec::is_empty")]
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	fields: Vec<Field<T>>,
 }
 

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -33,7 +33,7 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 ))]
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(skip_serializing_if = "Option::is_none", default)]
 	name: Option<T::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -19,7 +19,7 @@ use crate::{
 	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use scale::{Decode, Encode};
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 /// A field of a struct like data type.
 ///
@@ -27,7 +27,7 @@ use serde::{Serialize, Deserialize};
 ///
 /// This can be a named field of a struct type or a struct variant.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -18,22 +18,23 @@ use crate::{
 	form::{CompactForm, Form, MetaForm},
 	IntoCompact, MetaType, Registry, TypeInfo,
 };
-use serde::Serialize;
+use scale::{Decode, Encode};
+use serde::{Serialize, Deserialize};
 
 /// A field of a struct like data type.
 ///
 /// Name is optional so it can represent both named and unnamed fields.
 ///
 /// This can be a named field of a struct type or a struct variant.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
-pub struct Field<F: Form = MetaForm> {
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound = "T::TypeId: Serialize")]
+pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	name: Option<F::String>,
+	name: Option<T::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]
-	ty: F::TypeId,
+	ty: T::TypeId,
 }
 
 impl IntoCompact for Field {

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -27,7 +27,10 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 ///
 /// This can be a named field of a struct type or a struct variant.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -25,12 +25,12 @@ use serde::Serialize;
 /// Name is optional so it can represent both named and unnamed fields.
 ///
 /// This can be a named field of a struct type or a struct variant.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct Field<F: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	name: Option<&'static str>,
+	name: Option<F::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]
 	ty: F::TypeId,

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -19,7 +19,7 @@ use crate::{
 	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use scale::{Decode, Encode};
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A field of a struct like data type.
 ///

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -45,7 +45,7 @@ impl IntoCompact for Field {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Field {
-			name: self.name,
+			name: self.name.map(|name| name.into_compact(registry)),
 			ty: registry.register_type(&self.ty),
 		}
 	}

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use derive_more::From;
+use scale::{Decode};
 use serde::Serialize;
 
 mod composite;
@@ -30,7 +31,7 @@ mod variant;
 pub use self::{composite::*, fields::*, path::*, variant::*};
 
 /// A [`Type`] definition with optional metadata.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct Type<F: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
@@ -95,12 +96,13 @@ impl Type {
 			path,
 			type_params: type_params.into_iter().collect(),
 			type_def: type_def.into(),
+			// marker: MetaForm,
 		}
 	}
 }
 
 /// The possible types a SCALE encodable Rust value could have.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<F: Form = MetaForm> {
@@ -134,7 +136,7 @@ impl IntoCompact for TypeDef {
 }
 
 /// A primitive Rust type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum TypeDefPrimitive {
 	/// `bool` type
@@ -166,7 +168,7 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefArray<F: Form = MetaForm> {
 	/// The length of the array type.
@@ -195,7 +197,7 @@ impl TypeDefArray {
 }
 
 /// A type to refer to tuple types.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(transparent)]
 pub struct TypeDefTuple<F: Form = MetaForm> {
@@ -231,7 +233,7 @@ impl TypeDefTuple {
 }
 
 /// A type to refer to a sequence of elements of the same type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefSequence<F: Form = MetaForm> {
 	/// The element type of the sequence type.

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -32,7 +32,10 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 
 /// A [`Type`] definition with optional metadata.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty")]
@@ -103,7 +106,10 @@ impl Type {
 
 /// The possible types a SCALE encodable Rust value could have.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<T: Form = MetaForm> {
 	/// A composite type (e.g. a struct or a tuple)

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -99,7 +99,6 @@ impl Type {
 			path,
 			type_params: type_params.into_iter().collect(),
 			type_def: type_def.into(),
-			// marker: MetaForm,
 		}
 	}
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -32,17 +32,17 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 
 /// A [`Type`] definition with optional metadata.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
-pub struct Type<F: Form = MetaForm> {
+#[serde(bound = "T::TypeId: Serialize")]
+pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty")]
-	path: Path<F>,
+	path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty")]
-	type_params: Vec<F::TypeId>,
+	type_params: Vec<T::TypeId>,
 	/// The actual type definition
 	#[serde(rename = "def")]
-	type_def: TypeDef<F>,
+	type_def: TypeDef<T>,
 }
 
 impl IntoCompact for Type {
@@ -103,19 +103,19 @@ impl Type {
 
 /// The possible types a SCALE encodable Rust value could have.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
+#[serde(bound = "T::TypeId: Serialize")]
 #[serde(rename_all = "camelCase")]
-pub enum TypeDef<F: Form = MetaForm> {
+pub enum TypeDef<T: Form = MetaForm> {
 	/// A composite type (e.g. a struct or a tuple)
-	Composite(TypeDefComposite<F>),
+	Composite(TypeDefComposite<T>),
 	/// A variant type (e.g. an enum)
-	Variant(TypeDefVariant<F>),
+	Variant(TypeDefVariant<T>),
 	/// A sequence type with runtime known length.
-	Sequence(TypeDefSequence<F>),
+	Sequence(TypeDefSequence<T>),
 	/// An array type with compile-time known length.
-	Array(TypeDefArray<F>),
+	Array(TypeDefArray<T>),
 	/// A tuple type.
-	Tuple(TypeDefTuple<F>),
+	Tuple(TypeDefTuple<T>),
 	/// A Rust primitive type.
 	Primitive(TypeDefPrimitive),
 }
@@ -169,13 +169,13 @@ pub enum TypeDefPrimitive {
 
 /// An array type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "F::TypeId: Serialize")]
-pub struct TypeDefArray<F: Form = MetaForm> {
+#[serde(bound = "T::TypeId: Serialize")]
+pub struct TypeDefArray<T: Form = MetaForm> {
 	/// The length of the array type.
 	pub len: u32,
 	/// The element type of the array type.
 	#[serde(rename = "type")]
-	pub type_param: F::TypeId,
+	pub type_param: T::TypeId,
 }
 
 impl IntoCompact for TypeDefArray {
@@ -198,11 +198,11 @@ impl TypeDefArray {
 
 /// A type to refer to tuple types.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "F::TypeId: Serialize + Deserialize")]
+#[serde(bound = "T::TypeId: Serialize")]
 #[serde(transparent)]
-pub struct TypeDefTuple<F: Form = MetaForm> {
+pub struct TypeDefTuple<T: Form = MetaForm> {
 	/// The types of the tuple fields.
-	fields: Vec<F::TypeId>,
+	fields: Vec<T::TypeId>,
 }
 
 impl IntoCompact for TypeDefTuple {
@@ -234,11 +234,11 @@ impl TypeDefTuple {
 
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "F::TypeId: Serialize")]
-pub struct TypeDefSequence<F: Form = MetaForm> {
+#[serde(bound = "T::TypeId: Serialize")]
+pub struct TypeDefSequence<T: Form = MetaForm> {
 	/// The element type of the sequence type.
 	#[serde(rename = "type")]
-	type_param: F::TypeId,
+	type_param: T::TypeId,
 }
 
 impl IntoCompact for TypeDefSequence {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -20,8 +20,8 @@ use crate::{
 	IntoCompact, MetaType, Registry, TypeInfo,
 };
 use derive_more::From;
-use scale::{Decode};
-use serde::Serialize;
+use scale::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 mod composite;
 mod fields;
@@ -31,7 +31,7 @@ mod variant;
 pub use self::{composite::*, fields::*, path::*, variant::*};
 
 /// A [`Type`] definition with optional metadata.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Decode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct Type<F: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
@@ -102,7 +102,7 @@ impl Type {
 }
 
 /// The possible types a SCALE encodable Rust value could have.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Decode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<F: Form = MetaForm> {
@@ -136,7 +136,7 @@ impl IntoCompact for TypeDef {
 }
 
 /// A primitive Rust type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum TypeDefPrimitive {
 	/// `bool` type
@@ -168,7 +168,7 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefArray<F: Form = MetaForm> {
 	/// The length of the array type.
@@ -197,8 +197,8 @@ impl TypeDefArray {
 }
 
 /// A type to refer to tuple types.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
-#[serde(bound = "F::TypeId: Serialize")]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
+#[serde(bound = "F::TypeId: Serialize + Deserialize")]
 #[serde(transparent)]
 pub struct TypeDefTuple<F: Form = MetaForm> {
 	/// The types of the tuple fields.
@@ -233,7 +233,7 @@ impl TypeDefTuple {
 }
 
 /// A type to refer to a sequence of elements of the same type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Decode, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefSequence<F: Form = MetaForm> {
 	/// The element type of the sequence type.

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -35,7 +35,7 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 pub struct Type<F: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty")]
-	path: Path,
+	path: Path<F>,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty")]
 	type_params: Vec<F::TypeId>,
@@ -49,7 +49,7 @@ impl IntoCompact for Type {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Type {
-			path: self.path,
+			path: self.path.into_compact(registry),
 			type_params: registry.register_types(self.type_params),
 			type_def: self.type_def.into_compact(registry),
 		}

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use derive_more::From;
 use scale::{Decode, Encode};
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 mod composite;
 mod fields;

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use derive_more::From;
 use scale::{Decode, Encode};
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 mod composite;
 mod fields;
@@ -32,7 +32,7 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 
 /// A [`Type`] definition with optional metadata.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty")]
@@ -103,7 +103,7 @@ impl Type {
 
 /// The possible types a SCALE encodable Rust value could have.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<T: Form = MetaForm> {
 	/// A composite type (e.g. a struct or a tuple)
@@ -169,7 +169,7 @@ pub enum TypeDefPrimitive {
 
 /// An array type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 pub struct TypeDefArray<T: Form = MetaForm> {
 	/// The length of the array type.
 	pub len: u32,
@@ -198,7 +198,7 @@ impl TypeDefArray {
 
 /// A type to refer to tuple types.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 #[serde(transparent)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
 	/// The types of the tuple fields.
@@ -234,7 +234,7 @@ impl TypeDefTuple {
 
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
 	/// The element type of the sequence type.
 	#[serde(rename = "type")]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -38,10 +38,10 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 ))]
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
-	#[serde(skip_serializing_if = "Path::is_empty")]
+	#[serde(skip_serializing_if = "Path::is_empty", default)]
 	path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
-	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty")]
+	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
 	type_params: Vec<T::TypeId>,
 	/// The actual type definition
 	#[serde(rename = "def")]

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::{IntoCompact, form::{CompactForm, Form, MetaForm}, tm_std::*, utils::is_rust_identifier, Registry};
-use serde::Serialize;
+use scale::{Decode, Encode};
+use serde::{Serialize, Deserialize};
 
 /// Represents the path of a type definition.
 ///
@@ -22,16 +23,16 @@ use serde::Serialize;
 /// has been defined. The last
 ///
 /// Rust prelude type may have an empty namespace definition.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug, scale::Decode)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent)]
-pub struct Path<F: Form = MetaForm> {
+pub struct Path<T: Form = MetaForm> {
 	/// The segments of the namespace.
-	segments: Vec<F::String>,
+	segments: Vec<T::String>,
 }
 
-impl<F> Default for Path<F>
+impl<T> Default for Path<T>
 where
-	F: Form,
+	T: Form,
 {
 	fn default() -> Self {
 		Path { segments: Vec::new() }
@@ -96,9 +97,9 @@ impl Path {
 	}
 }
 
-impl<F> Path<F>
+impl<T> Path<T>
 where
-	F: Form
+	T: Form
 {
 	/// Returns `true` if the path is empty
 	pub fn is_empty(&self) -> bool {
@@ -106,12 +107,12 @@ where
 	}
 
 	/// Get the ident segment of the Path
-	pub fn ident(&self) -> Option<F::String> {
+	pub fn ident(&self) -> Option<T::String> {
 		self.segments.iter().last().cloned()
 	}
 
 	/// Get the namespace segments of the Path
-	pub fn namespace(&self) -> &[F::String] {
+	pub fn namespace(&self) -> &[T::String] {
 		self.segments.split_last().map(|(_, ns)| ns).unwrap_or(&[])
 	}
 }

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{IntoCompact, form::{CompactForm, Form, MetaForm}, tm_std::*, utils::is_rust_identifier, Registry};
+use crate::{
+	form::{CompactForm, Form, MetaForm},
+	tm_std::*,
+	utils::is_rust_identifier,
+	IntoCompact, Registry,
+};
 use scale::{Decode, Encode};
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Represents the path of a type definition.
 ///
@@ -103,7 +108,7 @@ impl Path {
 
 impl<T> Path<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns `true` if the path is empty
 	pub fn is_empty(&self) -> bool {

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -51,9 +51,9 @@ where
 impl IntoCompact for Path {
 	type Output = Path<CompactForm>;
 
-	fn into_compact(self, _registry: &mut Registry) -> Self::Output {
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Path {
-			segments: self.segments,
+			segments: registry.map_into_compact(self.segments),
 		}
 	}
 }

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -14,7 +14,7 @@
 
 use crate::{IntoCompact, form::{CompactForm, Form, MetaForm}, tm_std::*, utils::is_rust_identifier, Registry};
 use scale::{Decode, Encode};
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 /// Represents the path of a type definition.
 ///

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -25,6 +25,10 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 /// Rust prelude type may have an empty namespace definition.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent)]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 pub struct Path<T: Form = MetaForm> {
 	/// The segments of the namespace.
 	segments: Vec<T::String>,

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 /// has been defined. The last
 ///
 /// Rust prelude type may have an empty namespace definition.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug, scale::Decode)]
 #[serde(transparent)]
 pub struct Path<F: Form = MetaForm> {
 	/// The segments of the namespace.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -136,7 +136,7 @@ impl IntoCompact for Variant {
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		Variant {
-			name: self.name,
+			name: self.name.into_compact(registry),
 			fields: registry.map_into_compact(self.fields),
 			discriminant: self.discriminant,
 		}

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -20,8 +20,8 @@ use crate::{
 	Field, IntoCompact, Registry,
 };
 use derive_more::From;
-use scale::{Encode, Decode};
-use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use scale::{Decode, Encode};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A Enum type (consisting of variants).
 ///

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -62,7 +62,10 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 /// enum JustAMarker {}
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]
@@ -106,8 +109,11 @@ impl TypeDefVariant {
 /// //  ^^^^^^^^^^^^^^^^^^^^^ this is a struct enum variant
 /// }
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound(
+	serialize = "T::TypeId: Serialize, T::String: Serialize",
+	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+))]
 pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.
 	name: T::String,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -60,7 +60,7 @@ use serde::Serialize;
 /// ```
 /// enum JustAMarker {}
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<F: Form = MetaForm> {
@@ -105,11 +105,11 @@ impl TypeDefVariant {
 /// //  ^^^^^^^^^^^^^^^^^^^^^ this is a struct enum variant
 /// }
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct Variant<F: Form = MetaForm> {
 	/// The name of the struct variant.
-	name: &'static str,
+	name: F::String,
 	/// The fields of the struct variant.
 	#[serde(skip_serializing_if = "Vec::is_empty")]
 	fields: Vec<Field<F>>,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -20,7 +20,8 @@ use crate::{
 	Field, IntoCompact, Registry,
 };
 use derive_more::From;
-use serde::Serialize;
+use scale::{Encode, Decode};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 
 /// A Enum type (consisting of variants).
 ///
@@ -60,8 +61,8 @@ use serde::Serialize;
 /// ```
 /// enum JustAMarker {}
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]
@@ -106,7 +107,7 @@ impl TypeDefVariant {
 /// }
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
-#[serde(bound = "T::TypeId: Serialize")]
+#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
 pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.
 	name: T::String,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -61,11 +61,11 @@ use serde::Serialize;
 /// enum JustAMarker {}
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, From, scale::Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
+#[serde(bound = "T::TypeId: Serialize")]
 #[serde(rename_all = "lowercase")]
-pub struct TypeDefVariant<F: Form = MetaForm> {
+pub struct TypeDefVariant<T: Form = MetaForm> {
 	#[serde(skip_serializing_if = "Vec::is_empty")]
-	variants: Vec<Variant<F>>,
+	variants: Vec<Variant<T>>,
 }
 
 impl IntoCompact for TypeDefVariant {
@@ -106,13 +106,13 @@ impl TypeDefVariant {
 /// }
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, scale::Decode)]
-#[serde(bound = "F::TypeId: Serialize")]
-pub struct Variant<F: Form = MetaForm> {
+#[serde(bound = "T::TypeId: Serialize")]
+pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.
-	name: F::String,
+	name: T::String,
 	/// The fields of the struct variant.
 	#[serde(skip_serializing_if = "Vec::is_empty")]
-	fields: Vec<Field<F>>,
+	fields: Vec<Field<T>>,
 	/// The discriminant of the variant.
 	///
 	/// # Note

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -68,7 +68,7 @@ use serde::{Serialize, Deserialize, de::DeserializeOwned};
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
-	#[serde(skip_serializing_if = "Vec::is_empty")]
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	variants: Vec<Variant<T>>,
 }
 
@@ -118,7 +118,7 @@ pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.
 	name: T::String,
 	/// The fields of the struct variant.
-	#[serde(skip_serializing_if = "Vec::is_empty")]
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
 	fields: Vec<Field<T>>,
 	/// The discriminant of the variant.
 	///
@@ -127,7 +127,7 @@ pub struct Variant<T: Form = MetaForm> {
 	/// Even though setting the discriminant is optional
 	/// every C-like enum variant has a discriminant specified
 	/// upon compile-time.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(skip_serializing_if = "Option::is_none", default)]
 	discriminant: Option<u64>,
 }
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive"] }
 
+scale = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "1.3.4", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -14,48 +14,8 @@
 // limitations under the License.
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items, start)]
-
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
-	0
-}
-
-#[lang = "eh_personality"]
-pub extern "C" fn rust_eh_personality() {}
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! {
-	unsafe {
-		libc::abort();
-	}
-}
-#[alloc_error_handler]
-fn error_handler(_: core::alloc::Layout) -> ! {
-	unsafe {
-		libc::abort();
-	}
-}
 
 extern crate alloc;
-use alloc::alloc::{GlobalAlloc, Layout};
-
-pub struct Allocator;
-
-#[global_allocator]
-static ALLOCATOR: Allocator = Allocator;
-
-extern "C" {
-	fn ext_malloc(size: usize) -> *mut u8;
-	fn ext_free(ptr: *mut u8);
-}
-unsafe impl GlobalAlloc for Allocator {
-	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-		ext_malloc(layout.size()) as *mut u8
-	}
-	unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-		ext_free(ptr as *mut u8)
-	}
-}
 
 use scale_info::TypeInfo;
 

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -48,3 +48,6 @@ enum E<T> {
 	B { b: T },
 	C,
 }
+
+fn main() {
+}

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -21,7 +21,7 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
-
+use core::num::NonZeroU32;
 use pretty_assertions::{assert_eq, assert_ne};
 use scale::{Decode, Encode};
 use scale_info::{form::CompactForm, IntoCompact as _, MetaType, Registry, RegistryReadOnly, TypeInfo};
@@ -49,6 +49,7 @@ fn scale_encode_then_decode_to_readonly() {
 	let original_serialized = serde_json::to_value(registry).unwrap();
 
 	let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
+	assert!(readonly_decoded.resolve(NonZeroU32::new(1).unwrap()).is_some());
 	let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
 
 	assert_eq!(decoded_serialized, original_serialized);
@@ -62,6 +63,7 @@ fn json_serialize_then_deserialize_to_readonly() {
 	let original_serialized = serde_json::to_value(registry).unwrap();
 	// assert_eq!(original_serialized, serde_json::Value::Null);
 	let readonly_deserialized: RegistryReadOnly = serde_json::from_value(original_serialized.clone()).unwrap();
+	assert!(readonly_deserialized.resolve(NonZeroU32::new(1).unwrap()).is_some());
 	let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
 
 	assert_eq!(readonly_serialized, original_serialized);

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(dead_code)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
+use pretty_assertions::{assert_eq, assert_ne};
+use scale::{Encode, Decode};
+use scale_info::{form::CompactForm, MetaType, IntoCompact as _, Registry, RegistryReadOnly, TypeInfo};
+
+#[derive(TypeInfo)]
+struct A<T> {
+	a: bool,
+	b: Result<char, u32>,
+	c: T
+}
+
+#[derive(TypeInfo)]
+enum B {
+	A,
+	B(A<bool>),
+	C {
+		d: [u8; 32]
+	}
+}
+
+#[test]
+fn encode_decode_to_readonly() {
+	let mut registry = Registry::new();
+	registry.register_type(&MetaType::new::<A<B>>());
+
+	let mut encoded = registry.encode();
+	let original_serialized = serde_json::to_value(registry).unwrap();
+
+	let readonly_decoded = RegistryReadOnly::decode(&mut encoded[..]).unwrap();
+	let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
+
+	assert_eq!(decoded_serialized, original_serialized);
+}

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -48,10 +48,10 @@ fn encode_decode_to_readonly() {
 	registry.register_type(&MetaType::new::<A<B>>());
 
 	let mut encoded = registry.encode();
-	let original_serialized = serde_json::to_value(registry).unwrap();
-
-	let readonly_decoded = RegistryReadOnly::decode(&mut encoded[..]).unwrap();
-	let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
-
-	assert_eq!(decoded_serialized, original_serialized);
+	// let original_serialized = serde_json::to_value(registry).unwrap();
+	//
+	// let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
+	// let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
+	//
+	// assert_eq!(decoded_serialized, original_serialized);
 }

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -43,15 +43,15 @@ enum B {
 }
 
 #[test]
-fn encode_decode_to_readonly() {
+fn scale_encode_then_decode_to_readonly() {
 	let mut registry = Registry::new();
 	registry.register_type(&MetaType::new::<A<B>>());
 
 	let mut encoded = registry.encode();
-	// let original_serialized = serde_json::to_value(registry).unwrap();
-	//
-	// let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
-	// let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
-	//
-	// assert_eq!(decoded_serialized, original_serialized);
+	let original_serialized = serde_json::to_value(registry).unwrap();
+
+	let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
+	let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
+
+	assert_eq!(decoded_serialized, original_serialized);
 }

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -55,3 +55,16 @@ fn scale_encode_then_decode_to_readonly() {
 
 	assert_eq!(decoded_serialized, original_serialized);
 }
+
+#[test]
+fn json_serialize_then_deserialize_to_readonly() {
+	let mut registry = Registry::new();
+	registry.register_type(&MetaType::new::<A<B>>());
+
+	let original_serialized = serde_json::to_value(registry).unwrap();
+	// assert_eq!(original_serialized, serde_json::Value::Null);
+	let readonly_deserialized: RegistryReadOnly = serde_json::from_value(original_serialized.clone()).unwrap();
+	let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
+
+	assert_eq!(readonly_serialized, original_serialized);
+}

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -23,23 +23,21 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 
 use pretty_assertions::{assert_eq, assert_ne};
-use scale::{Encode, Decode};
-use scale_info::{form::CompactForm, MetaType, IntoCompact as _, Registry, RegistryReadOnly, TypeInfo};
+use scale::{Decode, Encode};
+use scale_info::{form::CompactForm, IntoCompact as _, MetaType, Registry, RegistryReadOnly, TypeInfo};
 
 #[derive(TypeInfo)]
 struct A<T> {
 	a: bool,
 	b: Result<char, u32>,
-	c: T
+	c: T,
 }
 
 #[derive(TypeInfo)]
 enum B {
 	A,
 	B(A<bool>),
-	C {
-		d: [u8; 32]
-	}
+	C { d: [u8; 32] },
 }
 
 #[test]


### PR DESCRIPTION
Closes #4 (rel https://github.com/type-metadata/type-metadata/pull/38).

Introduces `OwnedForm` and `RegistryReadOnly` to allow SCALE decoding and JSON deserialization.

- [ ] Consider adding features for `scale` and `serde`, maybe decoding specific for `no_std`