### PR TITLE
Enumerate RegistryReadOnly types, Display Path

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -194,4 +194,35 @@ impl RegistryReadOnly {
 	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
 		self.types.get((id.get() - 1) as usize)
 	}
+
+	/// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
+	pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm>)> {
+		self.types.iter().enumerate().map(|(i, ty)| {
+			let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
+			(id, ty)
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn readonly_enumerate() {
+		let mut registry = Registry::new();
+		registry.register_type(&MetaType::new::<u32>());
+		registry.register_type(&MetaType::new::<bool>());
+		registry.register_type(&MetaType::new::<Option<(u32, bool)>>());
+
+		let readonly: RegistryReadOnly = registry.into();
+
+		assert_eq!(4, readonly.enumerate().count());
+
+		let mut expected = 1;
+		for (i, _) in readonly.enumerate() {
+			assert_eq!(NonZeroU32::new(expected).unwrap(), i);
+			expected += 1;
+		}
+	}
 }

--- a/src/tm_std.rs
+++ b/src/tm_std.rs
@@ -37,10 +37,11 @@ pub use self::core::{
 	clone::{Clone},
 	cmp::{Eq, PartialEq, Ordering},
 	convert::{From, Into},
-	fmt::{Debug, Error as FmtError, Formatter},
+	fmt::{Debug, Display, Error as FmtError, Formatter},
 	hash::{Hash, Hasher},
 	iter,
 	mem,
+	write,
 };
 
 mod alloc {

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -58,6 +58,12 @@ impl IntoCompact for Path {
 	}
 }
 
+impl Display for Path<CompactForm> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+		write!(f, "{}", self.segments.join("::"))
+	}
+}
+
 impl Path {
 	/// Create a new Path
 	///
@@ -206,5 +212,12 @@ mod tests {
 	#[should_panic]
 	fn path_new_panics_with_invalid_identifiers() {
 		Path::new("Planet", "hello$!@$::world");
+	}
+
+	#[test]
+	fn path_display() {
+		let path = Path::new("Planet", "hello::world")
+			.into_compact(&mut Default::default());
+		assert_eq!("hello::world::Planet", format!("{}", path))
 	}
 }

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -216,8 +216,7 @@ mod tests {
 
 	#[test]
 	fn path_display() {
-		let path = Path::new("Planet", "hello::world")
-			.into_compact(&mut Default::default());
+		let path = Path::new("Planet", "hello::world").into_compact(&mut Default::default());
 		assert_eq!("hello::world::Planet", format!("{}", path))
 	}
 }


### PR DESCRIPTION
This is required for https://github.com/paritytech/cargo-contract/pull/79, in order to index the types by the `Path` so we can identify common environment types for custom encoding/decoding.

**Bonus:** Adds `Display` impl for `Path`