### PR TITLE
Add public getters for fields in meta type hierarchy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 scale-info-derive = { version = "0.2.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
-	type_params: Vec<T::TypeId>,
+	type_params: Vec<T::Type>,
 	/// The actual type definition
 	type_def: TypeDef<T>,
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 /// instantiated out of the flux and compact forms that require some sort of
 /// interning data structures.
 pub trait Form {
-	/// The type identifier type.
+	/// The type representing the type.
 	type Type: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 	/// The string type.
 	type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;

--- a/src/form.rs
+++ b/src/form.rs
@@ -41,7 +41,7 @@ use serde::Serialize;
 /// interning data structures.
 pub trait Form {
 	/// The type identifier type.
-	type TypeId: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+	type Type: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 	/// The string type.
 	type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 }
@@ -54,7 +54,7 @@ pub trait Form {
 pub enum MetaForm {}
 
 impl Form for MetaForm {
-	type TypeId = MetaType;
+	type Type = MetaType;
 	type String = &'static str;
 }
 
@@ -71,6 +71,6 @@ impl Form for MetaForm {
 pub enum CompactForm {}
 
 impl Form for CompactForm {
-	type TypeId = UntrackedSymbol<TypeId>;
+	type Type = UntrackedSymbol<TypeId>;
 	type String = String;
 }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -31,7 +31,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UntrackedSymbol<T> {
-	id: NonZeroU32,
+	/// The index to the symbol in the interner table.
+	pub id: NonZeroU32,
 	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -184,7 +184,7 @@ pub struct RegistryReadOnly {
 impl From<Registry> for RegistryReadOnly {
 	fn from(registry: Registry) -> Self {
 		RegistryReadOnly {
-			types: registry.types.values().cloned().collect::<Vec<_>>()
+			types: registry.types.values().cloned().collect::<Vec<_>>(),
 		}
 	}
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -181,6 +181,14 @@ pub struct RegistryReadOnly {
 	types: Vec<Type<CompactForm>>,
 }
 
+impl From<Registry> for RegistryReadOnly {
+	fn from(registry: Registry) -> Self {
+		RegistryReadOnly {
+			types: registry.types.values().cloned().collect::<Vec<_>>()
+		}
+	}
+}
+
 impl RegistryReadOnly {
 	/// Returns the type definition for the given identifier, `None` if no type found for that ID.
 	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -84,7 +84,7 @@ impl TypeDefComposite {
 
 impl<T> TypeDefComposite<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns the fields of the composite type.
 	pub fn fields(&self) -> &[Field<T>] {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -57,7 +57,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub struct TypeDefComposite<T: Form = MetaForm> {
 	/// The fields of the composite type.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub fields: Vec<Field<T>>,
+	fields: Vec<Field<T>>,
 }
 
 impl IntoCompact for TypeDefComposite {
@@ -79,5 +79,15 @@ impl TypeDefComposite {
 		Self {
 			fields: fields.into_iter().collect(),
 		}
+	}
+}
+
+impl<T> TypeDefComposite<T>
+where
+	T: Form
+{
+	/// Returns the fields of the composite type.
+	pub fn fields(&self) -> &[Field<T>] {
+		&self.fields
 	}
 }

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -55,8 +55,9 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {
+	/// The fields of the composite type.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	fields: Vec<Field<T>>,
+	pub fields: Vec<Field<T>>,
 }
 
 impl IntoCompact for TypeDefComposite {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -50,8 +50,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -34,10 +34,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none", default)]
-	name: Option<T::String>,
+	pub name: Option<T::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]
-	ty: T::TypeId,
+	pub ty: T::TypeId,
 }
 
 impl IntoCompact for Field {

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -28,8 +28,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// This can be a named field of a struct type or a struct variant.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
@@ -37,7 +37,7 @@ pub struct Field<T: Form = MetaForm> {
 	pub name: Option<T::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]
-	pub ty: T::TypeId,
+	pub ty: T::Type,
 }
 
 impl IntoCompact for Field {

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -34,10 +34,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub struct Field<T: Form = MetaForm> {
 	/// The name of the field. None for unnamed fields.
 	#[serde(skip_serializing_if = "Option::is_none", default)]
-	pub name: Option<T::String>,
+	name: Option<T::String>,
 	/// The type of the field.
 	#[serde(rename = "type")]
-	pub ty: T::Type,
+	ty: T::Type,
 }
 
 impl IntoCompact for Field {
@@ -92,5 +92,20 @@ impl Field {
 		T: TypeInfo + ?Sized + 'static,
 	{
 		Self::new(None, MetaType::new::<T>())
+	}
+}
+
+impl<T> Field<T>
+where
+	T: Form
+{
+	/// Returns the name of the field. None for unnamed fields.
+	pub fn name(&self) -> Option<&T::String> {
+		self.name.as_ref()
+	}
+
+	/// Returns the type of the field.
+	pub fn ty(&self) -> &T::Type {
+		&self.ty
 	}
 }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -97,7 +97,7 @@ impl Field {
 
 impl<T> Field<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns the name of the field. None for unnamed fields.
 	pub fn name(&self) -> Option<&T::String> {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -33,8 +33,8 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 /// A [`Type`] definition with optional metadata.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
@@ -42,7 +42,7 @@ pub struct Type<T: Form = MetaForm> {
 	pub path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
-	pub type_params: Vec<T::TypeId>,
+	pub type_params: Vec<T::Type>,
 	/// The actual type definition
 	#[serde(rename = "def")]
 	pub type_def: TypeDef<T>,
@@ -106,8 +106,8 @@ impl Type {
 /// The possible types a SCALE encodable Rust value could have.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<T: Form = MetaForm> {
@@ -174,13 +174,13 @@ pub enum TypeDefPrimitive {
 
 /// An array type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
 pub struct TypeDefArray<T: Form = MetaForm> {
 	/// The length of the array type.
 	pub len: u32,
 	/// The element type of the array type.
 	#[serde(rename = "type")]
-	pub type_param: T::TypeId,
+	pub type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefArray {
@@ -203,11 +203,11 @@ impl TypeDefArray {
 
 /// A type to refer to tuple types.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
 #[serde(transparent)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
 	/// The types of the tuple fields.
-	fields: Vec<T::TypeId>,
+	fields: Vec<T::Type>,
 }
 
 impl IntoCompact for TypeDefTuple {
@@ -239,11 +239,11 @@ impl TypeDefTuple {
 
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::TypeId: Serialize", deserialize = "T::TypeId: DeserializeOwned"))]
+#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
 	/// The element type of the sequence type.
 	#[serde(rename = "type")]
-	pub type_param: T::TypeId,
+	pub type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefSequence {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -39,13 +39,13 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty", default)]
-	pub path: Path<T>,
+	path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
-	pub type_params: Vec<T::Type>,
+	type_params: Vec<T::Type>,
 	/// The actual type definition
 	#[serde(rename = "def")]
-	pub type_def: TypeDef<T>,
+	type_def: TypeDef<T>,
 }
 
 impl IntoCompact for Type {
@@ -100,6 +100,26 @@ impl Type {
 			type_params: type_params.into_iter().collect(),
 			type_def: type_def.into(),
 		}
+	}
+}
+
+impl<T> Type<T>
+where
+	T: Form,
+{
+	/// Returns the path of the type
+	pub fn path(&self) -> &Path<T> {
+		&self.path
+	}
+
+	/// Returns the generic type parameters of the type
+	pub fn type_params(&self) -> &[T::Type] {
+		&self.type_params
+	}
+
+	/// Returns the definition of the type
+	pub fn type_def(&self) -> &TypeDef<T> {
+		&self.type_def
 	}
 }
 
@@ -177,10 +197,10 @@ pub enum TypeDefPrimitive {
 #[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
 pub struct TypeDefArray<T: Form = MetaForm> {
 	/// The length of the array type.
-	pub len: u32,
+	len: u32,
 	/// The element type of the array type.
 	#[serde(rename = "type")]
-	pub type_param: T::Type,
+	type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefArray {
@@ -198,6 +218,21 @@ impl TypeDefArray {
 	/// Creates a new array type.
 	pub fn new(len: u32, type_param: MetaType) -> Self {
 		Self { len, type_param }
+	}
+}
+
+impl<T> TypeDefArray<T>
+where
+	T: Form
+{
+	/// Returns the length of the array type.
+	pub fn len(&self) -> u32 {
+		self.len
+	}
+
+	/// Returns the element type of the array type.
+	pub fn type_param(&self) -> &T::Type {
+		&self.type_param
 	}
 }
 
@@ -237,13 +272,23 @@ impl TypeDefTuple {
 	}
 }
 
+impl<T> TypeDefTuple<T>
+where
+	T: Form
+{
+	/// Returns the types of the tuple fields.
+	pub fn fields(&self) -> &[T::Type] {
+		&self.fields
+	}
+}
+
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
 #[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
 	/// The element type of the sequence type.
 	#[serde(rename = "type")]
-	pub type_param: T::Type,
+	type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefSequence {
@@ -273,5 +318,15 @@ impl TypeDefSequence {
 		T: TypeInfo + 'static,
 	{
 		Self::new(MetaType::new::<T>())
+	}
+}
+
+impl<T> TypeDefSequence<T>
+	where
+		T: Form
+{
+	/// Returns the element type of the sequence type.
+	pub fn type_param(&self) -> &T::Type {
+		&self.type_param
 	}
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -221,6 +221,7 @@ impl TypeDefArray {
 	}
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<T> TypeDefArray<T>
 where
 	T: Form,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -39,13 +39,13 @@ pub use self::{composite::*, fields::*, path::*, variant::*};
 pub struct Type<T: Form = MetaForm> {
 	/// The unique path to the type. Can be empty for built-in types
 	#[serde(skip_serializing_if = "Path::is_empty", default)]
-	path: Path<T>,
+	pub path: Path<T>,
 	/// The generic type parameters of the type in use. Empty for non generic types
 	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
-	type_params: Vec<T::TypeId>,
+	pub type_params: Vec<T::TypeId>,
 	/// The actual type definition
 	#[serde(rename = "def")]
-	type_def: TypeDef<T>,
+	pub type_def: TypeDef<T>,
 }
 
 impl IntoCompact for Type {
@@ -243,7 +243,7 @@ impl TypeDefTuple {
 pub struct TypeDefSequence<T: Form = MetaForm> {
 	/// The element type of the sequence type.
 	#[serde(rename = "type")]
-	type_param: T::TypeId,
+	pub type_param: T::TypeId,
 }
 
 impl IntoCompact for TypeDefSequence {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -223,7 +223,7 @@ impl TypeDefArray {
 
 impl<T> TypeDefArray<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns the length of the array type.
 	pub fn len(&self) -> u32 {
@@ -274,7 +274,7 @@ impl TypeDefTuple {
 
 impl<T> TypeDefTuple<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns the types of the tuple fields.
 	pub fn fields(&self) -> &[T::Type] {
@@ -322,8 +322,8 @@ impl TypeDefSequence {
 }
 
 impl<T> TypeDefSequence<T>
-	where
-		T: Form
+where
+	T: Form,
 {
 	/// Returns the element type of the sequence type.
 	pub fn type_param(&self) -> &T::Type {

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -36,7 +36,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 ))]
 pub struct Path<T: Form = MetaForm> {
 	/// The segments of the namespace.
-	pub segments: Vec<T::String>,
+	segments: Vec<T::String>,
 }
 
 impl<T> Default for Path<T>
@@ -110,6 +110,11 @@ impl<T> Path<T>
 where
 	T: Form,
 {
+	/// Returns the segments of the Path
+	pub fn segments(&self) -> &[T::String] {
+		&self.segments
+	}
+
 	/// Returns `true` if the path is empty
 	pub fn is_empty(&self) -> bool {
 		self.segments.is_empty()

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -36,7 +36,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 ))]
 pub struct Path<T: Form = MetaForm> {
 	/// The segments of the namespace.
-	segments: Vec<T::String>,
+	pub segments: Vec<T::String>,
 }
 
 impl<T> Default for Path<T>

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -31,8 +31,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Path<T: Form = MetaForm> {
 	/// The segments of the namespace.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -70,7 +70,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub struct TypeDefVariant<T: Form = MetaForm> {
 	/// The variants of a variant type
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub variants: Vec<Variant<T>>,
+	variants: Vec<Variant<T>>,
 }
 
 impl IntoCompact for TypeDefVariant {
@@ -95,6 +95,16 @@ impl TypeDefVariant {
 	}
 }
 
+impl<T> TypeDefVariant<T>
+where
+	T: Form
+{
+	/// Returns the variants of a variant type
+	pub fn variants(&self) -> &[Variant<T>] {
+		&self.variants
+	}
+}
+
 /// A struct enum variant with either named (struct) or unnamed (tuple struct)
 /// fields.
 ///
@@ -116,11 +126,11 @@ impl TypeDefVariant {
 	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Variant<T: Form = MetaForm> {
-	/// The name of the struct variant.
-	pub name: T::String,
-	/// The fields of the struct variant.
+	/// The name of the variant.
+	name: T::String,
+	/// The fields of the variant.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	pub fields: Vec<Field<T>>,
+	fields: Vec<Field<T>>,
 	/// The discriminant of the variant.
 	///
 	/// # Note
@@ -129,7 +139,7 @@ pub struct Variant<T: Form = MetaForm> {
 	/// every C-like enum variant has a discriminant specified
 	/// upon compile-time.
 	#[serde(skip_serializing_if = "Option::is_none", default)]
-	pub discriminant: Option<u64>,
+	discriminant: Option<u64>,
 }
 
 impl IntoCompact for Variant {
@@ -161,5 +171,25 @@ impl Variant {
 			fields: Vec::new(),
 			discriminant: Some(discriminant),
 		}
+	}
+}
+
+impl<T> TypeDefVariant<T>
+	where
+		T: Form
+{
+	/// Returns the name of the variant
+	pub fn name(&self) -> &T::String {
+		&self.name
+	}
+
+	/// Returns the fields of the struct variant.
+	pub fn fields(&self) -> &[Field<T>] {
+		&self.fields
+	}
+
+	/// Returns the discriminant of the variant.
+	pub fn discriminant(&self) -> Option<u64> {
+		self.discriminant
 	}
 }

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -68,8 +68,9 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
+	/// The variants of a variant type
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	variants: Vec<Variant<T>>,
+	pub variants: Vec<Variant<T>>,
 }
 
 impl IntoCompact for TypeDefVariant {
@@ -116,10 +117,10 @@ impl TypeDefVariant {
 ))]
 pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.
-	name: T::String,
+	pub name: T::String,
 	/// The fields of the struct variant.
 	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	fields: Vec<Field<T>>,
+	pub fields: Vec<Field<T>>,
 	/// The discriminant of the variant.
 	///
 	/// # Note
@@ -128,7 +129,7 @@ pub struct Variant<T: Form = MetaForm> {
 	/// every C-like enum variant has a discriminant specified
 	/// upon compile-time.
 	#[serde(skip_serializing_if = "Option::is_none", default)]
-	discriminant: Option<u64>,
+	pub discriminant: Option<u64>,
 }
 
 impl IntoCompact for Variant {

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -63,8 +63,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
@@ -112,8 +112,8 @@ impl TypeDefVariant {
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
 #[serde(bound(
-	serialize = "T::TypeId: Serialize, T::String: Serialize",
-	deserialize = "T::TypeId: DeserializeOwned, T::String: DeserializeOwned"
+	serialize = "T::Type: Serialize, T::String: Serialize",
+	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Variant<T: Form = MetaForm> {
 	/// The name of the struct variant.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -174,7 +174,7 @@ impl Variant {
 	}
 }
 
-impl<T> TypeDefVariant<T>
+impl<T> Variant<T>
 	where
 		T: Form
 {

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -97,7 +97,7 @@ impl TypeDefVariant {
 
 impl<T> TypeDefVariant<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Returns the variants of a variant type
 	pub fn variants(&self) -> &[Variant<T>] {
@@ -175,8 +175,8 @@ impl Variant {
 }
 
 impl<T> Variant<T>
-	where
-		T: Form
+where
+	T: Form,
 {
 	/// Returns the name of the variant
 	pub fn name(&self) -> &T::String {

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive"] }
 
-scale = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "1.3.4", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "1.3", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
Following on from #19 which enables decoding of `scale-info` meta types, this PR makes the fields of those types accessible via public getters.

The motivation for this is to allow 3rd party libraries to make use of instances of the meta types for e.g code generation of types in another language.

The immediate use case I am planning for is to build a library which is able to deserialize `ink!` contract metadata and use that to construct contract calls.

**Additionally** we rename `Form::TypeId` to `Form::Type` to be more accurate.