### PR TITLE
Unify transparent wrapper types e.g. references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ At its core is the `TypeInfo` trait:
 
 ```rust
 pub trait TypeInfo {
+    type Identity: ?Sized + 'static;
     fn type_info() -> Type;
 }
 ```

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -71,6 +71,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
 
 	let type_info_impl = quote! {
 		impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
+			type MetaType = Self;
 			fn type_info() -> _scale_info::Type {
 				_scale_info::Type::builder()
 					.path(_scale_info::Path::new(stringify!(#ident), module_path!()))

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -93,11 +93,11 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
 			let (ty, ident) = (&f.ty, &f.ident);
 			if let Some(i) = ident {
 				quote! {
-					.field_of::<#ty>(stringify!(#i))
+					.field(stringify!(#i), _scale_info::meta_type!(#ty))
 				}
 			} else {
 				quote! {
-					.field_of::<#ty>()
+					.field(_scale_info::meta_type!(#ty))
 				}
 			}
 		})

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -93,11 +93,11 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
 			let (ty, ident) = (&f.ty, &f.ident);
 			if let Some(i) = ident {
 				quote! {
-					.field(stringify!(#i), _scale_info::meta_type!(#ty))
+					.field_of::<#ty>(stringify!(#i))
 				}
 			} else {
 				quote! {
-					.field(_scale_info::meta_type!(#ty))
+					.field_of::<#ty>()
 				}
 			}
 		})

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -71,7 +71,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
 
 	let type_info_impl = quote! {
 		impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
-			type MetaType = Self;
+			type UnderlyingType = Self;
 			fn type_info() -> _scale_info::Type {
 				_scale_info::Type::builder()
 					.path(_scale_info::Path::new(stringify!(#ident), module_path!()))

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -71,7 +71,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
 
 	let type_info_impl = quote! {
 		impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
-			type UnderlyingType = Self;
+			type Identity = Self;
 			fn type_info() -> _scale_info::Type {
 				_scale_info::Type::builder()
 					.path(_scale_info::Path::new(stringify!(#ident), module_path!()))

--- a/src/build.rs
+++ b/src/build.rs
@@ -32,7 +32,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//!     type MetaType = Self;
+//!     type UnderlyingType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -51,7 +51,7 @@
 //! struct Foo(u32, bool);
 //!
 //! impl TypeInfo for Foo {
-//!     type MetaType = Self;
+//!     type UnderlyingType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -76,7 +76,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//!     type MetaType = Self;
+//!     type UnderlyingType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -101,7 +101,7 @@
 //! }
 //!
 //! impl TypeInfo for Foo {
-//!     type MetaType = Self;
+//!     type UnderlyingType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()

--- a/src/build.rs
+++ b/src/build.rs
@@ -32,7 +32,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//!     type UnderlyingType = Self;
+//!     type Identity = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -51,7 +51,7 @@
 //! struct Foo(u32, bool);
 //!
 //! impl TypeInfo for Foo {
-//!     type UnderlyingType = Self;
+//!     type Identity = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -76,7 +76,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//!     type UnderlyingType = Self;
+//!     type Identity = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -101,7 +101,7 @@
 //! }
 //!
 //! impl TypeInfo for Foo {
-//!     type UnderlyingType = Self;
+//!     type Identity = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()

--- a/src/build.rs
+++ b/src/build.rs
@@ -32,6 +32,8 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
+//! 	type MetaType = Self;
+//!
 //!     fn type_info() -> Type {
 //!         Type::builder()
 //!             .path(Path::new("Foo", module_path!()))
@@ -49,6 +51,8 @@
 //! struct Foo(u32, bool);
 //!
 //! impl TypeInfo for Foo {
+//! 	type MetaType = Self;
+//!
 //!     fn type_info() -> Type {
 //!         Type::builder()
 //!             .path(Path::new("Foo", module_path!()))
@@ -72,6 +76,8 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
+//! 	type MetaType = Self;
+//!
 //!     fn type_info() -> Type {
 //!         Type::builder()
 //!             .path(Path::new("Foo", module_path!()))
@@ -95,6 +101,8 @@
 //! }
 //!
 //! impl TypeInfo for Foo {
+//! 	type MetaType = Self;
+//!
 //!     fn type_info() -> Type {
 //!         Type::builder()
 //!             .path(Path::new("Foo", module_path!()))

--- a/src/build.rs
+++ b/src/build.rs
@@ -32,7 +32,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//! 	type MetaType = Self;
+//!     type MetaType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -51,7 +51,7 @@
 //! struct Foo(u32, bool);
 //!
 //! impl TypeInfo for Foo {
-//! 	type MetaType = Self;
+//!     type MetaType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -76,7 +76,7 @@
 //! where
 //!     T: TypeInfo + 'static,
 //! {
-//! 	type MetaType = Self;
+//!     type MetaType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()
@@ -101,7 +101,7 @@
 //! }
 //!
 //! impl TypeInfo for Foo {
-//! 	type MetaType = Self;
+//!     type MetaType = Self;
 //!
 //!     fn type_info() -> Type {
 //!         Type::builder()

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -19,7 +19,7 @@ use crate::*;
 macro_rules! impl_metadata_for_primitives {
 	( $( $t:ty => $ident_kind:expr, )* ) => { $(
 		impl TypeInfo for $t {
-			type UnderlyingType = Self;
+			type Identity = Self;
 
 			fn type_info() -> Type {
 				$ident_kind.into()
@@ -47,7 +47,7 @@ macro_rules! impl_metadata_for_array {
 	( $( $n:expr )* ) => {
 		$(
 			impl<T: TypeInfo + 'static> TypeInfo for [T; $n] {
-				type UnderlyingType = Self;
+				type Identity = Self;
 
 				fn type_info() -> Type {
 					TypeDefArray::new($n, MetaType::new::<T>()).into()
@@ -74,7 +74,7 @@ macro_rules! impl_metadata_for_tuple {
 				$ty: TypeInfo+ 'static,
 			)*
 		{
-			type UnderlyingType = Self;
+			type Identity = Self;
 
 			fn type_info() -> Type {
 				TypeDefTuple::new(tuple_meta_type!($($ty),*)).into()
@@ -99,7 +99,7 @@ impl<T> TypeInfo for Vec<T>
 where
 	T: TypeInfo + 'static,
 {
-	type UnderlyingType = [T];
+	type Identity = [T];
 
 	fn type_info() -> Type {
 		Self::UnderlyingType::type_info()
@@ -110,7 +110,7 @@ impl<T> TypeInfo for Option<T>
 where
 	T: TypeInfo + 'static,
 {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -129,7 +129,7 @@ where
 	T: TypeInfo + 'static,
 	E: TypeInfo + 'static,
 {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -148,7 +148,7 @@ where
 	K: TypeInfo + 'static,
 	V: TypeInfo + 'static,
 {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -162,7 +162,7 @@ impl<T> TypeInfo for Box<T>
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type UnderlyingType = T;
+	type Identity = T;
 
 	fn type_info() -> Type {
 		Self::UnderlyingType::type_info()
@@ -173,7 +173,7 @@ impl<T> TypeInfo for &T
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type UnderlyingType = T;
+	type Identity = T;
 
 	fn type_info() -> Type {
 		Self::UnderlyingType::type_info()
@@ -184,7 +184,7 @@ impl<T> TypeInfo for &mut T
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type UnderlyingType = T;
+	type Identity = T;
 
 	fn type_info() -> Type {
 		Self::UnderlyingType::type_info()
@@ -195,7 +195,7 @@ impl<T> TypeInfo for [T]
 where
 	T: TypeInfo + 'static,
 {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		TypeDefSequence::of::<T>().into()
@@ -203,7 +203,7 @@ where
 }
 
 impl TypeInfo for str {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		TypeDefPrimitive::Str.into()
@@ -211,7 +211,7 @@ impl TypeInfo for str {
 }
 
 impl TypeInfo for String {
-	type UnderlyingType = str;
+	type Identity = str;
 
 	fn type_info() -> Type {
 		Self::UnderlyingType::type_info()
@@ -222,7 +222,7 @@ impl<T> TypeInfo for PhantomData<T>
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type UnderlyingType = Self;
+	type Identity = Self;
 
 	fn type_info() -> Type {
 		Type::builder()

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -215,7 +215,8 @@ impl TypeInfo for String {
 
 	fn type_info() -> Type {
 		Self::MetaType::type_info()
-	}}
+	}
+}
 
 impl<T> TypeInfo for PhantomData<T>
 where

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -102,7 +102,7 @@ where
 	type Identity = [T];
 
 	fn type_info() -> Type {
-		Self::UnderlyingType::type_info()
+		Self::Identity::type_info()
 	}
 }
 
@@ -165,7 +165,7 @@ where
 	type Identity = T;
 
 	fn type_info() -> Type {
-		Self::UnderlyingType::type_info()
+		Self::Identity::type_info()
 	}
 }
 
@@ -176,7 +176,7 @@ where
 	type Identity = T;
 
 	fn type_info() -> Type {
-		Self::UnderlyingType::type_info()
+		Self::Identity::type_info()
 	}
 }
 
@@ -187,7 +187,7 @@ where
 	type Identity = T;
 
 	fn type_info() -> Type {
-		Self::UnderlyingType::type_info()
+		Self::Identity::type_info()
 	}
 }
 
@@ -214,7 +214,7 @@ impl TypeInfo for String {
 	type Identity = str;
 
 	fn type_info() -> Type {
-		Self::UnderlyingType::type_info()
+		Self::Identity::type_info()
 	}
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -19,6 +19,8 @@ use crate::*;
 macro_rules! impl_metadata_for_primitives {
 	( $( $t:ty => $ident_kind:expr, )* ) => { $(
 		impl TypeInfo for $t {
+			type MetaType = Self;
+
 			fn type_info() -> Type {
 				$ident_kind.into()
 			}
@@ -45,6 +47,8 @@ macro_rules! impl_metadata_for_array {
 	( $( $n:expr )* ) => {
 		$(
 			impl<T: TypeInfo + 'static> TypeInfo for [T; $n] {
+				type MetaType = Self;
+
 				fn type_info() -> Type {
 					TypeDefArray::new($n, MetaType::new::<T>()).into()
 				}
@@ -70,6 +74,8 @@ macro_rules! impl_metadata_for_tuple {
 				$ty: TypeInfo+ 'static,
 			)*
 		{
+			type MetaType = Self;
+
 			fn type_info() -> Type {
 				TypeDefTuple::new(tuple_meta_type!($($ty),*)).into()
 			}
@@ -93,8 +99,10 @@ impl<T> TypeInfo for Vec<T>
 where
 	T: TypeInfo + 'static,
 {
+	type MetaType = [T];
+
 	fn type_info() -> Type {
-		<[T] as TypeInfo>::type_info()
+		Self::MetaType::type_info()
 	}
 }
 
@@ -102,6 +110,8 @@ impl<T> TypeInfo for Option<T>
 where
 	T: TypeInfo + 'static,
 {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		Type::builder()
 			.path(Path::prelude("Option"))
@@ -119,6 +129,8 @@ where
 	T: TypeInfo + 'static,
 	E: TypeInfo + 'static,
 {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		Type::builder()
 			.path(Path::prelude("Result"))
@@ -136,6 +148,8 @@ where
 	K: TypeInfo + 'static,
 	V: TypeInfo + 'static,
 {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		Type::builder()
 			.path(Path::prelude("BTreeMap"))
@@ -146,28 +160,34 @@ where
 
 impl<T> TypeInfo for Box<T>
 where
-	T: TypeInfo + ?Sized,
+	T: TypeInfo + ?Sized + 'static,
 {
+	type MetaType = T;
+
 	fn type_info() -> Type {
-		T::type_info()
+		Self::MetaType::type_info()
 	}
 }
 
 impl<T> TypeInfo for &T
 where
-	T: TypeInfo + ?Sized,
+	T: TypeInfo + ?Sized + 'static,
 {
+	type MetaType = T;
+
 	fn type_info() -> Type {
-		T::type_info()
+		Self::MetaType::type_info()
 	}
 }
 
 impl<T> TypeInfo for &mut T
 where
-	T: TypeInfo + ?Sized,
+	T: TypeInfo + ?Sized + 'static,
 {
+	type MetaType = T;
+
 	fn type_info() -> Type {
-		T::type_info()
+		Self::MetaType::type_info()
 	}
 }
 
@@ -175,27 +195,34 @@ impl<T> TypeInfo for [T]
 where
 	T: TypeInfo + 'static,
 {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		TypeDefSequence::of::<T>().into()
 	}
 }
 
 impl TypeInfo for str {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		TypeDefPrimitive::Str.into()
 	}
 }
 
 impl TypeInfo for String {
+	type MetaType = str;
+
 	fn type_info() -> Type {
-		TypeDefPrimitive::Str.into()
-	}
-}
+		Self::MetaType::type_info()
+	}}
 
 impl<T> TypeInfo for PhantomData<T>
 where
 	T: TypeInfo + ?Sized + 'static,
 {
+	type MetaType = Self;
+
 	fn type_info() -> Type {
 		Type::builder()
 			.path(Path::prelude("PhantomData"))

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -19,7 +19,7 @@ use crate::*;
 macro_rules! impl_metadata_for_primitives {
 	( $( $t:ty => $ident_kind:expr, )* ) => { $(
 		impl TypeInfo for $t {
-			type MetaType = Self;
+			type UnderlyingType = Self;
 
 			fn type_info() -> Type {
 				$ident_kind.into()
@@ -47,7 +47,7 @@ macro_rules! impl_metadata_for_array {
 	( $( $n:expr )* ) => {
 		$(
 			impl<T: TypeInfo + 'static> TypeInfo for [T; $n] {
-				type MetaType = Self;
+				type UnderlyingType = Self;
 
 				fn type_info() -> Type {
 					TypeDefArray::new($n, MetaType::new::<T>()).into()
@@ -74,7 +74,7 @@ macro_rules! impl_metadata_for_tuple {
 				$ty: TypeInfo+ 'static,
 			)*
 		{
-			type MetaType = Self;
+			type UnderlyingType = Self;
 
 			fn type_info() -> Type {
 				TypeDefTuple::new(tuple_meta_type!($($ty),*)).into()
@@ -99,10 +99,10 @@ impl<T> TypeInfo for Vec<T>
 where
 	T: TypeInfo + 'static,
 {
-	type MetaType = [T];
+	type UnderlyingType = [T];
 
 	fn type_info() -> Type {
-		Self::MetaType::type_info()
+		Self::UnderlyingType::type_info()
 	}
 }
 
@@ -110,7 +110,7 @@ impl<T> TypeInfo for Option<T>
 where
 	T: TypeInfo + 'static,
 {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -129,7 +129,7 @@ where
 	T: TypeInfo + 'static,
 	E: TypeInfo + 'static,
 {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -148,7 +148,7 @@ where
 	K: TypeInfo + 'static,
 	V: TypeInfo + 'static,
 {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		Type::builder()
@@ -162,10 +162,10 @@ impl<T> TypeInfo for Box<T>
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type MetaType = T;
+	type UnderlyingType = T;
 
 	fn type_info() -> Type {
-		Self::MetaType::type_info()
+		Self::UnderlyingType::type_info()
 	}
 }
 
@@ -173,10 +173,10 @@ impl<T> TypeInfo for &T
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type MetaType = T;
+	type UnderlyingType = T;
 
 	fn type_info() -> Type {
-		Self::MetaType::type_info()
+		Self::UnderlyingType::type_info()
 	}
 }
 
@@ -184,10 +184,10 @@ impl<T> TypeInfo for &mut T
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type MetaType = T;
+	type UnderlyingType = T;
 
 	fn type_info() -> Type {
-		Self::MetaType::type_info()
+		Self::UnderlyingType::type_info()
 	}
 }
 
@@ -195,7 +195,7 @@ impl<T> TypeInfo for [T]
 where
 	T: TypeInfo + 'static,
 {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		TypeDefSequence::of::<T>().into()
@@ -203,7 +203,7 @@ where
 }
 
 impl TypeInfo for str {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		TypeDefPrimitive::Str.into()
@@ -211,10 +211,10 @@ impl TypeInfo for str {
 }
 
 impl TypeInfo for String {
-	type MetaType = str;
+	type UnderlyingType = str;
 
 	fn type_info() -> Type {
-		Self::MetaType::type_info()
+		Self::UnderlyingType::type_info()
 	}
 }
 
@@ -222,7 +222,7 @@ impl<T> TypeInfo for PhantomData<T>
 where
 	T: TypeInfo + ?Sized + 'static,
 {
-	type MetaType = Self;
+	type UnderlyingType = Self;
 
 	fn type_info() -> Type {
 		Type::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,14 +134,14 @@ pub use scale_info_derive::TypeInfo;
 
 /// Implementors return their meta type information.
 pub trait TypeInfo {
-	/// The type for which this trait provides type info.
+	/// The underlying type for which type info is provided.
 	///
 	/// # Note
 	///
 	/// This is used to uniquely identify a type via [`core::any::TypeId::of`]. In most cases it
 	/// will just be `Self`, but can be used to unify different types which have the same encoded
 	/// representation e.g. reference types `Box<T>`, `&T` and `&mut T`.
-	type MetaType: ?Sized + 'static;
+	type UnderlyingType: ?Sized + 'static;
 
 	/// Returns the static type identifier for `Self`.
 	fn type_info() -> Type;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,17 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+/// TODO: docs
+#[macro_export]
+macro_rules! meta_type {
+    ($meta_type:ty) => ({
+        #[allow(unused_imports)]
+        use $crate::{TypeInfoKind, WrapperTypeKind};
+        let meta_type = core::marker::PhantomData::<$meta_type>;
+        (&meta_type).kind().new()
+    });
+}
+
 /// Takes a number of types and returns a vector that contains their respective
 /// [`MetaType`](`crate::MetaType`) instances.
 ///
@@ -102,7 +113,7 @@ macro_rules! tuple_meta_type {
 			let mut v = std::vec![];
 
 			$(
-				v.push($crate::MetaType::new::<$ty>());
+				v.push($crate::meta_type!($ty));
 			)*
 			v
 		}
@@ -124,7 +135,7 @@ mod utils;
 mod tests;
 
 pub use self::{
-	meta_type::MetaType,
+	meta_type::{MetaType, TypeInfoKind, WrapperTypeKind},
 	registry::{IntoCompact, Registry, RegistryReadOnly},
 	ty::*,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,15 @@ pub use scale_info_derive::TypeInfo;
 
 /// Implementors return their meta type information.
 pub trait TypeInfo {
+	/// The type for which this trait provides type info.
+	///
+	/// # Note
+	///
+	/// This is used to uniquely identify a type via [`core::any::TypeId::of`]. In most cases it
+	/// will just be `Self`, but can be used to unify different types which have the same encoded
+	/// representation e.g. reference types `Box<T>`, `&T` and `&mut T`.
+	type MetaType: ?Sized + 'static;
+
 	/// Returns the static type identifier for `Self`.
 	fn type_info() -> Type;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,17 +65,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-/// TODO: docs
-#[macro_export]
-macro_rules! meta_type {
-    ($meta_type:ty) => ({
-        #[allow(unused_imports)]
-        use $crate::{TypeInfoKind, WrapperTypeKind};
-        let meta_type = core::marker::PhantomData::<$meta_type>;
-        (&meta_type).kind().new()
-    });
-}
-
 /// Takes a number of types and returns a vector that contains their respective
 /// [`MetaType`](`crate::MetaType`) instances.
 ///
@@ -113,7 +102,7 @@ macro_rules! tuple_meta_type {
 			let mut v = std::vec![];
 
 			$(
-				v.push($crate::meta_type!($ty));
+				v.push($crate::MetaType::new::<$ty>());
 			)*
 			v
 		}
@@ -135,7 +124,7 @@ mod utils;
 mod tests;
 
 pub use self::{
-	meta_type::{MetaType, TypeInfoKind, WrapperTypeKind},
+	meta_type::MetaType,
 	registry::{IntoCompact, Registry, RegistryReadOnly},
 	ty::*,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,14 +134,14 @@ pub use scale_info_derive::TypeInfo;
 
 /// Implementors return their meta type information.
 pub trait TypeInfo {
-	/// The underlying type for which type info is provided.
+	/// The type identifying for which type info is provided.
 	///
 	/// # Note
 	///
 	/// This is used to uniquely identify a type via [`core::any::TypeId::of`]. In most cases it
 	/// will just be `Self`, but can be used to unify different types which have the same encoded
 	/// representation e.g. reference types `Box<T>`, `&T` and `&mut T`.
-	type UnderlyingType: ?Sized + 'static;
+	type Identity: ?Sized + 'static;
 
 	/// Returns the static type identifier for `Self`.
 	fn type_info() -> Type;

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -75,7 +75,7 @@ impl MetaType {
 	{
 		Self {
 			fn_type_info: <T as TypeInfo>::type_info,
-			type_id: TypeId::of::<T>(),
+			type_id: TypeId::of::<T::MetaType>(),
 		}
 	}
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -88,7 +88,7 @@ impl MetaType {
 	/// ```
 	/// # use scale_info::MetaType;
 	/// // u32 and Box<u32> are encoded to the same SCALE representation
-	/// MetaType::new_wrapper::<u32, Box<u32>>();
+	/// MetaType::new_aliased::<u32, Box<u32>>();
 	/// ```
 	pub fn new_wrapper<T, U>() -> Self
 	where

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -75,7 +75,7 @@ impl MetaType {
 	{
 		Self {
 			fn_type_info: <T as TypeInfo>::type_info,
-			type_id: TypeId::of::<T::UnderlyingType>(),
+			type_id: TypeId::of::<T::Identity>(),
 		}
 	}
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -75,7 +75,7 @@ impl MetaType {
 	{
 		Self {
 			fn_type_info: <T as TypeInfo>::type_info,
-			type_id: TypeId::of::<T::MetaType>(),
+			type_id: TypeId::of::<T::UnderlyingType>(),
 		}
 	}
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -79,28 +79,6 @@ impl MetaType {
 		}
 	}
 
-	/// Creates a new meta type which is a transparent wrapper of another compile-time known type.
-	///
-	/// This should be used where [`EncodeLike`](scale::WrapperTypeEncode) is implemented.
-	///
-	/// # Example
-	///
-	/// ```
-	/// # use scale_info::MetaType;
-	/// // u32 and Box<u32> are encoded to the same SCALE representation
-	/// MetaType::new_aliased::<u32, Box<u32>>();
-	/// ```
-	pub fn new_wrapper<T, U>() -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-		U: TypeInfo + ?Sized + 'static,
-	{
-		Self {
-			fn_type_info: <T as TypeInfo>::type_info,
-			type_id: TypeId::of::<U>(),
-		}
-	}
-
 	/// Creates a new meta types from the type of the given reference.
 	pub fn of<T>(_elem: &T) -> Self
 	where
@@ -117,68 +95,5 @@ impl MetaType {
 	/// Returns the type identifier provided by `core::any`.
 	pub fn type_id(&self) -> TypeId {
 		self.type_id
-	}
-}
-
-///
-pub struct TypeInfoTag<T>(PhantomData<T>);
-
-/// TODO: docs
-pub trait TypeInfoKind {
-	/// TODO: docs
-	type Type: TypeInfo + 'static;
-
-	/// TODO: docs
-	#[inline]
-	fn kind(&self) -> TypeInfoTag<Self::Type> {
-		TypeInfoTag(PhantomData)
-	}
-}
-
-impl<T: TypeInfo + 'static> TypeInfoTag<T> {
-	/// TODO: docs
-	#[inline]
-	pub fn new(self) -> MetaType {
-		MetaType::new::<T>()
-	}
-}
-
-// Requires one extra autoref to call! Lower priority than WrapperTypeKind.
-impl<T: TypeInfo + 'static> TypeInfoKind for &PhantomData<T> {
-	type Type = T;
-}
-
-/// TODO: docs
-pub struct WrapperTypeTag<T>(PhantomData<T>);
-
-/// TODO: docs
-pub trait WrapperTypeKind {
-	/// TODO: docs
-	type Type: scale::WrapperTypeEncode<Target = Self::Target>;
-	/// TODO: docs
-	type Target: TypeInfo + 'static;
-
-	/// TODO: docs
-	#[inline]
-	fn kind(&self) -> WrapperTypeTag<Self::Type> {
-		WrapperTypeTag(PhantomData)
-	}
-}
-
-// Does not require any autoref if called as (&error).anyhow_kind().
-impl<T: scale::WrapperTypeEncode<Target = U>, U: TypeInfo + 'static> WrapperTypeKind for PhantomData<T> {
-	type Type = T;
-	type Target = U;
-}
-
-impl<T, U> WrapperTypeTag<T>
-where
-	T: TypeInfo + scale::WrapperTypeEncode<Target = U> + 'static,
-	U: TypeInfo + 'static
-{
-	/// TODO: docs
-	#[inline]
-	pub fn new(self) -> MetaType {
-		MetaType::new_wrapper::<T, U>()
 	}
 }

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -79,6 +79,28 @@ impl MetaType {
 		}
 	}
 
+	/// Creates a new meta type which is a transparent wrapper of another compile-time known type.
+	///
+	/// This should be used where [`EncodeLike`](scale::WrapperTypeEncode) is implemented.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use scale_info::MetaType;
+	/// // u32 and Box<u32> are encoded to the same SCALE representation
+	/// MetaType::new_aliased::<u32, Box<u32>>();
+	/// ```
+	pub fn new_wrapper<T, U>() -> Self
+	where
+		T: TypeInfo + ?Sized + 'static,
+		U: TypeInfo + ?Sized + 'static,
+	{
+		Self {
+			fn_type_info: <T as TypeInfo>::type_info,
+			type_id: TypeId::of::<U>(),
+		}
+	}
+
 	/// Creates a new meta types from the type of the given reference.
 	pub fn of<T>(_elem: &T) -> Self
 	where
@@ -95,5 +117,68 @@ impl MetaType {
 	/// Returns the type identifier provided by `core::any`.
 	pub fn type_id(&self) -> TypeId {
 		self.type_id
+	}
+}
+
+///
+pub struct TypeInfoTag<T>(PhantomData<T>);
+
+/// TODO: docs
+pub trait TypeInfoKind {
+	/// TODO: docs
+	type Type: TypeInfo + 'static;
+
+	/// TODO: docs
+	#[inline]
+	fn kind(&self) -> TypeInfoTag<Self::Type> {
+		TypeInfoTag(PhantomData)
+	}
+}
+
+impl<T: TypeInfo + 'static> TypeInfoTag<T> {
+	/// TODO: docs
+	#[inline]
+	pub fn new(self) -> MetaType {
+		MetaType::new::<T>()
+	}
+}
+
+// Requires one extra autoref to call! Lower priority than WrapperTypeKind.
+impl<T: TypeInfo + 'static> TypeInfoKind for &PhantomData<T> {
+	type Type = T;
+}
+
+/// TODO: docs
+pub struct WrapperTypeTag<T>(PhantomData<T>);
+
+/// TODO: docs
+pub trait WrapperTypeKind {
+	/// TODO: docs
+	type Type: scale::WrapperTypeEncode<Target = Self::Target>;
+	/// TODO: docs
+	type Target: TypeInfo + 'static;
+
+	/// TODO: docs
+	#[inline]
+	fn kind(&self) -> WrapperTypeTag<Self::Type> {
+		WrapperTypeTag(PhantomData)
+	}
+}
+
+// Does not require any autoref if called as (&error).anyhow_kind().
+impl<T: scale::WrapperTypeEncode<Target = U>, U: TypeInfo + 'static> WrapperTypeKind for PhantomData<T> {
+	type Type = T;
+	type Target = U;
+}
+
+impl<T, U> WrapperTypeTag<T>
+where
+	T: TypeInfo + scale::WrapperTypeEncode<Target = U> + 'static,
+	U: TypeInfo + 'static
+{
+	/// TODO: docs
+	#[inline]
+	pub fn new(self) -> MetaType {
+		MetaType::new_wrapper::<T, U>()
 	}
 }

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -88,7 +88,7 @@ impl MetaType {
 	/// ```
 	/// # use scale_info::MetaType;
 	/// // u32 and Box<u32> are encoded to the same SCALE representation
-	/// MetaType::new_aliased::<u32, Box<u32>>();
+	/// MetaType::new_wrapper::<u32, Box<u32>>();
 	/// ```
 	pub fn new_wrapper<T, U>() -> Self
 	where

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -215,9 +215,9 @@ mod tests {
 				Type::builder()
 					.path(Path::new("RecursiveRefs", module_path!()))
 					.composite(Fields::named()
-						.field("boxed", meta_type!(Box<RecursiveRefs>))
-						.field("reference", meta_type!(&RecursiveRefs))
-						.field("mutable_reference", meta_type!(&mut RecursiveRefs))
+						.field_of::<Box<RecursiveRefs>>("boxed")
+						.field_of::<&'static RecursiveRefs<'static>>("reference")
+						.field_of::<&'static mut RecursiveRefs<'static>>("mutable_reference")
 					)
 					.into()
 			}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -199,7 +199,7 @@ impl RegistryReadOnly {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{TypeInfo, TypeDef, Path, build::Fields, meta_type};
+	use crate::{build::Fields, meta_type, Path, TypeDef, TypeInfo};
 
 	#[test]
 	fn recursive_struct_with_references() {
@@ -216,10 +216,11 @@ mod tests {
 			fn type_info() -> Type {
 				Type::builder()
 					.path(Path::new("RecursiveRefs", module_path!()))
-					.composite(Fields::named()
-						.field_of::<Box<RecursiveRefs>>("boxed")
-						.field_of::<&'static RecursiveRefs<'static>>("reference")
-						.field_of::<&'static mut RecursiveRefs<'static>>("mutable_reference")
+					.composite(
+						Fields::named()
+							.field_of::<Box<RecursiveRefs>>("boxed")
+							.field_of::<&'static RecursiveRefs<'static>>("reference")
+							.field_of::<&'static mut RecursiveRefs<'static>>("mutable_reference"),
 					)
 					.into()
 			}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -207,6 +207,7 @@ impl RegistryReadOnly {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::{build::Fields, meta_type, Path, TypeDef, TypeInfo};
 
 	#[test]
 	fn readonly_enumerate() {
@@ -225,12 +226,6 @@ mod tests {
 			expected += 1;
 		}
 	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::{build::Fields, meta_type, Path, TypeDef, TypeInfo};
 
 	#[test]
 	fn recursive_struct_with_references() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -211,6 +211,8 @@ mod tests {
 		}
 
 		impl TypeInfo for RecursiveRefs<'static> {
+			type MetaType = Self;
+
 			fn type_info() -> Type {
 				Type::builder()
 					.path(Path::new("RecursiveRefs", module_path!()))

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -211,7 +211,7 @@ mod tests {
 		}
 
 		impl TypeInfo for RecursiveRefs<'static> {
-			type MetaType = Self;
+			type UnderlyingType = Self;
 
 			fn type_info() -> Type {
 				Type::builder()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -237,7 +237,7 @@ mod tests {
 		}
 
 		impl TypeInfo for RecursiveRefs<'static> {
-			type UnderlyingType = Self;
+			type Identity = Self;
 
 			fn type_info() -> Type {
 				Type::builder()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -215,9 +215,9 @@ mod tests {
 				Type::builder()
 					.path(Path::new("RecursiveRefs", module_path!()))
 					.composite(Fields::named()
-						.field_of::<Box<RecursiveRefs>>("boxed")
-						.field_of::<&'static RecursiveRefs<'static>>("reference")
-						.field_of::<&'static mut RecursiveRefs<'static>>("mutable_reference")
+						.field("boxed", meta_type!(Box<RecursiveRefs>))
+						.field("reference", meta_type!(&RecursiveRefs))
+						.field("mutable_reference", meta_type!(&mut RecursiveRefs))
 					)
 					.into()
 			}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,7 +118,7 @@ fn struct_with_generics() {
 	where
 		T: TypeInfo + 'static,
 	{
-		type UnderlyingType = Self;
+		type Identity = Self;
 
 		fn type_info() -> Type {
 			Type::builder()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,6 +118,8 @@ fn struct_with_generics() {
 	where
 		T: TypeInfo + 'static,
 	{
+		type MetaType = Self;
+
 		fn type_info() -> Type {
 			Type::builder()
 				.path(Path::new("MyStruct", module_path!()))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,7 +118,7 @@ fn struct_with_generics() {
 	where
 		T: TypeInfo + 'static,
 	{
-		type MetaType = Self;
+		type UnderlyingType = Self;
 
 		fn type_info() -> Type {
 			Type::builder()

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -138,16 +138,16 @@ fn recursive_type_derive() {
 		Node { right: Box<Tree>, left: Box<Tree> },
 	}
 
-	let ty = Type::builder()
-		.path(Path::new("Tree", "derive"))
-		.variant(
-			Variants::with_fields()
-				.variant("Leaf", Fields::named().field_of::<i32>("value"))
-				.variant("Node", Fields::named()
+	let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
+		Variants::with_fields()
+			.variant("Leaf", Fields::named().field_of::<i32>("value"))
+			.variant(
+				"Node",
+				Fields::named()
 					.field_of::<Box<Tree>>("right")
-					.field_of::<Box<Tree>>("left")
-				)
-		);
+					.field_of::<Box<Tree>>("left"),
+			),
+	);
 
 	assert_type!(Tree, ty);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::build::*;
-use scale_info::{tuple_meta_type, Path, Type, TypeInfo};
+use scale_info::{meta_type, tuple_meta_type, Path, Type, TypeInfo};
 
 fn assert_type<T, E>(expected: E)
 where
@@ -55,13 +55,15 @@ fn struct_derive() {
 	assert_type!(S<bool, u8>, struct_type);
 
 	// With "`Self` typed" fields
-
 	type SelfTyped = S<Box<S<bool, u8>>, bool>;
 
 	let self_typed_type = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
-		.composite(Fields::named().field_of::<Box<S<bool, u8>>>("t").field_of::<bool>("u"));
+		.composite(Fields::named()
+			.field("t", meta_type!(Box<S<bool, u8>>))
+			.field_of::<bool>("u")
+		);
 	assert_type!(SelfTyped, self_typed_type);
 }
 
@@ -144,8 +146,8 @@ fn recursive_type_derive() {
 			Variants::with_fields()
 				.variant("Leaf", Fields::named().field_of::<i32>("value"))
 				.variant("Node", Fields::named()
-					.field_of::<Box<Tree>>("right")
-					.field_of::<Box<Tree>>("left")
+					.field("right", meta_type!(Box<Tree>))
+					.field("left", meta_type!(Box<Tree>))
 				)
 		);
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -128,3 +128,26 @@ fn enum_derive() {
 
 	assert_type!(E<bool>, ty);
 }
+
+#[test]
+fn recursive_type_derive() {
+	#[allow(unused)]
+	#[derive(TypeInfo)]
+	pub enum Tree {
+		Leaf { value: i32 },
+		Node { right: Box<Tree>, left: Box<Tree> },
+	}
+
+	let ty = Type::builder()
+		.path(Path::new("Tree", "derive"))
+		.variant(
+			Variants::with_fields()
+				.variant("Leaf", Fields::named().field_of::<i32>("value"))
+				.variant("Node", Fields::named()
+					.field_of::<Box<Tree>>("right")
+					.field_of::<Box<Tree>>("left")
+				)
+		);
+
+	assert_type!(Tree, ty);
+}

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -22,7 +22,7 @@ use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::build::*;
-use scale_info::{meta_type, tuple_meta_type, Path, Type, TypeInfo};
+use scale_info::{tuple_meta_type, Path, Type, TypeInfo};
 
 fn assert_type<T, E>(expected: E)
 where
@@ -55,15 +55,13 @@ fn struct_derive() {
 	assert_type!(S<bool, u8>, struct_type);
 
 	// With "`Self` typed" fields
+
 	type SelfTyped = S<Box<S<bool, u8>>, bool>;
 
 	let self_typed_type = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
-		.composite(Fields::named()
-			.field("t", meta_type!(Box<S<bool, u8>>))
-			.field_of::<bool>("u")
-		);
+		.composite(Fields::named().field_of::<Box<S<bool, u8>>>("t").field_of::<bool>("u"));
 	assert_type!(SelfTyped, self_typed_type);
 }
 
@@ -146,8 +144,8 @@ fn recursive_type_derive() {
 			Variants::with_fields()
 				.variant("Leaf", Fields::named().field_of::<i32>("value"))
 				.variant("Node", Fields::named()
-					.field("right", meta_type!(Box<Tree>))
-					.field("left", meta_type!(Box<Tree>))
+					.field_of::<Box<Tree>>("right")
+					.field_of::<Box<Tree>>("left")
 				)
 		);
 

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -264,8 +264,8 @@ fn test_recursive_type_with_box() {
 							{
 								"name": "Node",
 								"fields": [
-									{ "name": "right", "type": 3, },
-									{ "name": "left", "type": 3, },
+									{ "name": "right", "type": 1, },
+									{ "name": "left", "type": 1, },
 								],
 							}
 						],
@@ -274,28 +274,6 @@ fn test_recursive_type_with_box() {
 			},
 			{
 				"def": { "primitive": "i32" },
-			},
-			{
-				"path": ["json", "Tree"],
-				"def": {
-					"variant": {
-						"variants": [
-							{
-								"name": "Leaf",
-								"fields": [
-									{ "name": "value", "type": 2 },
-								],
-							},
-							{
-								"name": "Node",
-								"fields": [
-									{ "name": "right", "type": 3, },
-									{ "name": "left", "type": 3, },
-								],
-							}
-						],
-					},
-				}
 			},
 		]
 	});

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -20,7 +20,7 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 
 use pretty_assertions::{assert_eq, assert_ne};
 use scale_info::{form::CompactForm, meta_type, IntoCompact as _, Registry, TypeInfo};
@@ -235,6 +235,72 @@ fn test_enum() {
 			},
 		}
 	}));
+}
+
+#[test]
+fn test_recursive_type_with_box() {
+	#[derive(TypeInfo)]
+	pub enum Tree {
+		Leaf { value: i32 },
+		Node { right: Box<Tree>, left: Box<Tree> },
+	}
+
+	let mut registry = Registry::new();
+	registry.register_type(&meta_type::<Tree>());
+
+	let expected_json = json!({
+		"types": [
+			{
+				"path": ["json", "Tree"],
+				"def": {
+					"variant": {
+						"variants": [
+							{
+								"name": "Leaf",
+								"fields": [
+									{ "name": "value", "type": 2 },
+								],
+							},
+							{
+								"name": "Node",
+								"fields": [
+									{ "name": "right", "type": 3, },
+									{ "name": "left", "type": 3, },
+								],
+							}
+						],
+					},
+				}
+			},
+			{
+				"def": { "primitive": "i32" },
+			},
+			{
+				"path": ["json", "Tree"],
+				"def": {
+					"variant": {
+						"variants": [
+							{
+								"name": "Leaf",
+								"fields": [
+									{ "name": "value", "type": 2 },
+								],
+							},
+							{
+								"name": "Node",
+								"fields": [
+									{ "name": "right", "type": 3, },
+									{ "name": "left", "type": 3, },
+								],
+							}
+						],
+					},
+				}
+			},
+		]
+	});
+
+	assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }
 
 #[test]


### PR DESCRIPTION
## Background

A bug was discovered by @Robbepop with the following recursive type using `Box`:

```
#[derive(TypeInfo)]
pub enum Tree {
	Leaf { value: i32 },
	Node { right: Box<Tree>, left: Box<Tree> },
}
```

This should result in a self-referential type definition in the type registry, instead it was creating two equivalent definitions: `Tree` and `Box<Tree>`.

The cause is that `any::TypeId::of<T>()` is used to uniquely identify types, and `Tree` and `Box<Tree>` are different types and therefore have different `TypeId`s. This regression was likely introduced in https://github.com/paritytech/scale-info/pull/3, which removed the original separation between a type id and its definition.

## "Transparent" wrapper types in SCALE

`Box` is an example of what in `parity-scale-codec` is known as a "wrapper" type. Such types are marked by the [`WrapperTypeEncode`](https://docs.rs/parity-scale-codec/1.3.5/parity_scale_codec/trait.WrapperTypeEncode.html) trait:

> A marker trait for types that wrap other encodable type. Such types should not carry any additional information that would require to be encoded, because the encoding is assumed to be the same as the wrapped type.

For our purposes that means that the SCALE encoded representation of `T` is the same as that of `Box<T>`, therefore we consider it a "transparent" wrapper type. Such a type would be erased in the type registry since it has the same definition.

Other types which implement `WrapperTypeEncode` are 

![image](https://user-images.githubusercontent.com/75586/98964633-f7a5d480-2500-11eb-9007-54b01cf2cebb.png)

### Faux specialization

**EDIT: I abandoned this approach because it doesn't work with generics e.g. `GenericStruct<Box<GenericStruct>>`**

Therefore what we need is to be able to say that `meta_type(T) == metatype(Box<T>) == metadtype(&T) ...)`. To do this, for any type which implements `WrapperTypeEncode` we need to identify by `any::TypeId::of<T>()` (the id of the wrapped type). This way the same type definition is used for the wrapped type and it is erased during type registration.

The initial approach in this PR is adapted from the [autoref based specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md). Here is a [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=4a1f4b737f6894d0480a9b2d76fec472) demonstrating the concept.

### Adding an associated type to the `TypeInfo` trait

This is a simple alternative, which adds the associated type `MetaType` to `TypeInfo`. This will be set to `Self` by the derive macro and for most primitive type definitions. For the transparent wrapper types described above it will be set to the underlying wrapped type e.g. the `T` in `Box<T>`. 

The associated type will then be used when constructing the metatype to get the unique id with `core::any::TypeId::of<T::MetaType>()`. So for any type `T`, the equivalent `Box<T>` will have the same type id, and there will appear only a single type definition in the type registry.



