### PR TITLE
Configure formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,9 @@
 root = true
-[*]
-indent_style=tab
-indent_size=tab
-tab_width=4
-end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-max_line_length=100
-insert_final_newline=true
 
-[*.yml]
-indent_style=space
-indent_size=2
-tab_width=8
-end_of_line=lf
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,8 +1,67 @@
-# These formatting rules to try conform the Substrate style guidelines:
-# >   https://wiki.parity.io/Substrate-Style-Guide
-
+max_width = 90 # changed
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+use_small_heuristics = "Default"
+indent_style = "Block"
+wrap_comments = false
+format_code_in_doc_comments = false
+comment_width = 80
+normalize_comments = true # changed
+normalize_doc_attributes = false
+license_template_path = "FILE_TEMPLATE" # changed
+format_strings = false
+format_macro_matchers = false
+format_macro_bodies = true
+empty_item_single_line = true
+struct_lit_single_line = true
+fn_single_line = false
+where_single_line = false
+imports_indent = "Block"
+imports_layout = "Vertical" # changed
+merge_imports = true # changed
 reorder_imports = true
-hard_tabs = true
-max_width = 120
+reorder_modules = true
+reorder_impl_items = false
+type_punctuation_density = "Wide"
+space_before_colon = false
+space_after_colon = true
+spaces_around_ranges = false
+binop_separator = "Front"
+remove_nested_parens = true
+combine_control_expr = false # changed
+overflow_delimited_expr = false
+struct_field_align_threshold = 0
+enum_discrim_align_threshold = 0
+match_arm_blocks = true
+force_multiline_blocks = true # changed
+fn_args_layout = "Tall"
+brace_style = "SameLineWhere"
+control_brace_style = "AlwaysSameLine"
+trailing_semicolon = false # changed
+trailing_comma = "Vertical"
+match_block_trailing_comma = false
+blank_lines_upper_bound = 1
+blank_lines_lower_bound = 0
+edition = "2018" # changed
+version = "One"
+merge_derives = true
+use_try_shorthand = true # changed
+use_field_init_shorthand = true # changed
+force_explicit_abi = true
+condense_wildcard_suffixes = false
+color = "Auto"
+unstable_features = true # changed
+disable_all_formatting = false
+skip_children = false
+hide_parse_errors = false
+error_on_line_overflow = false
+error_on_unformatted = false
+report_todo = "Always"
+report_fixme = "Always"
+ignore = []
 
-license_template_path = "FILE_TEMPLATE"
+# Below are `rustfmt` internal settings
+#
+# emit_mode = "Files"
+# make_backup = false

--- a/derive/src/impl_wrapper.rs
+++ b/derive/src/impl_wrapper.rs
@@ -13,41 +13,51 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::ToString};
+use alloc::{
+    format,
+    string::ToString,
+};
 
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::{
+    Span,
+    TokenStream as TokenStream2,
+};
 use quote::quote;
 use syn::Ident;
 
-pub fn wrap(ident: &Ident, trait_name: &'static str, impl_quote: TokenStream2) -> TokenStream2 {
-	let mut renamed = format!("_IMPL_{}_FOR_", trait_name);
-	renamed.push_str(ident.to_string().trim_start_matches("r#"));
-	let dummy_const = Ident::new(&renamed, Span::call_site());
+pub fn wrap(
+    ident: &Ident,
+    trait_name: &'static str,
+    impl_quote: TokenStream2,
+) -> TokenStream2 {
+    let mut renamed = format!("_IMPL_{}_FOR_", trait_name);
+    renamed.push_str(ident.to_string().trim_start_matches("r#"));
+    let dummy_const = Ident::new(&renamed, Span::call_site());
 
-	quote! {
-		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-		const #dummy_const: () = {
-			#[allow(unknown_lints)]
-			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-			#[allow(rust_2018_idioms)]
-			use scale_info as _scale_info;
+    quote! {
+        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        const #dummy_const: () = {
+            #[allow(unknown_lints)]
+            #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
+            #[allow(rust_2018_idioms)]
+            use scale_info as _scale_info;
 
-			#[cfg(not(feature = "std"))]
-			extern crate alloc;
+            #[cfg(not(feature = "std"))]
+            extern crate alloc;
 
-			#[cfg(feature = "std")]
-			mod __core {
-				pub use ::core::*;
-				pub use ::std::{vec, vec::Vec};
-			}
+            #[cfg(feature = "std")]
+            mod __core {
+                pub use ::core::*;
+                pub use ::std::{vec, vec::Vec};
+            }
 
-			#[cfg(not(feature = "std"))]
-			mod __core {
-				pub use ::core::*;
-				pub use ::alloc::{vec, vec::Vec};
-			}
+            #[cfg(not(feature = "std"))]
+            mod __core {
+                pub use ::core::*;
+                pub use ::alloc::{vec, vec::Vec};
+            }
 
-			#impl_quote;
-		};
-	}
+            #impl_quote;
+        };
+    }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -24,140 +24,155 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-	parse::{Error, Result},
-	parse_quote,
-	punctuated::Punctuated,
-	token::Comma,
-	Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Field, Fields, Lit, Variant,
+    parse::{
+        Error,
+        Result,
+    },
+    parse_quote,
+    punctuated::Punctuated,
+    token::Comma,
+    Data,
+    DataEnum,
+    DataStruct,
+    DeriveInput,
+    Expr,
+    ExprLit,
+    Field,
+    Fields,
+    Lit,
+    Variant,
 };
 
 #[proc_macro_derive(TypeInfo)]
 pub fn type_info(input: TokenStream) -> TokenStream {
-	match generate(input.into()) {
-		Ok(output) => output.into(),
-		Err(err) => err.to_compile_error().into(),
-	}
+    match generate(input.into()) {
+        Ok(output) => output.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }
 
 fn generate(input: TokenStream2) -> Result<TokenStream2> {
-	let mut tokens = quote! {};
-	tokens.extend(generate_type(input)?);
-	Ok(tokens)
+    let mut tokens = quote! {};
+    tokens.extend(generate_type(input)?);
+    Ok(tokens)
 }
 
 fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
-	let mut ast: DeriveInput = syn::parse2(input.clone())?;
+    let mut ast: DeriveInput = syn::parse2(input.clone())?;
 
-	ast.generics.type_params_mut().for_each(|p| {
-		p.bounds.push(parse_quote!(_scale_info::TypeInfo));
-		p.bounds.push(parse_quote!('static));
-	});
+    ast.generics.type_params_mut().for_each(|p| {
+        p.bounds.push(parse_quote!(_scale_info::TypeInfo));
+        p.bounds.push(parse_quote!('static));
+    });
 
-	let ident = &ast.ident;
-	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-	let generic_type_ids = ast.generics.type_params().map(|ty| {
-		let ty_ident = &ty.ident;
-		quote! {
-			_scale_info::meta_type::<#ty_ident>()
-		}
-	});
+    let ident = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let generic_type_ids = ast.generics.type_params().map(|ty| {
+        let ty_ident = &ty.ident;
+        quote! {
+            _scale_info::meta_type::<#ty_ident>()
+        }
+    });
 
-	let ast: DeriveInput = syn::parse2(input.clone())?;
-	let build_type = match &ast.data {
-		Data::Struct(ref s) => generate_composite_type(s),
-		Data::Enum(ref e) => generate_variant_type(e),
-		Data::Union(_) => return Err(Error::new_spanned(input, "Unions not supported")),
-	};
+    let ast: DeriveInput = syn::parse2(input.clone())?;
+    let build_type = match &ast.data {
+        Data::Struct(ref s) => generate_composite_type(s),
+        Data::Enum(ref e) => generate_variant_type(e),
+        Data::Union(_) => return Err(Error::new_spanned(input, "Unions not supported")),
+    };
 
-	let type_info_impl = quote! {
-		impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
-			type Identity = Self;
-			fn type_info() -> _scale_info::Type {
-				_scale_info::Type::builder()
-					.path(_scale_info::Path::new(stringify!(#ident), module_path!()))
-					.type_params(__core::vec![ #( #generic_type_ids ),* ])
-					.#build_type
-					.into()
-			}
-		}
-	};
+    let type_info_impl = quote! {
+        impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
+            type Identity = Self;
+            fn type_info() -> _scale_info::Type {
+                _scale_info::Type::builder()
+                    .path(_scale_info::Path::new(stringify!(#ident), module_path!()))
+                    .type_params(__core::vec![ #( #generic_type_ids ),* ])
+                    .#build_type
+                    .into()
+            }
+        }
+    };
 
-	Ok(impl_wrapper::wrap(ident, "TYPE_INFO", type_info_impl))
+    Ok(impl_wrapper::wrap(ident, "TYPE_INFO", type_info_impl))
 }
 
 type FieldsList = Punctuated<Field, Comma>;
 
 fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
-	fields
-		.iter()
-		.map(|f| {
-			let (ty, ident) = (&f.ty, &f.ident);
-			if let Some(i) = ident {
-				quote! {
-					.field_of::<#ty>(stringify!(#i))
-				}
-			} else {
-				quote! {
-					.field_of::<#ty>()
-				}
-			}
-		})
-		.collect()
+    fields
+        .iter()
+        .map(|f| {
+            let (ty, ident) = (&f.ty, &f.ident);
+            if let Some(i) = ident {
+                quote! {
+                    .field_of::<#ty>(stringify!(#i))
+                }
+            } else {
+                quote! {
+                    .field_of::<#ty>()
+                }
+            }
+        })
+        .collect()
 }
 
 fn generate_composite_type(data_struct: &DataStruct) -> TokenStream2 {
-	let fields = match data_struct.fields {
-		Fields::Named(ref fs) => {
-			let fields = generate_fields(&fs.named);
-			quote! { named()#( #fields )* }
-		}
-		Fields::Unnamed(ref fs) => {
-			let fields = generate_fields(&fs.unnamed);
-			quote! { unnamed()#( #fields )* }
-		}
-		Fields::Unit => quote! {
-			unit()
-		},
-	};
-	quote! {
-		composite(_scale_info::build::Fields::#fields)
-	}
+    let fields = match data_struct.fields {
+        Fields::Named(ref fs) => {
+            let fields = generate_fields(&fs.named);
+            quote! { named()#( #fields )* }
+        }
+        Fields::Unnamed(ref fs) => {
+            let fields = generate_fields(&fs.unnamed);
+            quote! { unnamed()#( #fields )* }
+        }
+        Fields::Unit => {
+            quote! {
+                unit()
+            }
+        }
+    };
+    quote! {
+        composite(_scale_info::build::Fields::#fields)
+    }
 }
 
 type VariantList = Punctuated<Variant, Comma>;
 
 fn generate_c_like_enum_def(variants: &VariantList) -> TokenStream2 {
-	let variants = variants.into_iter().enumerate().map(|(i, v)| {
-		let name = &v.ident;
-		let discriminant = if let Some((
-			_,
-			Expr::Lit(ExprLit {
-				lit: Lit::Int(lit_int), ..
-			}),
-		)) = &v.discriminant
-		{
-			match lit_int.base10_parse::<u64>() {
-				Ok(i) => i,
-				Err(err) => return err.to_compile_error(),
-			}
-		} else {
-			i as u64
-		};
-		quote! {
-			.variant(stringify!(#name), #discriminant)
-		}
-	});
-	quote! {
-		variant(
-			_scale_info::build::Variants::fieldless()
-				#( #variants )*
-		)
-	}
+    let variants = variants.into_iter().enumerate().map(|(i, v)| {
+        let name = &v.ident;
+        let discriminant = if let Some((
+            _,
+            Expr::Lit(ExprLit {
+                lit: Lit::Int(lit_int),
+                ..
+            }),
+        )) = &v.discriminant
+        {
+            match lit_int.base10_parse::<u64>() {
+                Ok(i) => i,
+                Err(err) => return err.to_compile_error(),
+            }
+        } else {
+            i as u64
+        };
+        quote! {
+            .variant(stringify!(#name), #discriminant)
+        }
+    });
+    quote! {
+        variant(
+            _scale_info::build::Variants::fieldless()
+                #( #variants )*
+        )
+    }
 }
 
 fn is_c_like_enum(variants: &VariantList) -> bool {
-	// any variant has an explicit discriminant
-	variants.iter().any(|v| v.discriminant.is_some()) ||
+    // any variant has an explicit discriminant
+    variants.iter().any(|v| v.discriminant.is_some()) ||
 		// all variants are unit
 		variants.iter().all(|v| match v.fields {
 			Fields::Unit => true,
@@ -166,45 +181,47 @@ fn is_c_like_enum(variants: &VariantList) -> bool {
 }
 
 fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {
-	let variants = &data_enum.variants;
+    let variants = &data_enum.variants;
 
-	if is_c_like_enum(&variants) {
-		return generate_c_like_enum_def(variants);
-	}
+    if is_c_like_enum(&variants) {
+        return generate_c_like_enum_def(variants)
+    }
 
-	let variants = variants.into_iter().map(|v| {
-		let ident = &v.ident;
-		let v_name = quote! {stringify!(#ident) };
-		match v.fields {
-			Fields::Named(ref fs) => {
-				let fields = generate_fields(&fs.named);
-				quote! {
-					.variant(
-						#v_name,
-						_scale_info::build::Fields::named()
-							#( #fields)*
-					)
-				}
-			}
-			Fields::Unnamed(ref fs) => {
-				let fields = generate_fields(&fs.unnamed);
-				quote! {
-					.variant(
-						#v_name,
-						_scale_info::build::Fields::unnamed()
-							#( #fields)*
-					)
-				}
-			}
-			Fields::Unit => quote! {
-				.variant_unit(#v_name)
-			},
-		}
-	});
-	quote! {
-		variant(
-			_scale_info::build::Variants::with_fields()
-				#( #variants)*
-		)
-	}
+    let variants = variants.into_iter().map(|v| {
+        let ident = &v.ident;
+        let v_name = quote! {stringify!(#ident) };
+        match v.fields {
+            Fields::Named(ref fs) => {
+                let fields = generate_fields(&fs.named);
+                quote! {
+                    .variant(
+                        #v_name,
+                        _scale_info::build::Fields::named()
+                            #( #fields)*
+                    )
+                }
+            }
+            Fields::Unnamed(ref fs) => {
+                let fields = generate_fields(&fs.unnamed);
+                quote! {
+                    .variant(
+                        #v_name,
+                        _scale_info::build::Fields::unnamed()
+                            #( #fields)*
+                    )
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    .variant_unit(#v_name)
+                }
+            }
+        }
+    });
+    quote! {
+        variant(
+            _scale_info::build::Variants::with_fields()
+                #( #variants)*
+        )
+    }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -117,75 +117,84 @@
 //! ```
 
 use crate::{
-	form::MetaForm, tm_std::*, Field, MetaType, Path, Type, TypeDef, TypeDefComposite, TypeDefVariant, TypeInfo,
-	Variant,
+    form::MetaForm,
+    tm_std::*,
+    Field,
+    MetaType,
+    Path,
+    Type,
+    TypeDef,
+    TypeDefComposite,
+    TypeDefVariant,
+    TypeInfo,
+    Variant,
 };
 
 /// State types for type builders which require a Path
 pub mod state {
-	/// State where the builder has not assigned a Path to the type
-	pub enum PathNotAssigned {}
-	/// State where the builder has assigned a Path to the type
-	pub enum PathAssigned {}
+    /// State where the builder has not assigned a Path to the type
+    pub enum PathNotAssigned {}
+    /// State where the builder has assigned a Path to the type
+    pub enum PathAssigned {}
 }
 
 /// Builds a [`Type`](`crate::Type`)
 pub struct TypeBuilder<S = state::PathNotAssigned> {
-	path: Option<Path>,
-	type_params: Vec<MetaType>,
-	marker: PhantomData<fn() -> S>,
+    path: Option<Path>,
+    type_params: Vec<MetaType>,
+    marker: PhantomData<fn() -> S>,
 }
 
 impl<S> Default for TypeBuilder<S> {
-	fn default() -> Self {
-		TypeBuilder {
-			path: Default::default(),
-			type_params: Default::default(),
-			marker: Default::default(),
-		}
-	}
+    fn default() -> Self {
+        TypeBuilder {
+            path: Default::default(),
+            type_params: Default::default(),
+            marker: Default::default(),
+        }
+    }
 }
 
 impl TypeBuilder<state::PathNotAssigned> {
-	/// Set the Path for the type
-	pub fn path(self, path: Path) -> TypeBuilder<state::PathAssigned> {
-		TypeBuilder {
-			path: Some(path),
-			type_params: self.type_params,
-			marker: Default::default(),
-		}
-	}
+    /// Set the Path for the type
+    pub fn path(self, path: Path) -> TypeBuilder<state::PathAssigned> {
+        TypeBuilder {
+            path: Some(path),
+            type_params: self.type_params,
+            marker: Default::default(),
+        }
+    }
 }
 
 impl TypeBuilder<state::PathAssigned> {
-	fn build<D>(self, type_def: D) -> Type
-	where
-		D: Into<TypeDef>,
-	{
-		let path = self.path.expect("Path not assigned");
-		Type::new(path, self.type_params, type_def)
-	}
+    fn build<D>(self, type_def: D) -> Type
+    where
+        D: Into<TypeDef>,
+    {
+        let path = self.path.expect("Path not assigned");
+        Type::new(path, self.type_params, type_def)
+    }
 
-	/// Construct a "variant" type i.e an `enum`
-	pub fn variant<V>(self, builder: VariantsBuilder<V>) -> Type {
-		self.build(builder.done())
-	}
+    /// Construct a "variant" type i.e an `enum`
+    pub fn variant<V>(self, builder: VariantsBuilder<V>) -> Type {
+        self.build(builder.done())
+    }
 
-	/// Construct a "composite" type i.e. a `struct`
-	pub fn composite<F>(self, fields: FieldsBuilder<F>) -> Type {
-		self.build(TypeDefComposite::new(fields.done()))
-	}
+    /// Construct a "composite" type i.e. a `struct`
+    pub fn composite<F>(self, fields: FieldsBuilder<F>) -> Type {
+        self.build(TypeDefComposite::new(fields.done()))
+    }
 }
 
 impl<S> TypeBuilder<S> {
-	/// Set the type parameters if it's a generic type
-	pub fn type_params<I>(mut self, type_params: I) -> Self
-	where
-		I: IntoIterator<Item = MetaType>,
-	{
-		self.type_params = type_params.into_iter().collect();
-		self
-	}
+    /// Set the type parameters if it's a generic type
+    pub fn type_params<I>(mut self, type_params: I) -> Self
+    where
+        I: IntoIterator<Item = MetaType>,
+    {
+        self.type_params = type_params.into_iter().collect();
+        self
+    }
 }
 
 /// A fields builder has no fields (e.g. a unit struct)
@@ -199,76 +208,76 @@ pub enum UnnamedFields {}
 pub enum Fields {}
 
 impl Fields {
-	/// The type construct has no fields
-	pub fn unit() -> FieldsBuilder<NoFields> {
-		FieldsBuilder::<NoFields>::default()
-	}
+    /// The type construct has no fields
+    pub fn unit() -> FieldsBuilder<NoFields> {
+        FieldsBuilder::<NoFields>::default()
+    }
 
-	/// Fields for a type construct with named fields
-	pub fn named() -> FieldsBuilder<NamedFields> {
-		FieldsBuilder::default()
-	}
+    /// Fields for a type construct with named fields
+    pub fn named() -> FieldsBuilder<NamedFields> {
+        FieldsBuilder::default()
+    }
 
-	/// Fields for a type construct with unnamed fields
-	pub fn unnamed() -> FieldsBuilder<UnnamedFields> {
-		FieldsBuilder::default()
-	}
+    /// Fields for a type construct with unnamed fields
+    pub fn unnamed() -> FieldsBuilder<UnnamedFields> {
+        FieldsBuilder::default()
+    }
 }
 
 /// Build a set of either all named (e.g. for a struct) or all unnamed (e.g. for a tuple struct)
 pub struct FieldsBuilder<T> {
-	fields: Vec<Field<MetaForm>>,
-	marker: PhantomData<fn() -> T>,
+    fields: Vec<Field<MetaForm>>,
+    marker: PhantomData<fn() -> T>,
 }
 
 impl<T> Default for FieldsBuilder<T> {
-	fn default() -> Self {
-		Self {
-			fields: Vec::new(),
-			marker: Default::default(),
-		}
-	}
+    fn default() -> Self {
+        Self {
+            fields: Vec::new(),
+            marker: Default::default(),
+        }
+    }
 }
 
 impl<T> FieldsBuilder<T> {
-	/// Complete building and return the set of fields
-	pub fn done(self) -> Vec<Field<MetaForm>> {
-		self.fields
-	}
+    /// Complete building and return the set of fields
+    pub fn done(self) -> Vec<Field<MetaForm>> {
+        self.fields
+    }
 }
 
 impl FieldsBuilder<NamedFields> {
-	/// Add a named field with the given [`MetaType`](`crate::MetaType`) instance
-	pub fn field(mut self, name: &'static str, ty: MetaType) -> Self {
-		self.fields.push(Field::named(name, ty));
-		self
-	}
+    /// Add a named field with the given [`MetaType`](`crate::MetaType`) instance
+    pub fn field(mut self, name: &'static str, ty: MetaType) -> Self {
+        self.fields.push(Field::named(name, ty));
+        self
+    }
 
-	/// Add a named field with the type of the type parameter `T`
-	pub fn field_of<T>(mut self, name: &'static str) -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		self.fields.push(Field::named_of::<T>(name));
-		self
-	}
+    /// Add a named field with the type of the type parameter `T`
+    pub fn field_of<T>(mut self, name: &'static str) -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        self.fields.push(Field::named_of::<T>(name));
+        self
+    }
 }
 
 impl FieldsBuilder<UnnamedFields> {
-	/// Add an unnamed field with the given [`MetaType`](`crate::MetaType`) instance
-	pub fn field(mut self, ty: MetaType) -> Self {
-		self.fields.push(Field::unnamed(ty));
-		self
-	}
+    /// Add an unnamed field with the given [`MetaType`](`crate::MetaType`) instance
+    pub fn field(mut self, ty: MetaType) -> Self {
+        self.fields.push(Field::unnamed(ty));
+        self
+    }
 
-	/// Add an unnamed field with the type of the type parameter `T`
-	pub fn field_of<T>(mut self) -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		self.fields.push(Field::unnamed_of::<T>());
-		self
-	}
+    /// Add an unnamed field with the type of the type parameter `T`
+    pub fn field_of<T>(mut self) -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        self.fields.push(Field::unnamed_of::<T>());
+        self
+    }
 }
 
 /// Build a type with no variants.
@@ -283,55 +292,56 @@ pub enum Fieldless {}
 pub enum Variants {}
 
 impl Variants {
-	/// Build a set of variants, at least one of which will have fields.
-	pub fn with_fields() -> VariantsBuilder<VariantFields> {
-		VariantsBuilder::new()
-	}
+    /// Build a set of variants, at least one of which will have fields.
+    pub fn with_fields() -> VariantsBuilder<VariantFields> {
+        VariantsBuilder::new()
+    }
 
-	/// Build a set of variants, none of which will have fields, and the discriminant can
-	/// be directly chosen or accessed
-	pub fn fieldless() -> VariantsBuilder<Fieldless> {
-		VariantsBuilder::new()
-	}
+    /// Build a set of variants, none of which will have fields, and the discriminant can
+    /// be directly chosen or accessed
+    pub fn fieldless() -> VariantsBuilder<Fieldless> {
+        VariantsBuilder::new()
+    }
 }
 
 /// Builds a definition of a variant type i.e an `enum`
 #[derive(Default)]
 pub struct VariantsBuilder<T> {
-	variants: Vec<Variant>,
-	marker: PhantomData<fn() -> T>,
+    variants: Vec<Variant>,
+    marker: PhantomData<fn() -> T>,
 }
 
 impl VariantsBuilder<VariantFields> {
-	/// Add a variant with fields constructed by the supplied [`FieldsBuilder`](`crate::build::FieldsBuilder`)
-	pub fn variant<F>(mut self, name: &'static str, fields: FieldsBuilder<F>) -> Self {
-		self.variants.push(Variant::with_fields(name, fields));
-		self
-	}
+    /// Add a variant with fields constructed by the supplied [`FieldsBuilder`](`crate::build::FieldsBuilder`)
+    pub fn variant<F>(mut self, name: &'static str, fields: FieldsBuilder<F>) -> Self {
+        self.variants.push(Variant::with_fields(name, fields));
+        self
+    }
 
-	/// Add a variant with no fields i.e. a unit variant
-	pub fn variant_unit(self, name: &'static str) -> Self {
-		self.variant::<NoFields>(name, Fields::unit())
-	}
+    /// Add a variant with no fields i.e. a unit variant
+    pub fn variant_unit(self, name: &'static str) -> Self {
+        self.variant::<NoFields>(name, Fields::unit())
+    }
 }
 
 impl VariantsBuilder<Fieldless> {
-	/// Add a fieldless variant, explicitly setting the discriminant
-	pub fn variant(mut self, name: &'static str, discriminant: u64) -> Self {
-		self.variants.push(Variant::with_discriminant(name, discriminant));
-		self
-	}
+    /// Add a fieldless variant, explicitly setting the discriminant
+    pub fn variant(mut self, name: &'static str, discriminant: u64) -> Self {
+        self.variants
+            .push(Variant::with_discriminant(name, discriminant));
+        self
+    }
 }
 
 impl<T> VariantsBuilder<T> {
-	fn new() -> Self {
-		VariantsBuilder {
-			variants: Vec::new(),
-			marker: Default::default(),
-		}
-	}
+    fn new() -> Self {
+        VariantsBuilder {
+            variants: Vec::new(),
+            marker: Default::default(),
+        }
+    }
 
-	fn done(self) -> TypeDefVariant {
-		TypeDefVariant::new(self.variants)
-	}
+    fn done(self) -> TypeDefVariant {
+        TypeDefVariant::new(self.variants)
+    }
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -30,8 +30,11 @@
 //! Other forms, such as a compact form that is still bound to the registry
 //! (also via lifetime tracking) are possible but current not needed.
 
-use crate::tm_std::*;
-use crate::{interner::UntrackedSymbol, meta_type::MetaType};
+use crate::{
+    interner::UntrackedSymbol,
+    meta_type::MetaType,
+    tm_std::*,
+};
 use serde::Serialize;
 
 /// Trait to control the internal structures of type definitions.
@@ -40,10 +43,10 @@ use serde::Serialize;
 /// instantiated out of the flux and compact forms that require some sort of
 /// interning data structures.
 pub trait Form {
-	/// The type representing the type.
-	type Type: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
-	/// The string type.
-	type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+    /// The type representing the type.
+    type Type: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+    /// The string type.
+    type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
 }
 
 /// A meta meta-type.
@@ -54,8 +57,8 @@ pub trait Form {
 pub enum MetaForm {}
 
 impl Form for MetaForm {
-	type Type = MetaType;
-	type String = &'static str;
+    type Type = MetaType;
+    type String = &'static str;
 }
 
 /// Compact form that has its lifetime untracked in association to its interner.
@@ -71,6 +74,6 @@ impl Form for MetaForm {
 pub enum CompactForm {}
 
 impl Form for CompactForm {
-	type Type = UntrackedSymbol<TypeId>;
-	type String = String;
+    type Type = UntrackedSymbol<TypeId>;
+    type String = String;
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::build::*;
-use crate::tm_std::*;
-use crate::*;
+use crate::{
+    build::*,
+    tm_std::*,
+    *,
+};
 
 macro_rules! impl_metadata_for_primitives {
 	( $( $t:ty => $ident_kind:expr, )* ) => { $(
@@ -29,18 +31,18 @@ macro_rules! impl_metadata_for_primitives {
 }
 
 impl_metadata_for_primitives!(
-	bool => TypeDefPrimitive::Bool,
-	char => TypeDefPrimitive::Char,
-	u8 => TypeDefPrimitive::U8,
-	u16 => TypeDefPrimitive::U16,
-	u32 => TypeDefPrimitive::U32,
-	u64 => TypeDefPrimitive::U64,
-	u128 => TypeDefPrimitive::U128,
-	i8 => TypeDefPrimitive::I8,
-	i16 => TypeDefPrimitive::I16,
-	i32 => TypeDefPrimitive::I32,
-	i64 => TypeDefPrimitive::I64,
-	i128 => TypeDefPrimitive::I128,
+    bool => TypeDefPrimitive::Bool,
+    char => TypeDefPrimitive::Char,
+    u8 => TypeDefPrimitive::U8,
+    u16 => TypeDefPrimitive::U16,
+    u32 => TypeDefPrimitive::U32,
+    u64 => TypeDefPrimitive::U64,
+    u128 => TypeDefPrimitive::U128,
+    i8 => TypeDefPrimitive::I8,
+    i16 => TypeDefPrimitive::I16,
+    i32 => TypeDefPrimitive::I32,
+    i64 => TypeDefPrimitive::I64,
+    i128 => TypeDefPrimitive::I128,
 );
 
 macro_rules! impl_metadata_for_array {
@@ -97,137 +99,137 @@ impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J);
 
 impl<T> TypeInfo for Vec<T>
 where
-	T: TypeInfo + 'static,
+    T: TypeInfo + 'static,
 {
-	type Identity = [T];
+    type Identity = [T];
 
-	fn type_info() -> Type {
-		Self::Identity::type_info()
-	}
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
 }
 
 impl<T> TypeInfo for Option<T>
 where
-	T: TypeInfo + 'static,
+    T: TypeInfo + 'static,
 {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		Type::builder()
-			.path(Path::prelude("Option"))
-			.type_params(tuple_meta_type![T])
-			.variant(
-				Variants::with_fields()
-					.variant_unit("None")
-					.variant("Some", Fields::unnamed().field_of::<T>()),
-			)
-	}
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::prelude("Option"))
+            .type_params(tuple_meta_type![T])
+            .variant(
+                Variants::with_fields()
+                    .variant_unit("None")
+                    .variant("Some", Fields::unnamed().field_of::<T>()),
+            )
+    }
 }
 
 impl<T, E> TypeInfo for Result<T, E>
 where
-	T: TypeInfo + 'static,
-	E: TypeInfo + 'static,
+    T: TypeInfo + 'static,
+    E: TypeInfo + 'static,
 {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		Type::builder()
-			.path(Path::prelude("Result"))
-			.type_params(tuple_meta_type!(T, E))
-			.variant(
-				Variants::with_fields()
-					.variant("Ok", Fields::unnamed().field_of::<T>())
-					.variant("Err", Fields::unnamed().field_of::<E>()),
-			)
-	}
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::prelude("Result"))
+            .type_params(tuple_meta_type!(T, E))
+            .variant(
+                Variants::with_fields()
+                    .variant("Ok", Fields::unnamed().field_of::<T>())
+                    .variant("Err", Fields::unnamed().field_of::<E>()),
+            )
+    }
 }
 
 impl<K, V> TypeInfo for BTreeMap<K, V>
 where
-	K: TypeInfo + 'static,
-	V: TypeInfo + 'static,
+    K: TypeInfo + 'static,
+    V: TypeInfo + 'static,
 {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		Type::builder()
-			.path(Path::prelude("BTreeMap"))
-			.type_params(tuple_meta_type![(K, V)])
-			.composite(Fields::unnamed().field_of::<[(K, V)]>())
-	}
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::prelude("BTreeMap"))
+            .type_params(tuple_meta_type![(K, V)])
+            .composite(Fields::unnamed().field_of::<[(K, V)]>())
+    }
 }
 
 impl<T> TypeInfo for Box<T>
 where
-	T: TypeInfo + ?Sized + 'static,
+    T: TypeInfo + ?Sized + 'static,
 {
-	type Identity = T;
+    type Identity = T;
 
-	fn type_info() -> Type {
-		Self::Identity::type_info()
-	}
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
 }
 
 impl<T> TypeInfo for &T
 where
-	T: TypeInfo + ?Sized + 'static,
+    T: TypeInfo + ?Sized + 'static,
 {
-	type Identity = T;
+    type Identity = T;
 
-	fn type_info() -> Type {
-		Self::Identity::type_info()
-	}
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
 }
 
 impl<T> TypeInfo for &mut T
 where
-	T: TypeInfo + ?Sized + 'static,
+    T: TypeInfo + ?Sized + 'static,
 {
-	type Identity = T;
+    type Identity = T;
 
-	fn type_info() -> Type {
-		Self::Identity::type_info()
-	}
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
 }
 
 impl<T> TypeInfo for [T]
 where
-	T: TypeInfo + 'static,
+    T: TypeInfo + 'static,
 {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		TypeDefSequence::of::<T>().into()
-	}
+    fn type_info() -> Type {
+        TypeDefSequence::of::<T>().into()
+    }
 }
 
 impl TypeInfo for str {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		TypeDefPrimitive::Str.into()
-	}
+    fn type_info() -> Type {
+        TypeDefPrimitive::Str.into()
+    }
 }
 
 impl TypeInfo for String {
-	type Identity = str;
+    type Identity = str;
 
-	fn type_info() -> Type {
-		Self::Identity::type_info()
-	}
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
 }
 
 impl<T> TypeInfo for PhantomData<T>
 where
-	T: TypeInfo + ?Sized + 'static,
+    T: TypeInfo + ?Sized + 'static,
 {
-	type Identity = Self;
+    type Identity = Self;
 
-	fn type_info() -> Type {
-		Type::builder()
-			.path(Path::prelude("PhantomData"))
-			.type_params(vec![meta_type::<T>()])
-			.composite(Fields::unit())
-	}
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::prelude("PhantomData"))
+            .type_params(vec![meta_type::<T>()])
+            .composite(Fields::unit())
+    }
 }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,7 +22,10 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::tm_std::*;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 /// A symbol that is not lifetime tracked.
 ///
@@ -31,37 +34,37 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UntrackedSymbol<T> {
-	/// The index to the symbol in the interner table.
-	id: NonZeroU32,
-	#[serde(skip)]
-	marker: PhantomData<fn() -> T>,
+    /// The index to the symbol in the interner table.
+    id: NonZeroU32,
+    #[serde(skip)]
+    marker: PhantomData<fn() -> T>,
 }
 
 impl<T> scale::Encode for UntrackedSymbol<T> {
-	fn encode_to<W: scale::Output>(&self, dest: &mut W) {
-		self.id.get().encode_to(dest)
-	}
+    fn encode_to<W: scale::Output>(&self, dest: &mut W) {
+        self.id.get().encode_to(dest)
+    }
 }
 
 impl<T> scale::Decode for UntrackedSymbol<T> {
-	fn decode<I: scale::Input>(value: &mut I) -> Result<Self, scale::Error> {
-		let id = <u32 as scale::Decode>::decode(value)?;
-		if id < 1 {
-			return Err("UntrackedSymbol::id should be a non-zero unsigned integer".into());
-		}
-		let id = NonZeroU32::new(id).expect("ID is non zero");
-		Ok(UntrackedSymbol {
-			id,
-			marker: Default::default(),
-		})
-	}
+    fn decode<I: scale::Input>(value: &mut I) -> Result<Self, scale::Error> {
+        let id = <u32 as scale::Decode>::decode(value)?;
+        if id < 1 {
+            return Err("UntrackedSymbol::id should be a non-zero unsigned integer".into())
+        }
+        let id = NonZeroU32::new(id).expect("ID is non zero");
+        Ok(UntrackedSymbol {
+            id,
+            marker: Default::default(),
+        })
+    }
 }
 
 impl<T> UntrackedSymbol<T> {
-	/// Returns the index to the symbol in the interner table.
-	pub fn id(&self) -> NonZeroU32 {
-		self.id
-	}
+    /// Returns the index to the symbol in the interner table.
+    pub fn id(&self) -> NonZeroU32 {
+        self.id
+    }
 }
 
 /// A symbol from an interner.
@@ -70,33 +73,33 @@ impl<T> UntrackedSymbol<T> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub struct Symbol<'a, T> {
-	id: NonZeroU32,
-	#[serde(skip)]
-	marker: PhantomData<fn() -> &'a T>,
+    id: NonZeroU32,
+    #[serde(skip)]
+    marker: PhantomData<fn() -> &'a T>,
 }
 
 impl<T> Symbol<'_, T> {
-	/// Removes the lifetime tracking for this symbol.
-	///
-	/// # Note
-	///
-	/// - This can be useful in situations where a data structure owns all
-	///   symbols and interners and can verify accesses by itself.
-	/// - For further safety reasons an untracked symbol can no longer be used
-	///   to resolve from an interner. It is still useful for serialization
-	///   purposes.
-	///
-	/// # Safety
-	///
-	/// Although removing lifetime constraints this operation can be
-	/// considered to be safe since untracked symbols can no longer be
-	/// used to resolve their associated instance from the interner.
-	pub fn into_untracked(self) -> UntrackedSymbol<T> {
-		UntrackedSymbol {
-			id: self.id,
-			marker: PhantomData,
-		}
-	}
+    /// Removes the lifetime tracking for this symbol.
+    ///
+    /// # Note
+    ///
+    /// - This can be useful in situations where a data structure owns all
+    ///   symbols and interners and can verify accesses by itself.
+    /// - For further safety reasons an untracked symbol can no longer be used
+    ///   to resolve from an interner. It is still useful for serialization
+    ///   purposes.
+    ///
+    /// # Safety
+    ///
+    /// Although removing lifetime constraints this operation can be
+    /// considered to be safe since untracked symbols can no longer be
+    /// used to resolve their associated instance from the interner.
+    pub fn into_untracked(self) -> UntrackedSymbol<T> {
+        UntrackedSymbol {
+            id: self.id,
+            marker: PhantomData,
+        }
+    }
 }
 
 /// Interning data structure generic over the element type.
@@ -111,118 +114,124 @@ impl<T> Symbol<'_, T> {
 #[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct Interner<T> {
-	/// A mapping from the interned elements to their respective compact
-	/// identifiers.
-	///
-	/// The idenfitiers can be used to retrieve information about the original
-	/// element from the interner.
-	#[serde(skip)]
-	map: BTreeMap<T, usize>,
-	/// The ordered sequence of cached elements.
-	///
-	/// This is used to efficiently provide access to the cached elements and
-	/// to establish a strict ordering upon them since each is uniquely
-	/// idenfitied later by its position in the vector.
-	vec: Vec<T>,
+    /// A mapping from the interned elements to their respective compact
+    /// identifiers.
+    ///
+    /// The idenfitiers can be used to retrieve information about the original
+    /// element from the interner.
+    #[serde(skip)]
+    map: BTreeMap<T, usize>,
+    /// The ordered sequence of cached elements.
+    ///
+    /// This is used to efficiently provide access to the cached elements and
+    /// to establish a strict ordering upon them since each is uniquely
+    /// idenfitied later by its position in the vector.
+    vec: Vec<T>,
 }
 
 impl<T> Interner<T>
 where
-	T: Ord,
+    T: Ord,
 {
-	/// Creates a new empty interner.
-	pub fn new() -> Self {
-		Self {
-			map: BTreeMap::new(),
-			vec: Vec::new(),
-		}
-	}
+    /// Creates a new empty interner.
+    pub fn new() -> Self {
+        Self {
+            map: BTreeMap::new(),
+            vec: Vec::new(),
+        }
+    }
 }
 
 impl<T: Ord> Default for Interner<T> {
-	fn default() -> Self {
-		Self::new()
-	}
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> Interner<T>
 where
-	T: Ord + Clone,
+    T: Ord + Clone,
 {
-	/// Interns the given element or returns its associated symbol if it has
-	/// already been interned.
-	pub fn intern_or_get(&mut self, s: T) -> (bool, Symbol<T>) {
-		let next_id = self.vec.len();
-		let (inserted, sym_id) = match self.map.entry(s.clone()) {
-			Entry::Vacant(vacant) => {
-				vacant.insert(next_id);
-				self.vec.push(s);
-				(true, next_id)
-			}
-			Entry::Occupied(occupied) => (false, *occupied.get()),
-		};
-		(
-			inserted,
-			Symbol {
-				id: NonZeroU32::new((sym_id + 1) as u32).unwrap(),
-				marker: PhantomData,
-			},
-		)
-	}
+    /// Interns the given element or returns its associated symbol if it has
+    /// already been interned.
+    pub fn intern_or_get(&mut self, s: T) -> (bool, Symbol<T>) {
+        let next_id = self.vec.len();
+        let (inserted, sym_id) = match self.map.entry(s.clone()) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(next_id);
+                self.vec.push(s);
+                (true, next_id)
+            }
+            Entry::Occupied(occupied) => (false, *occupied.get()),
+        };
+        (
+            inserted,
+            Symbol {
+                id: NonZeroU32::new((sym_id + 1) as u32).unwrap(),
+                marker: PhantomData,
+            },
+        )
+    }
 
-	/// Returns the symbol of the given element or `None` if it hasn't been
-	/// interned already.
-	pub fn get(&self, s: &T) -> Option<Symbol<T>> {
-		self.map.get(s).map(|&id| Symbol {
-			id: NonZeroU32::new(id as u32).unwrap(),
-			marker: PhantomData,
-		})
-	}
+    /// Returns the symbol of the given element or `None` if it hasn't been
+    /// interned already.
+    pub fn get(&self, s: &T) -> Option<Symbol<T>> {
+        self.map.get(s).map(|&id| {
+            Symbol {
+                id: NonZeroU32::new(id as u32).unwrap(),
+                marker: PhantomData,
+            }
+        })
+    }
 
-	/// Resolves the original element given its associated symbol or
-	/// returns `None` if it has not been interned yet.
-	pub fn resolve(&self, sym: Symbol<T>) -> Option<&T> {
-		let idx = (sym.id.get() - 1) as usize;
-		if idx >= self.vec.len() {
-			return None;
-		}
-		self.vec.get(idx)
-	}
+    /// Resolves the original element given its associated symbol or
+    /// returns `None` if it has not been interned yet.
+    pub fn resolve(&self, sym: Symbol<T>) -> Option<&T> {
+        let idx = (sym.id.get() - 1) as usize;
+        if idx >= self.vec.len() {
+            return None
+        }
+        self.vec.get(idx)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	type StringInterner = Interner<&'static str>;
+    type StringInterner = Interner<&'static str>;
 
-	fn assert_id(interner: &mut StringInterner, new_symbol: &'static str, expected_id: u32) {
-		let actual_id = interner.intern_or_get(new_symbol).1.id.get();
-		assert_eq!(actual_id, expected_id,);
-	}
+    fn assert_id(
+        interner: &mut StringInterner,
+        new_symbol: &'static str,
+        expected_id: u32,
+    ) {
+        let actual_id = interner.intern_or_get(new_symbol).1.id.get();
+        assert_eq!(actual_id, expected_id,);
+    }
 
-	fn assert_resolve<E>(interner: &mut StringInterner, symbol_id: u32, expected_str: E)
-	where
-		E: Into<Option<&'static str>>,
-	{
-		let actual_str = interner.resolve(Symbol {
-			id: NonZeroU32::new(symbol_id).unwrap(),
-			marker: PhantomData,
-		});
-		assert_eq!(actual_str.cloned(), expected_str.into(),);
-	}
+    fn assert_resolve<E>(interner: &mut StringInterner, symbol_id: u32, expected_str: E)
+    where
+        E: Into<Option<&'static str>>,
+    {
+        let actual_str = interner.resolve(Symbol {
+            id: NonZeroU32::new(symbol_id).unwrap(),
+            marker: PhantomData,
+        });
+        assert_eq!(actual_str.cloned(), expected_str.into(),);
+    }
 
-	#[test]
-	fn simple() {
-		let mut interner = StringInterner::new();
-		assert_id(&mut interner, "Hello", 1);
-		assert_id(&mut interner, ", World!", 2);
-		assert_id(&mut interner, "1 2 3", 3);
-		assert_id(&mut interner, "Hello", 1);
+    #[test]
+    fn simple() {
+        let mut interner = StringInterner::new();
+        assert_id(&mut interner, "Hello", 1);
+        assert_id(&mut interner, ", World!", 2);
+        assert_id(&mut interner, "1 2 3", 3);
+        assert_id(&mut interner, "Hello", 1);
 
-		assert_resolve(&mut interner, 1, "Hello");
-		assert_resolve(&mut interner, 2, ", World!");
-		assert_resolve(&mut interner, 3, "1 2 3");
-		assert_resolve(&mut interner, 4, None);
-	}
+        assert_resolve(&mut interner, 1, "Hello");
+        assert_resolve(&mut interner, 2, ", World!");
+        assert_resolve(&mut interner, 3, "1 2 3");
+        assert_resolve(&mut interner, 4, None);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,13 @@ mod utils;
 mod tests;
 
 pub use self::{
-	meta_type::MetaType,
-	registry::{IntoCompact, Registry, RegistryReadOnly},
-	ty::*,
+    meta_type::MetaType,
+    registry::{
+        IntoCompact,
+        Registry,
+        RegistryReadOnly,
+    },
+    ty::*,
 };
 
 #[cfg(feature = "derive")]
@@ -134,23 +138,23 @@ pub use scale_info_derive::TypeInfo;
 
 /// Implementors return their meta type information.
 pub trait TypeInfo {
-	/// The type identifying for which type info is provided.
-	///
-	/// # Note
-	///
-	/// This is used to uniquely identify a type via [`core::any::TypeId::of`]. In most cases it
-	/// will just be `Self`, but can be used to unify different types which have the same encoded
-	/// representation e.g. reference types `Box<T>`, `&T` and `&mut T`.
-	type Identity: ?Sized + 'static;
+    /// The type identifying for which type info is provided.
+    ///
+    /// # Note
+    ///
+    /// This is used to uniquely identify a type via [`core::any::TypeId::of`]. In most cases it
+    /// will just be `Self`, but can be used to unify different types which have the same encoded
+    /// representation e.g. reference types `Box<T>`, `&T` and `&mut T`.
+    type Identity: ?Sized + 'static;
 
-	/// Returns the static type identifier for `Self`.
-	fn type_info() -> Type;
+    /// Returns the static type identifier for `Self`.
+    fn type_info() -> Type;
 }
 
 /// Returns the runtime bridge to the types compile-time type information.
 pub fn meta_type<T>() -> MetaType
 where
-	T: ?Sized + TypeInfo + 'static,
+    T: ?Sized + TypeInfo + 'static,
 {
-	MetaType::new::<T>()
+    MetaType::new::<T>()
 }

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tm_std::*;
-use crate::{form::MetaForm, Type, TypeInfo};
+use crate::{
+    form::MetaForm,
+    tm_std::*,
+    Type,
+    TypeInfo,
+};
 
 /// A metatype abstraction.
 ///
@@ -24,76 +28,76 @@ use crate::{form::MetaForm, Type, TypeInfo};
 /// in order to be serializable.
 #[derive(Clone, Copy)]
 pub struct MetaType {
-	/// Function pointer to get type information.
-	fn_type_info: fn() -> Type<MetaForm>,
-	// The standard type ID (ab)used in order to provide
-	// cheap implementations of the standard traits
-	// such as `PartialEq`, `PartialOrd`, `Debug` and `Hash`.
-	type_id: TypeId,
+    /// Function pointer to get type information.
+    fn_type_info: fn() -> Type<MetaForm>,
+    // The standard type ID (ab)used in order to provide
+    // cheap implementations of the standard traits
+    // such as `PartialEq`, `PartialOrd`, `Debug` and `Hash`.
+    type_id: TypeId,
 }
 
 impl PartialEq for MetaType {
-	fn eq(&self, other: &Self) -> bool {
-		self.type_id == other.type_id
-	}
+    fn eq(&self, other: &Self) -> bool {
+        self.type_id == other.type_id
+    }
 }
 
 impl Eq for MetaType {}
 
 impl PartialOrd for MetaType {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		self.type_id.partial_cmp(&other.type_id)
-	}
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.type_id.partial_cmp(&other.type_id)
+    }
 }
 
 impl Ord for MetaType {
-	fn cmp(&self, other: &Self) -> Ordering {
-		self.type_id.cmp(&other.type_id)
-	}
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.type_id.cmp(&other.type_id)
+    }
 }
 
 impl Hash for MetaType {
-	fn hash<H>(&self, state: &mut H)
-	where
-		H: Hasher,
-	{
-		self.type_id.hash(state)
-	}
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.type_id.hash(state)
+    }
 }
 
 impl Debug for MetaType {
-	fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-		self.type_id.fmt(f)
-	}
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        self.type_id.fmt(f)
+    }
 }
 
 impl MetaType {
-	/// Creates a new meta type from the given compile-time known type.
-	pub fn new<T>() -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		Self {
-			fn_type_info: <T as TypeInfo>::type_info,
-			type_id: TypeId::of::<T::Identity>(),
-		}
-	}
+    /// Creates a new meta type from the given compile-time known type.
+    pub fn new<T>() -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        Self {
+            fn_type_info: <T as TypeInfo>::type_info,
+            type_id: TypeId::of::<T::Identity>(),
+        }
+    }
 
-	/// Creates a new meta types from the type of the given reference.
-	pub fn of<T>(_elem: &T) -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		Self::new::<T>()
-	}
+    /// Creates a new meta types from the type of the given reference.
+    pub fn of<T>(_elem: &T) -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        Self::new::<T>()
+    }
 
-	/// Returns the meta type information.
-	pub fn type_info(&self) -> Type<MetaForm> {
-		(self.fn_type_info)()
-	}
+    /// Returns the meta type information.
+    pub fn type_info(&self) -> Type<MetaForm> {
+        (self.fn_type_info)()
+    }
 
-	/// Returns the type identifier provided by `core::any`.
-	pub fn type_id(&self) -> TypeId {
-		self.type_id
-	}
+    /// Returns the type identifier provided by `core::any`.
+    pub fn type_id(&self) -> TypeId {
+        self.type_id
+    }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,31 +24,43 @@
 //! has been defined. Rust prelude types live within the so-called root
 //! namespace that is just empty.
 
-use crate::tm_std::*;
 use crate::{
-	form::{CompactForm, Form},
-	interner::{Interner, UntrackedSymbol},
-	meta_type::MetaType,
-	Type,
+    form::{
+        CompactForm,
+        Form,
+    },
+    interner::{
+        Interner,
+        UntrackedSymbol,
+    },
+    meta_type::MetaType,
+    tm_std::*,
+    Type,
 };
-use scale::{Decode, Encode};
-use serde::{Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 /// Compacts the implementor using a registry.
 pub trait IntoCompact {
-	/// The compact version of `Self`.
-	type Output;
+    /// The compact version of `Self`.
+    type Output;
 
-	/// Compacts `self` by using the registry for caching and compaction.
-	fn into_compact(self, registry: &mut Registry) -> Self::Output;
+    /// Compacts `self` by using the registry for caching and compaction.
+    fn into_compact(self, registry: &mut Registry) -> Self::Output;
 }
 
 impl IntoCompact for &'static str {
-	type Output = <CompactForm as Form>::String;
+    type Output = <CompactForm as Form>::String;
 
-	fn into_compact(self, _registry: &mut Registry) -> Self::Output {
-		self.to_string()
-	}
+    fn into_compact(self, _registry: &mut Registry) -> Self::Output {
+        self.to_string()
+    }
 }
 
 /// The registry for compaction of type identifiers and definitions.
@@ -65,203 +77,215 @@ impl IntoCompact for &'static str {
 /// mechanism to stop recursion before going into an infinite loop.
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Registry {
-	/// The cache for already registered types.
-	///
-	/// This is just an accessor to the actual database
-	/// for all types found in the `types` field.
-	#[serde(skip)]
-	type_table: Interner<TypeId>,
-	/// The database where registered types actually reside.
-	///
-	/// This is going to be serialized upon serlialization.
-	#[serde(serialize_with = "serialize_registry_types")]
-	types: BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
+    /// The cache for already registered types.
+    ///
+    /// This is just an accessor to the actual database
+    /// for all types found in the `types` field.
+    #[serde(skip)]
+    type_table: Interner<TypeId>,
+    /// The database where registered types actually reside.
+    ///
+    /// This is going to be serialized upon serlialization.
+    #[serde(serialize_with = "serialize_registry_types")]
+    types: BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
 }
 
 /// Serializes the types of the registry by removing their unique IDs
 /// and instead serialize them in order of their removed unique ID.
 fn serialize_registry_types<S>(
-	types: &BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
-	serializer: S,
+    types: &BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
+    serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-	S: serde::Serializer,
+    S: serde::Serializer,
 {
-	let types = types.values().collect::<Vec<_>>();
-	types.serialize(serializer)
+    let types = types.values().collect::<Vec<_>>();
+    types.serialize(serializer)
 }
 
 impl Default for Registry {
-	fn default() -> Self {
-		Self::new()
-	}
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Encode for Registry {
-	fn size_hint(&self) -> usize {
-		mem::size_of::<u32>() + mem::size_of::<Type<CompactForm>>() * self.types.len()
-	}
+    fn size_hint(&self) -> usize {
+        mem::size_of::<u32>() + mem::size_of::<Type<CompactForm>>() * self.types.len()
+    }
 
-	fn encode_to<W: scale::Output>(&self, dest: &mut W) {
-		if self.types.len() > u32::max_value() as usize {
-			panic!("Attempted to encode too many elements.");
-		}
-		scale::Compact(self.types.len() as u32).encode_to(dest);
+    fn encode_to<W: scale::Output>(&self, dest: &mut W) {
+        if self.types.len() > u32::max_value() as usize {
+            panic!("Attempted to encode too many elements.");
+        }
+        scale::Compact(self.types.len() as u32).encode_to(dest);
 
-		for ty in self.types.values() {
-			ty.encode_to(dest);
-		}
-	}
+        for ty in self.types.values() {
+            ty.encode_to(dest);
+        }
+    }
 }
 
 impl Registry {
-	/// Creates a new empty registry.
-	pub fn new() -> Self {
-		Self {
-			type_table: Interner::new(),
-			types: BTreeMap::new(),
-		}
-	}
+    /// Creates a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            type_table: Interner::new(),
+            types: BTreeMap::new(),
+        }
+    }
 
-	/// Registers the given type ID into the registry.
-	///
-	/// Returns `false` as the first return value if the type ID has already
-	/// been registered into this registry.
-	/// Returns the associated type ID symbol as second return value.
-	///
-	/// # Note
-	///
-	/// This is an internal API and should not be called directly from the
-	/// outside.
-	fn intern_type_id(&mut self, type_id: TypeId) -> (bool, UntrackedSymbol<TypeId>) {
-		let (inserted, symbol) = self.type_table.intern_or_get(type_id);
-		(inserted, symbol.into_untracked())
-	}
+    /// Registers the given type ID into the registry.
+    ///
+    /// Returns `false` as the first return value if the type ID has already
+    /// been registered into this registry.
+    /// Returns the associated type ID symbol as second return value.
+    ///
+    /// # Note
+    ///
+    /// This is an internal API and should not be called directly from the
+    /// outside.
+    fn intern_type_id(&mut self, type_id: TypeId) -> (bool, UntrackedSymbol<TypeId>) {
+        let (inserted, symbol) = self.type_table.intern_or_get(type_id);
+        (inserted, symbol.into_untracked())
+    }
 
-	/// Registers the given type into the registry and returns
-	/// its associated type ID symbol.
-	///
-	/// # Note
-	///
-	/// Due to safety requirements the returns type ID symbol cannot
-	/// be used later to resolve back to the associated type definition.
-	/// However, since this facility is going to be used for serialization
-	/// purposes this functionality isn't needed anyway.
-	pub fn register_type(&mut self, ty: &MetaType) -> UntrackedSymbol<TypeId> {
-		let (inserted, symbol) = self.intern_type_id(ty.type_id());
-		if inserted {
-			let compact_id = ty.type_info().into_compact(self);
-			self.types.insert(symbol, compact_id);
-		}
-		symbol
-	}
+    /// Registers the given type into the registry and returns
+    /// its associated type ID symbol.
+    ///
+    /// # Note
+    ///
+    /// Due to safety requirements the returns type ID symbol cannot
+    /// be used later to resolve back to the associated type definition.
+    /// However, since this facility is going to be used for serialization
+    /// purposes this functionality isn't needed anyway.
+    pub fn register_type(&mut self, ty: &MetaType) -> UntrackedSymbol<TypeId> {
+        let (inserted, symbol) = self.intern_type_id(ty.type_id());
+        if inserted {
+            let compact_id = ty.type_info().into_compact(self);
+            self.types.insert(symbol, compact_id);
+        }
+        symbol
+    }
 
-	/// Calls `register_type` for each `MetaType` in the given `iter`
-	pub fn register_types<I>(&mut self, iter: I) -> Vec<UntrackedSymbol<TypeId>>
-	where
-		I: IntoIterator<Item = MetaType>,
-	{
-		iter.into_iter().map(|i| self.register_type(&i)).collect::<Vec<_>>()
-	}
+    /// Calls `register_type` for each `MetaType` in the given `iter`
+    pub fn register_types<I>(&mut self, iter: I) -> Vec<UntrackedSymbol<TypeId>>
+    where
+        I: IntoIterator<Item = MetaType>,
+    {
+        iter.into_iter()
+            .map(|i| self.register_type(&i))
+            .collect::<Vec<_>>()
+    }
 
-	/// Converts an iterator into a Vec of the equivalent compact
-	/// representations
-	pub fn map_into_compact<I, T>(&mut self, iter: I) -> Vec<T::Output>
-	where
-		I: IntoIterator<Item = T>,
-		T: IntoCompact,
-	{
-		iter.into_iter().map(|i| i.into_compact(self)).collect::<Vec<_>>()
-	}
+    /// Converts an iterator into a Vec of the equivalent compact
+    /// representations
+    pub fn map_into_compact<I, T>(&mut self, iter: I) -> Vec<T::Output>
+    where
+        I: IntoIterator<Item = T>,
+        T: IntoCompact,
+    {
+        iter.into_iter()
+            .map(|i| i.into_compact(self))
+            .collect::<Vec<_>>()
+    }
 }
 
 /// A read-only registry, to be used for decoding/deserializing
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Decode)]
 pub struct RegistryReadOnly {
-	types: Vec<Type<CompactForm>>,
+    types: Vec<Type<CompactForm>>,
 }
 
 impl From<Registry> for RegistryReadOnly {
-	fn from(registry: Registry) -> Self {
-		RegistryReadOnly {
-			types: registry.types.values().cloned().collect::<Vec<_>>(),
-		}
-	}
+    fn from(registry: Registry) -> Self {
+        RegistryReadOnly {
+            types: registry.types.values().cloned().collect::<Vec<_>>(),
+        }
+    }
 }
 
 impl RegistryReadOnly {
-	/// Returns the type definition for the given identifier, `None` if no type found for that ID.
-	pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
-		self.types.get((id.get() - 1) as usize)
-	}
+    /// Returns the type definition for the given identifier, `None` if no type found for that ID.
+    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
+        self.types.get((id.get() - 1) as usize)
+    }
 
-	/// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
-	pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm>)> {
-		self.types.iter().enumerate().map(|(i, ty)| {
-			let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
-			(id, ty)
-		})
-	}
+    /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
+    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm>)> {
+        self.types.iter().enumerate().map(|(i, ty)| {
+            let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
+            (id, ty)
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::{build::Fields, meta_type, Path, TypeDef, TypeInfo};
+    use super::*;
+    use crate::{
+        build::Fields,
+        meta_type,
+        Path,
+        TypeDef,
+        TypeInfo,
+    };
 
-	#[test]
-	fn readonly_enumerate() {
-		let mut registry = Registry::new();
-		registry.register_type(&MetaType::new::<u32>());
-		registry.register_type(&MetaType::new::<bool>());
-		registry.register_type(&MetaType::new::<Option<(u32, bool)>>());
+    #[test]
+    fn readonly_enumerate() {
+        let mut registry = Registry::new();
+        registry.register_type(&MetaType::new::<u32>());
+        registry.register_type(&MetaType::new::<bool>());
+        registry.register_type(&MetaType::new::<Option<(u32, bool)>>());
 
-		let readonly: RegistryReadOnly = registry.into();
+        let readonly: RegistryReadOnly = registry.into();
 
-		assert_eq!(4, readonly.enumerate().count());
+        assert_eq!(4, readonly.enumerate().count());
 
-		let mut expected = 1;
-		for (i, _) in readonly.enumerate() {
-			assert_eq!(NonZeroU32::new(expected).unwrap(), i);
-			expected += 1;
-		}
-	}
+        let mut expected = 1;
+        for (i, _) in readonly.enumerate() {
+            assert_eq!(NonZeroU32::new(expected).unwrap(), i);
+            expected += 1;
+        }
+    }
 
-	#[test]
-	fn recursive_struct_with_references() {
-		#[allow(unused)]
-		struct RecursiveRefs<'a> {
-			boxed: Box<RecursiveRefs<'a>>,
-			reference: &'a RecursiveRefs<'a>,
-			mutable_reference: &'a mut RecursiveRefs<'a>,
-		}
+    #[test]
+    fn recursive_struct_with_references() {
+        #[allow(unused)]
+        struct RecursiveRefs<'a> {
+            boxed: Box<RecursiveRefs<'a>>,
+            reference: &'a RecursiveRefs<'a>,
+            mutable_reference: &'a mut RecursiveRefs<'a>,
+        }
 
-		impl TypeInfo for RecursiveRefs<'static> {
-			type Identity = Self;
+        impl TypeInfo for RecursiveRefs<'static> {
+            type Identity = Self;
 
-			fn type_info() -> Type {
-				Type::builder()
-					.path(Path::new("RecursiveRefs", module_path!()))
-					.composite(
-						Fields::named()
-							.field_of::<Box<RecursiveRefs>>("boxed")
-							.field_of::<&'static RecursiveRefs<'static>>("reference")
-							.field_of::<&'static mut RecursiveRefs<'static>>("mutable_reference"),
-					)
-					.into()
-			}
-		}
+            fn type_info() -> Type {
+                Type::builder()
+                    .path(Path::new("RecursiveRefs", module_path!()))
+                    .composite(
+                        Fields::named()
+                            .field_of::<Box<RecursiveRefs>>("boxed")
+                            .field_of::<&'static RecursiveRefs<'static>>("reference")
+                            .field_of::<&'static mut RecursiveRefs<'static>>(
+                                "mutable_reference",
+                            ),
+                    )
+                    .into()
+            }
+        }
 
-		let mut registry = Registry::new();
-		let type_id = registry.register_type(&meta_type::<RecursiveRefs>());
+        let mut registry = Registry::new();
+        let type_id = registry.register_type(&meta_type::<RecursiveRefs>());
 
-		let recursive = registry.types.get(&type_id).unwrap();
-		if let TypeDef::Composite(composite) = recursive.type_def() {
-			for field in composite.fields() {
-				assert_eq!(*field.ty(), type_id)
-			}
-		} else {
-			panic!("Should be a composite type definition")
-		}
-	}
+        let recursive = registry.types.get(&type_id).unwrap();
+        if let TypeDef::Composite(composite) = recursive.type_def() {
+            for field in composite.fields() {
+                assert_eq!(*field.ty(), type_id)
+            }
+        } else {
+            panic!("Should be a composite type definition")
+        }
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,136 +12,145 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::build::*;
-use crate::*;
+use crate::{
+    build::*,
+    *,
+};
 use core::marker::PhantomData;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec};
+use alloc::{
+    boxed::Box,
+    string::String,
+    vec,
+};
 
 fn assert_type<T, E>(expected: E)
 where
-	T: TypeInfo + ?Sized,
-	E: Into<Type>,
+    T: TypeInfo + ?Sized,
+    E: Into<Type>,
 {
-	assert_eq!(T::type_info(), expected.into());
+    assert_eq!(T::type_info(), expected.into());
 }
 
 macro_rules! assert_type {
-	( $ty:ty, $expected:expr ) => {{
-		assert_type::<$ty, _>($expected)
-		}};
+    ( $ty:ty, $expected:expr ) => {{
+        assert_type::<$ty, _>($expected)
+    }};
 }
 
 #[test]
 fn primitives() {
-	assert_type!(bool, TypeDefPrimitive::Bool);
-	assert_type!(&str, TypeDefPrimitive::Str);
-	assert_type!(i8, TypeDefPrimitive::I8);
+    assert_type!(bool, TypeDefPrimitive::Bool);
+    assert_type!(&str, TypeDefPrimitive::Str);
+    assert_type!(i8, TypeDefPrimitive::I8);
 
-	assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
+    assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
 }
 
 #[test]
 fn prelude_items() {
-	assert_type!(String, TypeDefPrimitive::Str);
+    assert_type!(String, TypeDefPrimitive::Str);
 
-	assert_type!(
-		Option<u128>,
-		Type::builder()
-			.path(Path::prelude("Option"))
-			.type_params(tuple_meta_type!(u128))
-			.variant(
-				Variants::with_fields()
-					.variant_unit("None")
-					.variant("Some", Fields::unnamed().field_of::<u128>())
-			)
-	);
-	assert_type!(
-		Result<bool, String>,
-		Type::builder()
-			.path(Path::prelude("Result"))
-			.type_params(tuple_meta_type!(bool, String))
-			.variant(
-				Variants::with_fields()
-					.variant("Ok", Fields::unnamed().field_of::<bool>())
-					.variant("Err", Fields::unnamed().field_of::<String>())
-			)
-	);
-	assert_type!(
-		PhantomData<i32>,
-		Type::builder()
-			.path(Path::prelude("PhantomData"))
-			.type_params(tuple_meta_type!(i32))
-			.composite(Fields::unit())
-	);
+    assert_type!(
+        Option<u128>,
+        Type::builder()
+            .path(Path::prelude("Option"))
+            .type_params(tuple_meta_type!(u128))
+            .variant(
+                Variants::with_fields()
+                    .variant_unit("None")
+                    .variant("Some", Fields::unnamed().field_of::<u128>())
+            )
+    );
+    assert_type!(
+        Result<bool, String>,
+        Type::builder()
+            .path(Path::prelude("Result"))
+            .type_params(tuple_meta_type!(bool, String))
+            .variant(
+                Variants::with_fields()
+                    .variant("Ok", Fields::unnamed().field_of::<bool>())
+                    .variant("Err", Fields::unnamed().field_of::<String>())
+            )
+    );
+    assert_type!(
+        PhantomData<i32>,
+        Type::builder()
+            .path(Path::prelude("PhantomData"))
+            .type_params(tuple_meta_type!(i32))
+            .composite(Fields::unit())
+    );
 }
 
 #[test]
 fn tuple_primitives() {
-	// unit
-	assert_type!((), TypeDefTuple::new(tuple_meta_type!()));
+    // unit
+    assert_type!((), TypeDefTuple::new(tuple_meta_type!()));
 
-	// tuple with one element
-	assert_type!((bool,), TypeDefTuple::new(tuple_meta_type!(bool)));
+    // tuple with one element
+    assert_type!((bool,), TypeDefTuple::new(tuple_meta_type!(bool)));
 
-	// tuple with multiple elements
-	assert_type!((bool, String), TypeDefTuple::new(tuple_meta_type!(bool, String)));
+    // tuple with multiple elements
+    assert_type!(
+        (bool, String),
+        TypeDefTuple::new(tuple_meta_type!(bool, String))
+    );
 
-	// nested tuple
-	assert_type!(
-		((i8, i16), (u32, u64)),
-		TypeDefTuple::new(vec![meta_type::<(i8, i16)>(), meta_type::<(u32, u64)>(),])
-	);
+    // nested tuple
+    assert_type!(
+        ((i8, i16), (u32, u64)),
+        TypeDefTuple::new(vec![meta_type::<(i8, i16)>(), meta_type::<(u32, u64)>(),])
+    );
 }
 
 #[test]
 fn array_primitives() {
-	// array
-	assert_type!([bool; 3], TypeDefArray::new(3, meta_type::<bool>()));
-	// nested
-	assert_type!([[i32; 5]; 5], TypeDefArray::new(5, meta_type::<[i32; 5]>()));
-	// sequence
-	assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
-	// vec
-	assert_type!(Vec<bool>, TypeDefSequence::new(meta_type::<bool>()));
+    // array
+    assert_type!([bool; 3], TypeDefArray::new(3, meta_type::<bool>()));
+    // nested
+    assert_type!([[i32; 5]; 5], TypeDefArray::new(5, meta_type::<[i32; 5]>()));
+    // sequence
+    assert_type!([bool], TypeDefSequence::new(meta_type::<bool>()));
+    // vec
+    assert_type!(Vec<bool>, TypeDefSequence::new(meta_type::<bool>()));
 }
 
 #[test]
 fn struct_with_generics() {
-	#[allow(unused)]
-	struct MyStruct<T> {
-		data: T,
-	}
+    #[allow(unused)]
+    struct MyStruct<T> {
+        data: T,
+    }
 
-	impl<T> TypeInfo for MyStruct<T>
-	where
-		T: TypeInfo + 'static,
-	{
-		type Identity = Self;
+    impl<T> TypeInfo for MyStruct<T>
+    where
+        T: TypeInfo + 'static,
+    {
+        type Identity = Self;
 
-		fn type_info() -> Type {
-			Type::builder()
-				.path(Path::new("MyStruct", module_path!()))
-				.type_params(tuple_meta_type!(T))
-				.composite(Fields::named().field_of::<T>("data"))
-				.into()
-		}
-	}
+        fn type_info() -> Type {
+            Type::builder()
+                .path(Path::new("MyStruct", module_path!()))
+                .type_params(tuple_meta_type!(T))
+                .composite(Fields::named().field_of::<T>("data"))
+                .into()
+        }
+    }
 
-	// Normal struct
-	let struct_bool_type_info = Type::builder()
-		.path(Path::from_segments(vec!["scale_info", "tests", "MyStruct"]).unwrap())
-		.type_params(tuple_meta_type!(bool))
-		.composite(Fields::named().field_of::<bool>("data"));
+    // Normal struct
+    let struct_bool_type_info = Type::builder()
+        .path(Path::from_segments(vec!["scale_info", "tests", "MyStruct"]).unwrap())
+        .type_params(tuple_meta_type!(bool))
+        .composite(Fields::named().field_of::<bool>("data"));
 
-	assert_type!(MyStruct<bool>, struct_bool_type_info);
+    assert_type!(MyStruct<bool>, struct_bool_type_info);
 
-	// With "`Self` typed" fields
-	type SelfTyped = MyStruct<Box<MyStruct<bool>>>;
-	let expected_type = Type::builder()
-		.path(Path::new("MyStruct", "scale_info::tests"))
-		.type_params(tuple_meta_type!(Box<MyStruct<bool>>))
-		.composite(Fields::named().field_of::<Box<MyStruct<bool>>>("data"));
-	assert_type!(SelfTyped, expected_type);
+    // With "`Self` typed" fields
+    type SelfTyped = MyStruct<Box<MyStruct<bool>>>;
+    let expected_type = Type::builder()
+        .path(Path::new("MyStruct", "scale_info::tests"))
+        .type_params(tuple_meta_type!(Box<MyStruct<bool>>))
+        .composite(Fields::named().field_of::<Box<MyStruct<bool>>>("data"));
+    assert_type!(SelfTyped, expected_type);
 }

--- a/src/tm_std.rs
+++ b/src/tm_std.rs
@@ -15,11 +15,11 @@
 //! Exports from `std`, `core` and `alloc` crates.
 
 mod core {
-	#[cfg(not(feature = "std"))]
-	pub use core::*;
+    #[cfg(not(feature = "std"))]
+    pub use core::*;
 
-	#[cfg(feature = "std")]
-	pub use std::*;
+    #[cfg(feature = "std")]
+    pub use std::*;
 }
 
 #[rustfmt::skip]
@@ -45,11 +45,11 @@ pub use self::core::{
 };
 
 mod alloc {
-	#[cfg(not(feature = "std"))]
-	pub use ::alloc::*;
+    #[cfg(not(feature = "std"))]
+    pub use ::alloc::*;
 
-	#[cfg(feature = "std")]
-	pub use std::*;
+    #[cfg(feature = "std")]
+    pub use std::*;
 }
 
 #[rustfmt::skip]

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -15,12 +15,25 @@
 use crate::tm_std::*;
 
 use crate::{
-	form::{CompactForm, Form, MetaForm},
-	Field, IntoCompact, Registry,
+    form::{
+        CompactForm,
+        Form,
+        MetaForm,
+    },
+    Field,
+    IntoCompact,
+    Registry,
 };
 use derive_more::From;
-use scale::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+    Serialize,
+};
 
 /// A composite type, consisting of either named (struct) or unnamed (tuple
 /// struct) fields
@@ -48,46 +61,58 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// ```
 /// struct JustAMarker;
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Debug,
+    From,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefComposite<T: Form = MetaForm> {
-	/// The fields of the composite type.
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	fields: Vec<Field<T>>,
+    /// The fields of the composite type.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    fields: Vec<Field<T>>,
 }
 
 impl IntoCompact for TypeDefComposite {
-	type Output = TypeDefComposite<CompactForm>;
+    type Output = TypeDefComposite<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeDefComposite {
-			fields: registry.map_into_compact(self.fields),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeDefComposite {
+            fields: registry.map_into_compact(self.fields),
+        }
+    }
 }
 
 impl TypeDefComposite {
-	/// Creates a new struct definition with named fields.
-	pub fn new<I>(fields: I) -> Self
-	where
-		I: IntoIterator<Item = Field>,
-	{
-		Self {
-			fields: fields.into_iter().collect(),
-		}
-	}
+    /// Creates a new struct definition with named fields.
+    pub fn new<I>(fields: I) -> Self
+    where
+        I: IntoIterator<Item = Field>,
+    {
+        Self {
+            fields: fields.into_iter().collect(),
+        }
+    }
 }
 
 impl<T> TypeDefComposite<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the fields of the composite type.
-	pub fn fields(&self) -> &[Field<T>] {
-		&self.fields
-	}
+    /// Returns the fields of the composite type.
+    pub fn fields(&self) -> &[Field<T>] {
+        &self.fields
+    }
 }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -15,97 +15,113 @@
 use crate::tm_std::*;
 
 use crate::{
-	form::{CompactForm, Form, MetaForm},
-	IntoCompact, MetaType, Registry, TypeInfo,
+    form::{
+        CompactForm,
+        Form,
+        MetaForm,
+    },
+    IntoCompact,
+    MetaType,
+    Registry,
+    TypeInfo,
 };
-use scale::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+    Serialize,
+};
 
 /// A field of a struct like data type.
 ///
 /// Name is optional so it can represent both named and unnamed fields.
 ///
 /// This can be a named field of a struct type or a struct variant.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Field<T: Form = MetaForm> {
-	/// The name of the field. None for unnamed fields.
-	#[serde(skip_serializing_if = "Option::is_none", default)]
-	name: Option<T::String>,
-	/// The type of the field.
-	#[serde(rename = "type")]
-	ty: T::Type,
+    /// The name of the field. None for unnamed fields.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    name: Option<T::String>,
+    /// The type of the field.
+    #[serde(rename = "type")]
+    ty: T::Type,
 }
 
 impl IntoCompact for Field {
-	type Output = Field<CompactForm>;
+    type Output = Field<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		Field {
-			name: self.name.map(|name| name.into_compact(registry)),
-			ty: registry.register_type(&self.ty),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        Field {
+            name: self.name.map(|name| name.into_compact(registry)),
+            ty: registry.register_type(&self.ty),
+        }
+    }
 }
 
 impl Field {
-	/// Creates a new field.
-	///
-	/// Use this constructor if you want to instantiate from a given meta type.
-	pub fn new(name: Option<&'static str>, ty: MetaType) -> Self {
-		Self { name, ty }
-	}
+    /// Creates a new field.
+    ///
+    /// Use this constructor if you want to instantiate from a given meta type.
+    pub fn new(name: Option<&'static str>, ty: MetaType) -> Self {
+        Self { name, ty }
+    }
 
-	/// Creates a new named field
-	pub fn named(name: &'static str, ty: MetaType) -> Self {
-		Self::new(Some(name), ty)
-	}
+    /// Creates a new named field
+    pub fn named(name: &'static str, ty: MetaType) -> Self {
+        Self::new(Some(name), ty)
+    }
 
-	/// Creates a new named field.
-	///
-	/// Use this constructor if you want to instantiate from a given
-	/// compile-time type.
-	pub fn named_of<T>(name: &'static str) -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		Self::new(Some(name), MetaType::new::<T>())
-	}
+    /// Creates a new named field.
+    ///
+    /// Use this constructor if you want to instantiate from a given
+    /// compile-time type.
+    pub fn named_of<T>(name: &'static str) -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        Self::new(Some(name), MetaType::new::<T>())
+    }
 
-	/// Creates a new unnamed field.
-	///
-	/// Use this constructor if you want to instantiate an unnamed field from a
-	/// given meta type.
-	pub fn unnamed(meta_type: MetaType) -> Self {
-		Self::new(None, meta_type)
-	}
+    /// Creates a new unnamed field.
+    ///
+    /// Use this constructor if you want to instantiate an unnamed field from a
+    /// given meta type.
+    pub fn unnamed(meta_type: MetaType) -> Self {
+        Self::new(None, meta_type)
+    }
 
-	/// Creates a new unnamed field.
-	///
-	/// Use this constructor if you want to instantiate an unnamed field from a
-	/// given compile-time type.
-	pub fn unnamed_of<T>() -> Self
-	where
-		T: TypeInfo + ?Sized + 'static,
-	{
-		Self::new(None, MetaType::new::<T>())
-	}
+    /// Creates a new unnamed field.
+    ///
+    /// Use this constructor if you want to instantiate an unnamed field from a
+    /// given compile-time type.
+    pub fn unnamed_of<T>() -> Self
+    where
+        T: TypeInfo + ?Sized + 'static,
+    {
+        Self::new(None, MetaType::new::<T>())
+    }
 }
 
 impl<T> Field<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the name of the field. None for unnamed fields.
-	pub fn name(&self) -> Option<&T::String> {
-		self.name.as_ref()
-	}
+    /// Returns the name of the field. None for unnamed fields.
+    pub fn name(&self) -> Option<&T::String> {
+        self.name.as_ref()
+    }
 
-	/// Returns the type of the field.
-	pub fn ty(&self) -> &T::Type {
-		&self.ty
-	}
+    /// Returns the type of the field.
+    pub fn ty(&self) -> &T::Type {
+        &self.ty
+    }
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -15,323 +15,383 @@
 use crate::tm_std::*;
 
 use crate::{
-	build::TypeBuilder,
-	form::{CompactForm, Form, MetaForm},
-	IntoCompact, MetaType, Registry, TypeInfo,
+    build::TypeBuilder,
+    form::{
+        CompactForm,
+        Form,
+        MetaForm,
+    },
+    IntoCompact,
+    MetaType,
+    Registry,
+    TypeInfo,
 };
 use derive_more::From;
-use scale::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+    Serialize,
+};
 
 mod composite;
 mod fields;
 mod path;
 mod variant;
 
-pub use self::{composite::*, fields::*, path::*, variant::*};
+pub use self::{
+    composite::*,
+    fields::*,
+    path::*,
+    variant::*,
+};
 
 /// A [`Type`] definition with optional metadata.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    From,
+    Debug,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Type<T: Form = MetaForm> {
-	/// The unique path to the type. Can be empty for built-in types
-	#[serde(skip_serializing_if = "Path::is_empty", default)]
-	path: Path<T>,
-	/// The generic type parameters of the type in use. Empty for non generic types
-	#[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
-	type_params: Vec<T::Type>,
-	/// The actual type definition
-	#[serde(rename = "def")]
-	type_def: TypeDef<T>,
+    /// The unique path to the type. Can be empty for built-in types
+    #[serde(skip_serializing_if = "Path::is_empty", default)]
+    path: Path<T>,
+    /// The generic type parameters of the type in use. Empty for non generic types
+    #[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
+    type_params: Vec<T::Type>,
+    /// The actual type definition
+    #[serde(rename = "def")]
+    type_def: TypeDef<T>,
 }
 
 impl IntoCompact for Type {
-	type Output = Type<CompactForm>;
+    type Output = Type<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		Type {
-			path: self.path.into_compact(registry),
-			type_params: registry.register_types(self.type_params),
-			type_def: self.type_def.into_compact(registry),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        Type {
+            path: self.path.into_compact(registry),
+            type_params: registry.register_types(self.type_params),
+            type_def: self.type_def.into_compact(registry),
+        }
+    }
 }
 
 impl From<TypeDefPrimitive> for Type {
-	fn from(primitive: TypeDefPrimitive) -> Self {
-		Self::new(Path::voldemort(), Vec::new(), primitive)
-	}
+    fn from(primitive: TypeDefPrimitive) -> Self {
+        Self::new(Path::voldemort(), Vec::new(), primitive)
+    }
 }
 
 impl From<TypeDefArray> for Type {
-	fn from(array: TypeDefArray) -> Self {
-		Self::new(Path::voldemort(), Vec::new(), array)
-	}
+    fn from(array: TypeDefArray) -> Self {
+        Self::new(Path::voldemort(), Vec::new(), array)
+    }
 }
 
 impl From<TypeDefSequence> for Type {
-	fn from(sequence: TypeDefSequence) -> Self {
-		Self::new(Path::voldemort(), Vec::new(), sequence)
-	}
+    fn from(sequence: TypeDefSequence) -> Self {
+        Self::new(Path::voldemort(), Vec::new(), sequence)
+    }
 }
 
 impl From<TypeDefTuple> for Type {
-	fn from(tuple: TypeDefTuple) -> Self {
-		Self::new(Path::voldemort(), Vec::new(), tuple)
-	}
+    fn from(tuple: TypeDefTuple) -> Self {
+        Self::new(Path::voldemort(), Vec::new(), tuple)
+    }
 }
 
 impl Type {
-	/// Create a [`TypeBuilder`](`crate::build::TypeBuilder`) the public API for constructing a [`Type`]
-	pub fn builder() -> TypeBuilder {
-		TypeBuilder::default()
-	}
+    /// Create a [`TypeBuilder`](`crate::build::TypeBuilder`) the public API for constructing a [`Type`]
+    pub fn builder() -> TypeBuilder {
+        TypeBuilder::default()
+    }
 
-	pub(crate) fn new<I, D>(path: Path, type_params: I, type_def: D) -> Self
-	where
-		I: IntoIterator<Item = MetaType>,
-		D: Into<TypeDef>,
-	{
-		Self {
-			path,
-			type_params: type_params.into_iter().collect(),
-			type_def: type_def.into(),
-		}
-	}
+    pub(crate) fn new<I, D>(path: Path, type_params: I, type_def: D) -> Self
+    where
+        I: IntoIterator<Item = MetaType>,
+        D: Into<TypeDef>,
+    {
+        Self {
+            path,
+            type_params: type_params.into_iter().collect(),
+            type_def: type_def.into(),
+        }
+    }
 }
 
 impl<T> Type<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the path of the type
-	pub fn path(&self) -> &Path<T> {
-		&self.path
-	}
+    /// Returns the path of the type
+    pub fn path(&self) -> &Path<T> {
+        &self.path
+    }
 
-	/// Returns the generic type parameters of the type
-	pub fn type_params(&self) -> &[T::Type] {
-		&self.type_params
-	}
+    /// Returns the generic type parameters of the type
+    pub fn type_params(&self) -> &[T::Type] {
+        &self.type_params
+    }
 
-	/// Returns the definition of the type
-	pub fn type_def(&self) -> &TypeDef<T> {
-		&self.type_def
-	}
+    /// Returns the definition of the type
+    pub fn type_def(&self) -> &TypeDef<T> {
+        &self.type_def
+    }
 }
 
 /// The possible types a SCALE encodable Rust value could have.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    From,
+    Debug,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "camelCase")]
 pub enum TypeDef<T: Form = MetaForm> {
-	/// A composite type (e.g. a struct or a tuple)
-	Composite(TypeDefComposite<T>),
-	/// A variant type (e.g. an enum)
-	Variant(TypeDefVariant<T>),
-	/// A sequence type with runtime known length.
-	Sequence(TypeDefSequence<T>),
-	/// An array type with compile-time known length.
-	Array(TypeDefArray<T>),
-	/// A tuple type.
-	Tuple(TypeDefTuple<T>),
-	/// A Rust primitive type.
-	Primitive(TypeDefPrimitive),
+    /// A composite type (e.g. a struct or a tuple)
+    Composite(TypeDefComposite<T>),
+    /// A variant type (e.g. an enum)
+    Variant(TypeDefVariant<T>),
+    /// A sequence type with runtime known length.
+    Sequence(TypeDefSequence<T>),
+    /// An array type with compile-time known length.
+    Array(TypeDefArray<T>),
+    /// A tuple type.
+    Tuple(TypeDefTuple<T>),
+    /// A Rust primitive type.
+    Primitive(TypeDefPrimitive),
 }
 
 impl IntoCompact for TypeDef {
-	type Output = TypeDef<CompactForm>;
+    type Output = TypeDef<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		match self {
-			TypeDef::Composite(composite) => composite.into_compact(registry).into(),
-			TypeDef::Variant(variant) => variant.into_compact(registry).into(),
-			TypeDef::Sequence(sequence) => sequence.into_compact(registry).into(),
-			TypeDef::Array(array) => array.into_compact(registry).into(),
-			TypeDef::Tuple(tuple) => tuple.into_compact(registry).into(),
-			TypeDef::Primitive(primitive) => primitive.into(),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        match self {
+            TypeDef::Composite(composite) => composite.into_compact(registry).into(),
+            TypeDef::Variant(variant) => variant.into_compact(registry).into(),
+            TypeDef::Sequence(sequence) => sequence.into_compact(registry).into(),
+            TypeDef::Array(array) => array.into_compact(registry).into(),
+            TypeDef::Tuple(tuple) => tuple.into_compact(registry).into(),
+            TypeDef::Primitive(primitive) => primitive.into(),
+        }
+    }
 }
 
 /// A primitive Rust type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum TypeDefPrimitive {
-	/// `bool` type
-	Bool,
-	/// `char` type
-	Char,
-	/// `str` type
-	Str,
-	/// `u8`
-	U8,
-	/// `u16`
-	U16,
-	/// `u32`
-	U32,
-	/// `u64`
-	U64,
-	/// `u128`
-	U128,
-	/// 256 bits unsigned int (no rust equivalent)
-	U256,
-	/// `i8`
-	I8,
-	/// `i16`
-	I16,
-	/// `i32`
-	I32,
-	/// `i64`
-	I64,
-	/// `i128`
-	I128,
-	/// 256 bits signed int (no rust equivalent)
-	I256,
+    /// `bool` type
+    Bool,
+    /// `char` type
+    Char,
+    /// `str` type
+    Str,
+    /// `u8`
+    U8,
+    /// `u16`
+    U16,
+    /// `u32`
+    U32,
+    /// `u64`
+    U64,
+    /// `u128`
+    U128,
+    /// 256 bits unsigned int (no rust equivalent)
+    U256,
+    /// `i8`
+    I8,
+    /// `i16`
+    I16,
+    /// `i32`
+    I32,
+    /// `i64`
+    I64,
+    /// `i128`
+    I128,
+    /// 256 bits signed int (no rust equivalent)
+    I256,
 }
 
 /// An array type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
+)]
+#[serde(bound(
+    serialize = "T::Type: Serialize",
+    deserialize = "T::Type: DeserializeOwned"
+))]
 pub struct TypeDefArray<T: Form = MetaForm> {
-	/// The length of the array type.
-	len: u32,
-	/// The element type of the array type.
-	#[serde(rename = "type")]
-	type_param: T::Type,
+    /// The length of the array type.
+    len: u32,
+    /// The element type of the array type.
+    #[serde(rename = "type")]
+    type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefArray {
-	type Output = TypeDefArray<CompactForm>;
+    type Output = TypeDefArray<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeDefArray {
-			len: self.len,
-			type_param: registry.register_type(&self.type_param),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeDefArray {
+            len: self.len,
+            type_param: registry.register_type(&self.type_param),
+        }
+    }
 }
 
 impl TypeDefArray {
-	/// Creates a new array type.
-	pub fn new(len: u32, type_param: MetaType) -> Self {
-		Self { len, type_param }
-	}
+    /// Creates a new array type.
+    pub fn new(len: u32, type_param: MetaType) -> Self {
+        Self { len, type_param }
+    }
 }
 
 #[allow(clippy::len_without_is_empty)]
 impl<T> TypeDefArray<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the length of the array type.
-	pub fn len(&self) -> u32 {
-		self.len
-	}
+    /// Returns the length of the array type.
+    pub fn len(&self) -> u32 {
+        self.len
+    }
 
-	/// Returns the element type of the array type.
-	pub fn type_param(&self) -> &T::Type {
-		&self.type_param
-	}
+    /// Returns the element type of the array type.
+    pub fn type_param(&self) -> &T::Type {
+        &self.type_param
+    }
 }
 
 /// A type to refer to tuple types.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
+)]
+#[serde(bound(
+    serialize = "T::Type: Serialize",
+    deserialize = "T::Type: DeserializeOwned"
+))]
 #[serde(transparent)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
-	/// The types of the tuple fields.
-	fields: Vec<T::Type>,
+    /// The types of the tuple fields.
+    fields: Vec<T::Type>,
 }
 
 impl IntoCompact for TypeDefTuple {
-	type Output = TypeDefTuple<CompactForm>;
+    type Output = TypeDefTuple<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeDefTuple {
-			fields: registry.register_types(self.fields),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeDefTuple {
+            fields: registry.register_types(self.fields),
+        }
+    }
 }
 
 impl TypeDefTuple {
-	/// Creates a new tuple type definition from the given types.
-	pub fn new<T>(type_params: T) -> Self
-	where
-		T: IntoIterator<Item = MetaType>,
-	{
-		Self {
-			fields: type_params.into_iter().collect(),
-		}
-	}
+    /// Creates a new tuple type definition from the given types.
+    pub fn new<T>(type_params: T) -> Self
+    where
+        T: IntoIterator<Item = MetaType>,
+    {
+        Self {
+            fields: type_params.into_iter().collect(),
+        }
+    }
 
-	/// Creates a new unit tuple to represent the unit type, `()`.
-	pub fn unit() -> Self {
-		Self::new(vec![])
-	}
+    /// Creates a new unit tuple to represent the unit type, `()`.
+    pub fn unit() -> Self {
+        Self::new(vec![])
+    }
 }
 
 impl<T> TypeDefTuple<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the types of the tuple fields.
-	pub fn fields(&self) -> &[T::Type] {
-		&self.fields
-	}
+    /// Returns the types of the tuple fields.
+    pub fn fields(&self) -> &[T::Type] {
+        &self.fields
+    }
 }
 
 /// A type to refer to a sequence of elements of the same type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug)]
-#[serde(bound(serialize = "T::Type: Serialize", deserialize = "T::Type: DeserializeOwned"))]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
+)]
+#[serde(bound(
+    serialize = "T::Type: Serialize",
+    deserialize = "T::Type: DeserializeOwned"
+))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
-	/// The element type of the sequence type.
-	#[serde(rename = "type")]
-	type_param: T::Type,
+    /// The element type of the sequence type.
+    #[serde(rename = "type")]
+    type_param: T::Type,
 }
 
 impl IntoCompact for TypeDefSequence {
-	type Output = TypeDefSequence<CompactForm>;
+    type Output = TypeDefSequence<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeDefSequence {
-			type_param: registry.register_type(&self.type_param),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeDefSequence {
+            type_param: registry.register_type(&self.type_param),
+        }
+    }
 }
 
 impl TypeDefSequence {
-	/// Creates a new sequence type.
-	///
-	/// Use this constructor if you want to instantiate from a given meta type.
-	pub fn new(type_param: MetaType) -> Self {
-		Self { type_param }
-	}
+    /// Creates a new sequence type.
+    ///
+    /// Use this constructor if you want to instantiate from a given meta type.
+    pub fn new(type_param: MetaType) -> Self {
+        Self { type_param }
+    }
 
-	/// Creates a new sequence type.
-	///
-	/// Use this constructor if you want to instantiate from a given
-	/// compile-time type.
-	pub fn of<T>() -> Self
-	where
-		T: TypeInfo + 'static,
-	{
-		Self::new(MetaType::new::<T>())
-	}
+    /// Creates a new sequence type.
+    ///
+    /// Use this constructor if you want to instantiate from a given
+    /// compile-time type.
+    pub fn of<T>() -> Self
+    where
+        T: TypeInfo + 'static,
+    {
+        Self::new(MetaType::new::<T>())
+    }
 }
 
 impl<T> TypeDefSequence<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the element type of the sequence type.
-	pub fn type_param(&self) -> &T::Type {
-		&self.type_param
-	}
+    /// Returns the element type of the sequence type.
+    pub fn type_param(&self) -> &T::Type {
+        &self.type_param
+    }
 }

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -13,13 +13,25 @@
 // limitations under the License.
 
 use crate::{
-	form::{CompactForm, Form, MetaForm},
-	tm_std::*,
-	utils::is_rust_identifier,
-	IntoCompact, Registry,
+    form::{
+        CompactForm,
+        Form,
+        MetaForm,
+    },
+    tm_std::*,
+    utils::is_rust_identifier,
+    IntoCompact,
+    Registry,
 };
-use scale::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+    Serialize,
+};
 
 /// Represents the path of a type definition.
 ///
@@ -28,195 +40,209 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// has been defined. The last
 ///
 /// Rust prelude type may have an empty namespace definition.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode,
+)]
 #[serde(transparent)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Path<T: Form = MetaForm> {
-	/// The segments of the namespace.
-	segments: Vec<T::String>,
+    /// The segments of the namespace.
+    segments: Vec<T::String>,
 }
 
 impl<T> Default for Path<T>
 where
-	T: Form,
+    T: Form,
 {
-	fn default() -> Self {
-		Path { segments: Vec::new() }
-	}
+    fn default() -> Self {
+        Path {
+            segments: Vec::new(),
+        }
+    }
 }
 
 impl IntoCompact for Path {
-	type Output = Path<CompactForm>;
+    type Output = Path<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		Path {
-			segments: registry.map_into_compact(self.segments),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        Path {
+            segments: registry.map_into_compact(self.segments),
+        }
+    }
 }
 
 impl Display for Path<CompactForm> {
-	fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-		write!(f, "{}", self.segments.join("::"))
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        write!(f, "{}", self.segments.join("::"))
+    }
 }
 
 impl Path {
-	/// Create a new Path
-	///
-	/// # Panics
-	///
-	/// - If the type identifier or module path contain invalid Rust identifiers
-	pub fn new(ident: &'static str, module_path: &'static str) -> Path {
-		let mut segments = module_path.split("::").collect::<Vec<_>>();
-		segments.push(ident);
-		Self::from_segments(segments).expect("All path segments should be valid Rust identifiers")
-	}
+    /// Create a new Path
+    ///
+    /// # Panics
+    ///
+    /// - If the type identifier or module path contain invalid Rust identifiers
+    pub fn new(ident: &'static str, module_path: &'static str) -> Path {
+        let mut segments = module_path.split("::").collect::<Vec<_>>();
+        segments.push(ident);
+        Self::from_segments(segments)
+            .expect("All path segments should be valid Rust identifiers")
+    }
 
-	/// Create an empty path for types which shall not be named
-	#[allow(unused)]
-	pub(crate) fn voldemort() -> Path {
-		Path { segments: Vec::new() }
-	}
+    /// Create an empty path for types which shall not be named
+    #[allow(unused)]
+    pub(crate) fn voldemort() -> Path {
+        Path {
+            segments: Vec::new(),
+        }
+    }
 
-	/// Crate a Path for types in the Prelude namespace
-	///
-	/// # Panics
-	///
-	/// - If the supplied ident is not a valid Rust identifier
-	pub(crate) fn prelude(ident: &'static str) -> Path {
-		Self::from_segments(vec![ident]).unwrap_or_else(|_| panic!("{} is not a valid Rust identifier", ident))
-	}
+    /// Crate a Path for types in the Prelude namespace
+    ///
+    /// # Panics
+    ///
+    /// - If the supplied ident is not a valid Rust identifier
+    pub(crate) fn prelude(ident: &'static str) -> Path {
+        Self::from_segments(vec![ident])
+            .unwrap_or_else(|_| panic!("{} is not a valid Rust identifier", ident))
+    }
 
-	/// Create a Path from the given segments
-	///
-	/// # Errors
-	///
-	/// - If no segments are supplied
-	/// - If any of the segments are invalid Rust identifiers
-	pub fn from_segments<I>(segments: I) -> Result<Path, PathError>
-	where
-		I: IntoIterator<Item = &'static str>,
-	{
-		let segments = segments.into_iter().collect::<Vec<_>>();
-		if segments.is_empty() {
-			return Err(PathError::MissingSegments);
-		}
-		if let Some(err_at) = segments.iter().position(|seg| !is_rust_identifier(seg)) {
-			return Err(PathError::InvalidIdentifier { segment: err_at });
-		}
-		Ok(Path { segments })
-	}
+    /// Create a Path from the given segments
+    ///
+    /// # Errors
+    ///
+    /// - If no segments are supplied
+    /// - If any of the segments are invalid Rust identifiers
+    pub fn from_segments<I>(segments: I) -> Result<Path, PathError>
+    where
+        I: IntoIterator<Item = &'static str>,
+    {
+        let segments = segments.into_iter().collect::<Vec<_>>();
+        if segments.is_empty() {
+            return Err(PathError::MissingSegments)
+        }
+        if let Some(err_at) = segments.iter().position(|seg| !is_rust_identifier(seg)) {
+            return Err(PathError::InvalidIdentifier { segment: err_at })
+        }
+        Ok(Path { segments })
+    }
 }
 
 impl<T> Path<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the segments of the Path
-	pub fn segments(&self) -> &[T::String] {
-		&self.segments
-	}
+    /// Returns the segments of the Path
+    pub fn segments(&self) -> &[T::String] {
+        &self.segments
+    }
 
-	/// Returns `true` if the path is empty
-	pub fn is_empty(&self) -> bool {
-		self.segments.is_empty()
-	}
+    /// Returns `true` if the path is empty
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
 
-	/// Get the ident segment of the Path
-	pub fn ident(&self) -> Option<T::String> {
-		self.segments.iter().last().cloned()
-	}
+    /// Get the ident segment of the Path
+    pub fn ident(&self) -> Option<T::String> {
+        self.segments.iter().last().cloned()
+    }
 
-	/// Get the namespace segments of the Path
-	pub fn namespace(&self) -> &[T::String] {
-		self.segments.split_last().map(|(_, ns)| ns).unwrap_or(&[])
-	}
+    /// Get the namespace segments of the Path
+    pub fn namespace(&self) -> &[T::String] {
+        self.segments.split_last().map(|(_, ns)| ns).unwrap_or(&[])
+    }
 }
 
 /// An error that may be encountered upon constructing namespaces.
 #[derive(PartialEq, Eq, Debug)]
 pub enum PathError {
-	/// If the module path does not at least have one segment.
-	MissingSegments,
-	/// If a segment within a module path is not a proper Rust identifier.
-	InvalidIdentifier {
-		/// The index of the erroneous segment.
-		segment: usize,
-	},
+    /// If the module path does not at least have one segment.
+    MissingSegments,
+    /// If a segment within a module path is not a proper Rust identifier.
+    InvalidIdentifier {
+        /// The index of the erroneous segment.
+        segment: usize,
+    },
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn path_ok() {
-		assert_eq!(
-			Path::from_segments(vec!["hello"]),
-			Ok(Path {
-				segments: vec!["hello"]
-			})
-		);
-		assert_eq!(
-			Path::from_segments(vec!["Hello", "World"]),
-			Ok(Path {
-				segments: vec!["Hello", "World"]
-			})
-		);
-		assert_eq!(Path::from_segments(vec!["_"]), Ok(Path { segments: vec!["_"] }));
-	}
+    #[test]
+    fn path_ok() {
+        assert_eq!(
+            Path::from_segments(vec!["hello"]),
+            Ok(Path {
+                segments: vec!["hello"]
+            })
+        );
+        assert_eq!(
+            Path::from_segments(vec!["Hello", "World"]),
+            Ok(Path {
+                segments: vec!["Hello", "World"]
+            })
+        );
+        assert_eq!(
+            Path::from_segments(vec!["_"]),
+            Ok(Path {
+                segments: vec!["_"]
+            })
+        );
+    }
 
-	#[test]
-	fn path_err() {
-		assert_eq!(Path::from_segments(vec![]), Err(PathError::MissingSegments));
-		assert_eq!(
-			Path::from_segments(vec![""]),
-			Err(PathError::InvalidIdentifier { segment: 0 })
-		);
-		assert_eq!(
-			Path::from_segments(vec!["1"]),
-			Err(PathError::InvalidIdentifier { segment: 0 })
-		);
-		assert_eq!(
-			Path::from_segments(vec!["Hello", ", World!"]),
-			Err(PathError::InvalidIdentifier { segment: 1 })
-		);
-	}
+    #[test]
+    fn path_err() {
+        assert_eq!(Path::from_segments(vec![]), Err(PathError::MissingSegments));
+        assert_eq!(
+            Path::from_segments(vec![""]),
+            Err(PathError::InvalidIdentifier { segment: 0 })
+        );
+        assert_eq!(
+            Path::from_segments(vec!["1"]),
+            Err(PathError::InvalidIdentifier { segment: 0 })
+        );
+        assert_eq!(
+            Path::from_segments(vec!["Hello", ", World!"]),
+            Err(PathError::InvalidIdentifier { segment: 1 })
+        );
+    }
 
-	#[test]
-	fn path_from_module_path_and_ident() {
-		assert_eq!(
-			Path::new("Planet", "hello::world"),
-			Path {
-				segments: vec!["hello", "world", "Planet"]
-			}
-		);
-		assert_eq!(
-			Path::from_segments(vec!["Earth", "::world"]),
-			Err(PathError::InvalidIdentifier { segment: 1 })
-		);
-	}
+    #[test]
+    fn path_from_module_path_and_ident() {
+        assert_eq!(
+            Path::new("Planet", "hello::world"),
+            Path {
+                segments: vec!["hello", "world", "Planet"]
+            }
+        );
+        assert_eq!(
+            Path::from_segments(vec!["Earth", "::world"]),
+            Err(PathError::InvalidIdentifier { segment: 1 })
+        );
+    }
 
-	#[test]
-	fn path_get_namespace_and_ident() {
-		let path = Path::new("Planet", "hello::world");
-		assert_eq!(path.namespace(), &["hello", "world"]);
-		assert_eq!(path.ident(), Some("Planet"));
-	}
+    #[test]
+    fn path_get_namespace_and_ident() {
+        let path = Path::new("Planet", "hello::world");
+        assert_eq!(path.namespace(), &["hello", "world"]);
+        assert_eq!(path.ident(), Some("Planet"));
+    }
 
-	#[test]
-	#[should_panic]
-	fn path_new_panics_with_invalid_identifiers() {
-		Path::new("Planet", "hello$!@$::world");
-	}
+    #[test]
+    #[should_panic]
+    fn path_new_panics_with_invalid_identifiers() {
+        Path::new("Planet", "hello$!@$::world");
+    }
 
-	#[test]
-	fn path_display() {
-		let path = Path::new("Planet", "hello::world").into_compact(&mut Default::default());
-		assert_eq!("hello::world::Planet", format!("{}", path))
-	}
+    #[test]
+    fn path_display() {
+        let path =
+            Path::new("Planet", "hello::world").into_compact(&mut Default::default());
+        assert_eq!("hello::world::Planet", format!("{}", path))
+    }
 }

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -15,13 +15,26 @@
 use crate::tm_std::*;
 
 use crate::{
-	build::FieldsBuilder,
-	form::{CompactForm, Form, MetaForm},
-	Field, IntoCompact, Registry,
+    build::FieldsBuilder,
+    form::{
+        CompactForm,
+        Form,
+        MetaForm,
+    },
+    Field,
+    IntoCompact,
+    Registry,
 };
 use derive_more::From;
-use scale::{Decode, Encode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize,
+    Serialize,
+};
 
 /// A Enum type (consisting of variants).
 ///
@@ -61,48 +74,60 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// ```
 /// enum JustAMarker {}
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Debug,
+    From,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 #[serde(rename_all = "lowercase")]
 pub struct TypeDefVariant<T: Form = MetaForm> {
-	/// The variants of a variant type
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	variants: Vec<Variant<T>>,
+    /// The variants of a variant type
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    variants: Vec<Variant<T>>,
 }
 
 impl IntoCompact for TypeDefVariant {
-	type Output = TypeDefVariant<CompactForm>;
+    type Output = TypeDefVariant<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeDefVariant {
-			variants: registry.map_into_compact(self.variants),
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeDefVariant {
+            variants: registry.map_into_compact(self.variants),
+        }
+    }
 }
 
 impl TypeDefVariant {
-	/// Create a new `TypeDefVariant` with the given variants
-	pub fn new<I>(variants: I) -> Self
-	where
-		I: IntoIterator<Item = Variant>,
-	{
-		Self {
-			variants: variants.into_iter().collect(),
-		}
-	}
+    /// Create a new `TypeDefVariant` with the given variants
+    pub fn new<I>(variants: I) -> Self
+    where
+        I: IntoIterator<Item = Variant>,
+    {
+        Self {
+            variants: variants.into_iter().collect(),
+        }
+    }
 }
 
 impl<T> TypeDefVariant<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the variants of a variant type
-	pub fn variants(&self) -> &[Variant<T>] {
-		&self.variants
-	}
+    /// Returns the variants of a variant type
+    pub fn variants(&self) -> &[Variant<T>] {
+        &self.variants
+    }
 }
 
 /// A struct enum variant with either named (struct) or unnamed (tuple struct)
@@ -120,76 +145,78 @@ where
 /// //  ^^^^^^^^^^^^^^^^^^^^^ this is a struct enum variant
 /// }
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode,
+)]
 #[serde(bound(
-	serialize = "T::Type: Serialize, T::String: Serialize",
-	deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
 ))]
 pub struct Variant<T: Form = MetaForm> {
-	/// The name of the variant.
-	name: T::String,
-	/// The fields of the variant.
-	#[serde(skip_serializing_if = "Vec::is_empty", default)]
-	fields: Vec<Field<T>>,
-	/// The discriminant of the variant.
-	///
-	/// # Note
-	///
-	/// Even though setting the discriminant is optional
-	/// every C-like enum variant has a discriminant specified
-	/// upon compile-time.
-	#[serde(skip_serializing_if = "Option::is_none", default)]
-	discriminant: Option<u64>,
+    /// The name of the variant.
+    name: T::String,
+    /// The fields of the variant.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    fields: Vec<Field<T>>,
+    /// The discriminant of the variant.
+    ///
+    /// # Note
+    ///
+    /// Even though setting the discriminant is optional
+    /// every C-like enum variant has a discriminant specified
+    /// upon compile-time.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    discriminant: Option<u64>,
 }
 
 impl IntoCompact for Variant {
-	type Output = Variant<CompactForm>;
+    type Output = Variant<CompactForm>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		Variant {
-			name: self.name.into_compact(registry),
-			fields: registry.map_into_compact(self.fields),
-			discriminant: self.discriminant,
-		}
-	}
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        Variant {
+            name: self.name.into_compact(registry),
+            fields: registry.map_into_compact(self.fields),
+            discriminant: self.discriminant,
+        }
+    }
 }
 
 impl Variant {
-	/// Creates a new variant with the given fields.
-	pub fn with_fields<F>(name: &'static str, fields: FieldsBuilder<F>) -> Self {
-		Self {
-			name,
-			fields: fields.done(),
-			discriminant: None,
-		}
-	}
+    /// Creates a new variant with the given fields.
+    pub fn with_fields<F>(name: &'static str, fields: FieldsBuilder<F>) -> Self {
+        Self {
+            name,
+            fields: fields.done(),
+            discriminant: None,
+        }
+    }
 
-	/// Creates a new variant with the given discriminant.
-	pub fn with_discriminant(name: &'static str, discriminant: u64) -> Self {
-		Self {
-			name,
-			fields: Vec::new(),
-			discriminant: Some(discriminant),
-		}
-	}
+    /// Creates a new variant with the given discriminant.
+    pub fn with_discriminant(name: &'static str, discriminant: u64) -> Self {
+        Self {
+            name,
+            fields: Vec::new(),
+            discriminant: Some(discriminant),
+        }
+    }
 }
 
 impl<T> Variant<T>
 where
-	T: Form,
+    T: Form,
 {
-	/// Returns the name of the variant
-	pub fn name(&self) -> &T::String {
-		&self.name
-	}
+    /// Returns the name of the variant
+    pub fn name(&self) -> &T::String {
+        &self.name
+    }
 
-	/// Returns the fields of the struct variant.
-	pub fn fields(&self) -> &[Field<T>] {
-		&self.fields
-	}
+    /// Returns the fields of the struct variant.
+    pub fn fields(&self) -> &[Field<T>] {
+        &self.fields
+    }
 
-	/// Returns the discriminant of the variant.
-	pub fn discriminant(&self) -> Option<u64> {
-		self.discriminant
-	}
+    /// Returns the discriminant of the variant.
+    pub fn discriminant(&self) -> Option<u64> {
+        self.discriminant
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,20 +14,24 @@
 
 /// Returns `true` if the given string is a proper Rust identifier.
 pub fn is_rust_identifier(s: &str) -> bool {
-	// Only ascii encoding is allowed.
-	// Note: Maybe this check is superseded by the `head` and `tail` check.
-	if !s.is_ascii() {
-		return false;
-	}
-	if let Some((&head, tail)) = s.as_bytes().split_first() {
-		// Check if head and tail make up a proper Rust identifier.
-		let head_ok = head == b'_' || head >= b'a' && head <= b'z' || head >= b'A' && head <= b'Z';
-		let tail_ok = tail
-			.iter()
-			.all(|&ch| ch == b'_' || ch >= b'a' && ch <= b'z' || ch >= b'A' && ch <= b'Z' || ch >= b'0' && ch <= b'9');
-		head_ok && tail_ok
-	} else {
-		// String is empty and thus not a valid Rust identifier.
-		false
-	}
+    // Only ascii encoding is allowed.
+    // Note: Maybe this check is superseded by the `head` and `tail` check.
+    if !s.is_ascii() {
+        return false
+    }
+    if let Some((&head, tail)) = s.as_bytes().split_first() {
+        // Check if head and tail make up a proper Rust identifier.
+        let head_ok =
+            head == b'_' || head >= b'a' && head <= b'z' || head >= b'A' && head <= b'Z';
+        let tail_ok = tail.iter().all(|&ch| {
+            ch == b'_'
+                || ch >= b'a' && ch <= b'z'
+                || ch >= b'A' && ch <= b'Z'
+                || ch >= b'0' && ch <= b'9'
+        });
+        head_ok && tail_ok
+    } else {
+        // String is empty and thus not a valid Rust identifier.
+        false
+    }
 }

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -20,51 +20,72 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::{
+    vec,
+    vec::Vec,
+};
 use core::num::NonZeroU32;
-use pretty_assertions::{assert_eq, assert_ne};
-use scale::{Decode, Encode};
-use scale_info::{form::CompactForm, IntoCompact as _, MetaType, Registry, RegistryReadOnly, TypeInfo};
+use pretty_assertions::{
+    assert_eq,
+    assert_ne,
+};
+use scale::{
+    Decode,
+    Encode,
+};
+use scale_info::{
+    form::CompactForm,
+    IntoCompact as _,
+    MetaType,
+    Registry,
+    RegistryReadOnly,
+    TypeInfo,
+};
 
 #[derive(TypeInfo)]
 struct A<T> {
-	a: bool,
-	b: Result<char, u32>,
-	c: T,
+    a: bool,
+    b: Result<char, u32>,
+    c: T,
 }
 
 #[derive(TypeInfo)]
 enum B {
-	A,
-	B(A<bool>),
-	C { d: [u8; 32] },
+    A,
+    B(A<bool>),
+    C { d: [u8; 32] },
 }
 
 #[test]
 fn scale_encode_then_decode_to_readonly() {
-	let mut registry = Registry::new();
-	registry.register_type(&MetaType::new::<A<B>>());
+    let mut registry = Registry::new();
+    registry.register_type(&MetaType::new::<A<B>>());
 
-	let mut encoded = registry.encode();
-	let original_serialized = serde_json::to_value(registry).unwrap();
+    let mut encoded = registry.encode();
+    let original_serialized = serde_json::to_value(registry).unwrap();
 
-	let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
-	assert!(readonly_decoded.resolve(NonZeroU32::new(1).unwrap()).is_some());
-	let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
+    let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
+    assert!(readonly_decoded
+        .resolve(NonZeroU32::new(1).unwrap())
+        .is_some());
+    let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
 
-	assert_eq!(decoded_serialized, original_serialized);
+    assert_eq!(decoded_serialized, original_serialized);
 }
 
 #[test]
 fn json_serialize_then_deserialize_to_readonly() {
-	let mut registry = Registry::new();
-	registry.register_type(&MetaType::new::<A<B>>());
+    let mut registry = Registry::new();
+    registry.register_type(&MetaType::new::<A<B>>());
 
-	let original_serialized = serde_json::to_value(registry).unwrap();
-	// assert_eq!(original_serialized, serde_json::Value::Null);
-	let readonly_deserialized: RegistryReadOnly = serde_json::from_value(original_serialized.clone()).unwrap();
-	assert!(readonly_deserialized.resolve(NonZeroU32::new(1).unwrap()).is_some());
-	let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
+    let original_serialized = serde_json::to_value(registry).unwrap();
+    // assert_eq!(original_serialized, serde_json::Value::Null);
+    let readonly_deserialized: RegistryReadOnly =
+        serde_json::from_value(original_serialized.clone()).unwrap();
+    assert!(readonly_deserialized
+        .resolve(NonZeroU32::new(1).unwrap())
+        .is_some());
+    let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
 
-	assert_eq!(readonly_serialized, original_serialized);
+    assert_eq!(readonly_serialized, original_serialized);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -21,133 +21,144 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
-use scale_info::build::*;
-use scale_info::{tuple_meta_type, Path, Type, TypeInfo};
+use scale_info::{
+    build::*,
+    tuple_meta_type,
+    Path,
+    Type,
+    TypeInfo,
+};
 
 fn assert_type<T, E>(expected: E)
 where
-	T: TypeInfo + ?Sized,
-	E: Into<Type>,
+    T: TypeInfo + ?Sized,
+    E: Into<Type>,
 {
-	assert_eq!(T::type_info(), expected.into());
+    assert_eq!(T::type_info(), expected.into());
 }
 
 macro_rules! assert_type {
-	( $ty:ty, $expected:expr ) => {{
-		assert_type::<$ty, _>($expected)
-		}};
+    ( $ty:ty, $expected:expr ) => {{
+        assert_type::<$ty, _>($expected)
+    }};
 }
 
 #[test]
 fn struct_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	struct S<T, U> {
-		pub t: T,
-		pub u: U,
-	}
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct S<T, U> {
+        pub t: T,
+        pub u: U,
+    }
 
-	let struct_type = Type::builder()
-		.path(Path::new("S", "derive"))
-		.type_params(tuple_meta_type!(bool, u8))
-		.composite(Fields::named().field_of::<bool>("t").field_of::<u8>("u"));
+    let struct_type = Type::builder()
+        .path(Path::new("S", "derive"))
+        .type_params(tuple_meta_type!(bool, u8))
+        .composite(Fields::named().field_of::<bool>("t").field_of::<u8>("u"));
 
-	assert_type!(S<bool, u8>, struct_type);
+    assert_type!(S<bool, u8>, struct_type);
 
-	// With "`Self` typed" fields
+    // With "`Self` typed" fields
 
-	type SelfTyped = S<Box<S<bool, u8>>, bool>;
+    type SelfTyped = S<Box<S<bool, u8>>, bool>;
 
-	let self_typed_type = Type::builder()
-		.path(Path::new("S", "derive"))
-		.type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
-		.composite(Fields::named().field_of::<Box<S<bool, u8>>>("t").field_of::<bool>("u"));
-	assert_type!(SelfTyped, self_typed_type);
+    let self_typed_type = Type::builder()
+        .path(Path::new("S", "derive"))
+        .type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
+        .composite(
+            Fields::named()
+                .field_of::<Box<S<bool, u8>>>("t")
+                .field_of::<bool>("u"),
+        );
+    assert_type!(SelfTyped, self_typed_type);
 }
 
 #[test]
 fn tuple_struct_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	struct S<T>(T);
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct S<T>(T);
 
-	let ty = Type::builder()
-		.path(Path::new("S", "derive"))
-		.type_params(tuple_meta_type!(bool))
-		.composite(Fields::unnamed().field_of::<bool>());
+    let ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .type_params(tuple_meta_type!(bool))
+        .composite(Fields::unnamed().field_of::<bool>());
 
-	assert_type!(S<bool>, ty);
+    assert_type!(S<bool>, ty);
 }
 
 #[test]
 fn unit_struct_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	struct S;
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct S;
 
-	let ty = Type::builder().path(Path::new("S", "derive")).composite(Fields::unit());
+    let ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .composite(Fields::unit());
 
-	assert_type!(S, ty);
+    assert_type!(S, ty);
 }
 
 #[test]
 fn c_like_enum_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	enum E {
-		A,
-		B = 10,
-	}
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    enum E {
+        A,
+        B = 10,
+    }
 
-	let ty = Type::builder()
-		.path(Path::new("E", "derive"))
-		.variant(Variants::fieldless().variant("A", 0u64).variant("B", 10u64));
+    let ty = Type::builder()
+        .path(Path::new("E", "derive"))
+        .variant(Variants::fieldless().variant("A", 0u64).variant("B", 10u64));
 
-	assert_type!(E, ty);
+    assert_type!(E, ty);
 }
 
 #[test]
 fn enum_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	enum E<T> {
-		A(T),
-		B { b: T },
-		C,
-	}
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    enum E<T> {
+        A(T),
+        B { b: T },
+        C,
+    }
 
-	let ty = Type::builder()
-		.path(Path::new("E", "derive"))
-		.type_params(tuple_meta_type!(bool))
-		.variant(
-			Variants::with_fields()
-				.variant("A", Fields::unnamed().field_of::<bool>())
-				.variant("B", Fields::named().field_of::<bool>("b"))
-				.variant_unit("C"),
-		);
+    let ty = Type::builder()
+        .path(Path::new("E", "derive"))
+        .type_params(tuple_meta_type!(bool))
+        .variant(
+            Variants::with_fields()
+                .variant("A", Fields::unnamed().field_of::<bool>())
+                .variant("B", Fields::named().field_of::<bool>("b"))
+                .variant_unit("C"),
+        );
 
-	assert_type!(E<bool>, ty);
+    assert_type!(E<bool>, ty);
 }
 
 #[test]
 fn recursive_type_derive() {
-	#[allow(unused)]
-	#[derive(TypeInfo)]
-	pub enum Tree {
-		Leaf { value: i32 },
-		Node { right: Box<Tree>, left: Box<Tree> },
-	}
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    pub enum Tree {
+        Leaf { value: i32 },
+        Node { right: Box<Tree>, left: Box<Tree> },
+    }
 
-	let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
-		Variants::with_fields()
-			.variant("Leaf", Fields::named().field_of::<i32>("value"))
-			.variant(
-				"Node",
-				Fields::named()
-					.field_of::<Box<Tree>>("right")
-					.field_of::<Box<Tree>>("left"),
-			),
-	);
+    let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
+        Variants::with_fields()
+            .variant("Leaf", Fields::named().field_of::<i32>("value"))
+            .variant(
+                "Node",
+                Fields::named()
+                    .field_of::<Box<Tree>>("right")
+                    .field_of::<Box<Tree>>("left"),
+            ),
+    );
 
-	assert_type!(Tree, ty);
+    assert_type!(Tree, ty);
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -20,456 +20,481 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{
+    boxed::Box,
+    vec,
+    vec::Vec,
+};
 
-use pretty_assertions::{assert_eq, assert_ne};
-use scale_info::{form::CompactForm, meta_type, IntoCompact as _, Registry, TypeInfo};
+use pretty_assertions::{
+    assert_eq,
+    assert_ne,
+};
+use scale_info::{
+    form::CompactForm,
+    meta_type,
+    IntoCompact as _,
+    Registry,
+    TypeInfo,
+};
 use serde_json::json;
 
 fn assert_json_for_type<T>(expected_json: serde_json::Value)
 where
-	T: TypeInfo + ?Sized,
+    T: TypeInfo + ?Sized,
 {
-	let mut registry = Registry::new();
+    let mut registry = Registry::new();
 
-	let ty = T::type_info().into_compact(&mut registry);
+    let ty = T::type_info().into_compact(&mut registry);
 
-	assert_eq!(serde_json::to_value(ty).unwrap(), expected_json,);
+    assert_eq!(serde_json::to_value(ty).unwrap(), expected_json,);
 }
 
 #[test]
 fn test_primitives() {
-	assert_json_for_type::<bool>(json!({ "def": { "primitive": "bool" } }));
-	assert_json_for_type::<char>(json!({ "def": { "primitive": "char" } }));
-	assert_json_for_type::<u8>(json!({ "def": { "primitive": "u8" } }));
-	assert_json_for_type::<u16>(json!({ "def": { "primitive": "u16" } }));
-	assert_json_for_type::<u32>(json!({ "def": { "primitive": "u32" } }));
-	assert_json_for_type::<u64>(json!({ "def": { "primitive": "u64" } }));
-	assert_json_for_type::<u128>(json!({ "def": { "primitive": "u128" } }));
-	assert_json_for_type::<i16>(json!({ "def": { "primitive": "i16" } }));
-	assert_json_for_type::<i32>(json!({ "def": { "primitive": "i32" } }));
-	assert_json_for_type::<i64>(json!({ "def": { "primitive": "i64" } }));
-	assert_json_for_type::<i128>(json!({ "def": { "primitive": "i128" } }));
+    assert_json_for_type::<bool>(json!({ "def": { "primitive": "bool" } }));
+    assert_json_for_type::<char>(json!({ "def": { "primitive": "char" } }));
+    assert_json_for_type::<u8>(json!({ "def": { "primitive": "u8" } }));
+    assert_json_for_type::<u16>(json!({ "def": { "primitive": "u16" } }));
+    assert_json_for_type::<u32>(json!({ "def": { "primitive": "u32" } }));
+    assert_json_for_type::<u64>(json!({ "def": { "primitive": "u64" } }));
+    assert_json_for_type::<u128>(json!({ "def": { "primitive": "u128" } }));
+    assert_json_for_type::<i16>(json!({ "def": { "primitive": "i16" } }));
+    assert_json_for_type::<i32>(json!({ "def": { "primitive": "i32" } }));
+    assert_json_for_type::<i64>(json!({ "def": { "primitive": "i64" } }));
+    assert_json_for_type::<i128>(json!({ "def": { "primitive": "i128" } }));
 }
 
 #[test]
 fn test_builtins() {
-	// arrays
-	assert_json_for_type::<[u8; 2]>(json!({ "def": { "array": { "len": 2, "type": 1 } } }));
-	assert_json_for_type::<[bool; 4]>(json!({ "def": { "array": { "len": 4, "type": 1 } } }));
-	assert_json_for_type::<[char; 8]>(json!({ "def": { "array": { "len": 8, "type": 1 } } }));
-	// tuples
-	assert_json_for_type::<(u8, bool)>(json!({ "def": { "tuple": [ 1, 2 ] } }));
-	assert_json_for_type::<(u8, bool, char, u128)>(json!({ "def": { "tuple": [ 1, 2, 3, 4 ] } }));
-	assert_json_for_type::<(u8, bool, char, u128, i32, u32)>(json!({
-		"def": {
-			"tuple": [ 1, 2, 3, 4, 5, 6 ]
-		}
-	}));
-	// sequences
-	assert_json_for_type::<[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
-	assert_json_for_type::<&[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
-	assert_json_for_type::<Vec<bool>>(json!({ "def": { "sequence": { "type": 1 } } }));
-	// complex types
-	assert_json_for_type::<Option<&str>>(json!({
-		"path": ["Option"],
-		"params": [1],
-		"def": {
-			"variant": {
-				"variants": [
-					{
-						"name": "None",
-					},
-					{
-						"name": "Some",
-						"fields": [ { "type": 1 } ]
-					},
-				]
-			}
-		}
-	}));
-	assert_json_for_type::<Result<u32, u64>>(json!({
-		"path": ["Result"],
-		"params": [1, 2],
-		"def": {
-			"variant": {
-				"variants": [
-					{
-						"name": "Ok",
-						"fields": [ { "type": 1 } ]
-					},
-					{
-						"name": "Err",
-						"fields": [ { "type": 2 } ]
-					}
-				]
-			}
-		}
-	}));
-	// references
-	assert_json_for_type::<&bool>(json!({ "def": { "primitive": "bool" } }));
-	assert_json_for_type::<&mut str>(json!({ "def": { "primitive": "str" } }));
-	assert_json_for_type::<alloc::boxed::Box<u32>>(json!({ "def": { "primitive": "u32" } }));
-	// strings
-	assert_json_for_type::<alloc::string::String>(json!({ "def": { "primitive": "str" } }));
-	assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
-	// PhantomData
-	assert_json_for_type::<core::marker::PhantomData<bool>>(json!({
-		"path": ["PhantomData"],
-		"params": [1],
-		"def": {
-			"composite": {},
-		}
-	}))
+    // arrays
+    assert_json_for_type::<[u8; 2]>(
+        json!({ "def": { "array": { "len": 2, "type": 1 } } }),
+    );
+    assert_json_for_type::<[bool; 4]>(
+        json!({ "def": { "array": { "len": 4, "type": 1 } } }),
+    );
+    assert_json_for_type::<[char; 8]>(
+        json!({ "def": { "array": { "len": 8, "type": 1 } } }),
+    );
+    // tuples
+    assert_json_for_type::<(u8, bool)>(json!({ "def": { "tuple": [ 1, 2 ] } }));
+    assert_json_for_type::<(u8, bool, char, u128)>(
+        json!({ "def": { "tuple": [ 1, 2, 3, 4 ] } }),
+    );
+    assert_json_for_type::<(u8, bool, char, u128, i32, u32)>(json!({
+        "def": {
+            "tuple": [ 1, 2, 3, 4, 5, 6 ]
+        }
+    }));
+    // sequences
+    assert_json_for_type::<[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
+    assert_json_for_type::<&[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
+    assert_json_for_type::<Vec<bool>>(json!({ "def": { "sequence": { "type": 1 } } }));
+    // complex types
+    assert_json_for_type::<Option<&str>>(json!({
+        "path": ["Option"],
+        "params": [1],
+        "def": {
+            "variant": {
+                "variants": [
+                    {
+                        "name": "None",
+                    },
+                    {
+                        "name": "Some",
+                        "fields": [ { "type": 1 } ]
+                    },
+                ]
+            }
+        }
+    }));
+    assert_json_for_type::<Result<u32, u64>>(json!({
+        "path": ["Result"],
+        "params": [1, 2],
+        "def": {
+            "variant": {
+                "variants": [
+                    {
+                        "name": "Ok",
+                        "fields": [ { "type": 1 } ]
+                    },
+                    {
+                        "name": "Err",
+                        "fields": [ { "type": 2 } ]
+                    }
+                ]
+            }
+        }
+    }));
+    // references
+    assert_json_for_type::<&bool>(json!({ "def": { "primitive": "bool" } }));
+    assert_json_for_type::<&mut str>(json!({ "def": { "primitive": "str" } }));
+    assert_json_for_type::<alloc::boxed::Box<u32>>(
+        json!({ "def": { "primitive": "u32" } }),
+    );
+    // strings
+    assert_json_for_type::<alloc::string::String>(
+        json!({ "def": { "primitive": "str" } }),
+    );
+    assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
+    // PhantomData
+    assert_json_for_type::<core::marker::PhantomData<bool>>(json!({
+        "path": ["PhantomData"],
+        "params": [1],
+        "def": {
+            "composite": {},
+        }
+    }))
 }
 
 #[test]
 fn test_unit_struct() {
-	#[derive(TypeInfo)]
-	struct UnitStruct;
+    #[derive(TypeInfo)]
+    struct UnitStruct;
 
-	assert_json_for_type::<UnitStruct>(json!({
-		"path": ["json", "UnitStruct"],
-		"def": {
-			"composite": {},
-		}
-	}));
+    assert_json_for_type::<UnitStruct>(json!({
+        "path": ["json", "UnitStruct"],
+        "def": {
+            "composite": {},
+        }
+    }));
 }
 
 #[test]
 fn test_tuplestruct() {
-	#[derive(TypeInfo)]
-	struct TupleStruct(i32, [u8; 32], bool);
+    #[derive(TypeInfo)]
+    struct TupleStruct(i32, [u8; 32], bool);
 
-	assert_json_for_type::<TupleStruct>(json!({
-		"path": ["json", "TupleStruct"],
-		"def": {
-			"composite": {
-				"fields": [
-					{ "type": 1 },
-					{ "type": 2 },
-					{ "type": 4 },
-				],
-			},
-		}
-	}));
+    assert_json_for_type::<TupleStruct>(json!({
+        "path": ["json", "TupleStruct"],
+        "def": {
+            "composite": {
+                "fields": [
+                    { "type": 1 },
+                    { "type": 2 },
+                    { "type": 4 },
+                ],
+            },
+        }
+    }));
 }
 
 #[test]
 fn test_struct() {
-	#[derive(TypeInfo)]
-	struct Struct {
-		a: i32,
-		b: [u8; 32],
-		c: bool,
-	}
+    #[derive(TypeInfo)]
+    struct Struct {
+        a: i32,
+        b: [u8; 32],
+        c: bool,
+    }
 
-	assert_json_for_type::<Struct>(json!({
-		"path": ["json", "Struct"],
-		"def": {
-			"composite": {
-				"fields": [
-					{ "name": "a", "type": 1, },
-					{ "name": "b", "type": 2, },
-					{ "name": "c", "type": 4, },
-				],
-			},
-		}
-	}));
+    assert_json_for_type::<Struct>(json!({
+        "path": ["json", "Struct"],
+        "def": {
+            "composite": {
+                "fields": [
+                    { "name": "a", "type": 1, },
+                    { "name": "b", "type": 2, },
+                    { "name": "c", "type": 4, },
+                ],
+            },
+        }
+    }));
 }
 
 #[test]
 fn test_clike_enum() {
-	#[derive(TypeInfo)]
-	enum ClikeEnum {
-		A,
-		B = 42,
-		C,
-	}
+    #[derive(TypeInfo)]
+    enum ClikeEnum {
+        A,
+        B = 42,
+        C,
+    }
 
-	assert_json_for_type::<ClikeEnum>(json!({
-		"path": ["json", "ClikeEnum"],
-		"def": {
-			"variant": {
-				"variants": [
-					{ "name": "A", "discriminant": 0, },
-					{ "name": "B", "discriminant": 42, },
-					{ "name": "C", "discriminant": 2, },
-				],
-			},
-		}
-	}));
+    assert_json_for_type::<ClikeEnum>(json!({
+        "path": ["json", "ClikeEnum"],
+        "def": {
+            "variant": {
+                "variants": [
+                    { "name": "A", "discriminant": 0, },
+                    { "name": "B", "discriminant": 42, },
+                    { "name": "C", "discriminant": 2, },
+                ],
+            },
+        }
+    }));
 }
 
 #[test]
 fn test_enum() {
-	#[derive(TypeInfo)]
-	enum Enum {
-		ClikeVariant,
-		TupleStructVariant(u32, bool),
-		StructVariant { a: u32, b: [u8; 32], c: char },
-	}
+    #[derive(TypeInfo)]
+    enum Enum {
+        ClikeVariant,
+        TupleStructVariant(u32, bool),
+        StructVariant { a: u32, b: [u8; 32], c: char },
+    }
 
-	assert_json_for_type::<Enum>(json!({
-		"path": ["json", "Enum"],
-		"def": {
-			"variant": {
-				"variants": [
-					{ "name": "ClikeVariant" },
-					{
-						"name": "TupleStructVariant",
-						"fields": [
-							{ "type": 1 },
-							{ "type": 2 },
-						],
-					},
-					{
-						"name": "StructVariant",
-						"fields": [
-							{ "name": "a", "type": 1, },
-							{ "name": "b", "type": 3, },
-							{ "name": "c", "type": 5, },
-						],
-					}
-				],
-			},
-		}
-	}));
+    assert_json_for_type::<Enum>(json!({
+        "path": ["json", "Enum"],
+        "def": {
+            "variant": {
+                "variants": [
+                    { "name": "ClikeVariant" },
+                    {
+                        "name": "TupleStructVariant",
+                        "fields": [
+                            { "type": 1 },
+                            { "type": 2 },
+                        ],
+                    },
+                    {
+                        "name": "StructVariant",
+                        "fields": [
+                            { "name": "a", "type": 1, },
+                            { "name": "b", "type": 3, },
+                            { "name": "c", "type": 5, },
+                        ],
+                    }
+                ],
+            },
+        }
+    }));
 }
 
 #[test]
 fn test_recursive_type_with_box() {
-	#[derive(TypeInfo)]
-	pub enum Tree {
-		Leaf { value: i32 },
-		Node { right: Box<Tree>, left: Box<Tree> },
-	}
+    #[derive(TypeInfo)]
+    pub enum Tree {
+        Leaf { value: i32 },
+        Node { right: Box<Tree>, left: Box<Tree> },
+    }
 
-	let mut registry = Registry::new();
-	registry.register_type(&meta_type::<Tree>());
+    let mut registry = Registry::new();
+    registry.register_type(&meta_type::<Tree>());
 
-	let expected_json = json!({
-		"types": [
-			{
-				"path": ["json", "Tree"],
-				"def": {
-					"variant": {
-						"variants": [
-							{
-								"name": "Leaf",
-								"fields": [
-									{ "name": "value", "type": 2 },
-								],
-							},
-							{
-								"name": "Node",
-								"fields": [
-									{ "name": "right", "type": 1, },
-									{ "name": "left", "type": 1, },
-								],
-							}
-						],
-					},
-				}
-			},
-			{
-				"def": { "primitive": "i32" },
-			},
-		]
-	});
+    let expected_json = json!({
+        "types": [
+            {
+                "path": ["json", "Tree"],
+                "def": {
+                    "variant": {
+                        "variants": [
+                            {
+                                "name": "Leaf",
+                                "fields": [
+                                    { "name": "value", "type": 2 },
+                                ],
+                            },
+                            {
+                                "name": "Node",
+                                "fields": [
+                                    { "name": "right", "type": 1, },
+                                    { "name": "left", "type": 1, },
+                                ],
+                            }
+                        ],
+                    },
+                }
+            },
+            {
+                "def": { "primitive": "i32" },
+            },
+        ]
+    });
 
-	assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
+    assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }
 
 #[test]
 fn test_registry() {
-	let mut registry = Registry::new();
+    let mut registry = Registry::new();
 
-	#[derive(TypeInfo)]
-	struct UnitStruct;
-	#[derive(TypeInfo)]
-	struct TupleStruct(u8, u32);
-	#[derive(TypeInfo)]
-	struct Struct {
-		a: u8,
-		b: u32,
-		c: [u8; 32],
-	}
-	#[derive(TypeInfo)]
-	struct RecursiveStruct {
-		rec: Vec<RecursiveStruct>,
-	}
-	#[derive(TypeInfo)]
-	enum ClikeEnum {
-		A,
-		B,
-		C,
-	}
-	#[derive(TypeInfo)]
-	enum RustEnum {
-		A,
-		B(u8, u32),
-		C { a: u8, b: u32, c: [u8; 32] },
-	}
+    #[derive(TypeInfo)]
+    struct UnitStruct;
+    #[derive(TypeInfo)]
+    struct TupleStruct(u8, u32);
+    #[derive(TypeInfo)]
+    struct Struct {
+        a: u8,
+        b: u32,
+        c: [u8; 32],
+    }
+    #[derive(TypeInfo)]
+    struct RecursiveStruct {
+        rec: Vec<RecursiveStruct>,
+    }
+    #[derive(TypeInfo)]
+    enum ClikeEnum {
+        A,
+        B,
+        C,
+    }
+    #[derive(TypeInfo)]
+    enum RustEnum {
+        A,
+        B(u8, u32),
+        C { a: u8, b: u32, c: [u8; 32] },
+    }
 
-	registry.register_type(&meta_type::<UnitStruct>());
-	registry.register_type(&meta_type::<TupleStruct>());
-	registry.register_type(&meta_type::<Struct>());
-	registry.register_type(&meta_type::<RecursiveStruct>());
-	registry.register_type(&meta_type::<ClikeEnum>());
-	registry.register_type(&meta_type::<RustEnum>());
+    registry.register_type(&meta_type::<UnitStruct>());
+    registry.register_type(&meta_type::<TupleStruct>());
+    registry.register_type(&meta_type::<Struct>());
+    registry.register_type(&meta_type::<RecursiveStruct>());
+    registry.register_type(&meta_type::<ClikeEnum>());
+    registry.register_type(&meta_type::<RustEnum>());
 
-	let expected_json = json!({
-		"types": [
-			{ // type 1
-				"path": [
-					"json",
-					"UnitStruct",
-				],
-				"def": {
-					"composite": {},
-				}
-			},
-			{ // type 2
-				"path": [
-					"json",
-					"TupleStruct",
-				],
-				"def": {
-					"composite": {
-						"fields": [
-							{ "type": 3 },
-							{ "type": 4 },
-						],
-					},
-				}
-			},
-			{ // type 3
-				"def": { "primitive": "u8" },
-			},
-			{ // type 4
-				"def": { "primitive": "u32" },
-			},
-			{ // type 5
-				"path": [
-					"json",
-					"Struct",
-				],
-				"def": {
-					"composite": {
-						"fields": [
-							{
-								"name": "a",
-								"type": 3, // u8
-							},
-							{
-								"name": "b",
-								"type": 4, // u32
-							},
-							{
-								"name": "c",
-								"type": 6, // [u8; 32]
-							}
-						]
-					},
-				}
-			},
-			{ // type 6
-				"def": {
-					"array": {
-						"len": 32,
-						"type": 3, // u8
-					},
-				}
-			},
-			{ // type 7
-				"path": [
-					"json",
-					"RecursiveStruct",
-				],
-				"def": {
-					"composite": {
-						"fields": [
-							{
-								"name": "rec",
-								"type": 8, // Vec<RecursiveStruct>
-							}
-						]
-					},
-				}
-			},
-			{ // type 8
-				"def": {
-					"sequence": {
-						"type": 7, // RecursiveStruct
-					},
-				}
-			},
-			{ // type 9
-				"path": [
-					"json",
-					"ClikeEnum",
-				],
-				"def": {
-					"variant": {
-						"variants": [
-							{
-								"name": "A",
-								"discriminant": 0,
-							},
-							{
-								"name": "B",
-								"discriminant": 1,
-							},
-							{
-								"name": "C",
-								"discriminant": 2,
-							},
-						]
-					}
-				}
-			},
-			{ // type 10
-				"path": [
-					"json",
-					"RustEnum"
-				],
-				"def": {
-					"variant": {
-						"variants": [
-							{
-								"name": "A"
-							},
-							{
-								"name": "B",
-								"fields": [
-									{ "type": 3 }, // u8
-									{ "type": 4 }, // u32
-								]
-							},
-							{
-								"name": "C",
-								"fields": [
-									{
-										"name": "a",
-										"type": 3, // u8
-									},
-									{
-										"name": "b",
-										"type": 4, // u32
-									},
-									{
-										"name": "c",
-										"type": 6, // [u8; 32]
-									}
-								]
-							}
-						]
-					},
-				}
-			},
-		]
-	});
+    let expected_json = json!({
+        "types": [
+            { // type 1
+                "path": [
+                    "json",
+                    "UnitStruct",
+                ],
+                "def": {
+                    "composite": {},
+                }
+            },
+            { // type 2
+                "path": [
+                    "json",
+                    "TupleStruct",
+                ],
+                "def": {
+                    "composite": {
+                        "fields": [
+                            { "type": 3 },
+                            { "type": 4 },
+                        ],
+                    },
+                }
+            },
+            { // type 3
+                "def": { "primitive": "u8" },
+            },
+            { // type 4
+                "def": { "primitive": "u32" },
+            },
+            { // type 5
+                "path": [
+                    "json",
+                    "Struct",
+                ],
+                "def": {
+                    "composite": {
+                        "fields": [
+                            {
+                                "name": "a",
+                                "type": 3, // u8
+                            },
+                            {
+                                "name": "b",
+                                "type": 4, // u32
+                            },
+                            {
+                                "name": "c",
+                                "type": 6, // [u8; 32]
+                            }
+                        ]
+                    },
+                }
+            },
+            { // type 6
+                "def": {
+                    "array": {
+                        "len": 32,
+                        "type": 3, // u8
+                    },
+                }
+            },
+            { // type 7
+                "path": [
+                    "json",
+                    "RecursiveStruct",
+                ],
+                "def": {
+                    "composite": {
+                        "fields": [
+                            {
+                                "name": "rec",
+                                "type": 8, // Vec<RecursiveStruct>
+                            }
+                        ]
+                    },
+                }
+            },
+            { // type 8
+                "def": {
+                    "sequence": {
+                        "type": 7, // RecursiveStruct
+                    },
+                }
+            },
+            { // type 9
+                "path": [
+                    "json",
+                    "ClikeEnum",
+                ],
+                "def": {
+                    "variant": {
+                        "variants": [
+                            {
+                                "name": "A",
+                                "discriminant": 0,
+                            },
+                            {
+                                "name": "B",
+                                "discriminant": 1,
+                            },
+                            {
+                                "name": "C",
+                                "discriminant": 2,
+                            },
+                        ]
+                    }
+                }
+            },
+            { // type 10
+                "path": [
+                    "json",
+                    "RustEnum"
+                ],
+                "def": {
+                    "variant": {
+                        "variants": [
+                            {
+                                "name": "A"
+                            },
+                            {
+                                "name": "B",
+                                "fields": [
+                                    { "type": 3 }, // u8
+                                    { "type": 4 }, // u32
+                                ]
+                            },
+                            {
+                                "name": "C",
+                                "fields": [
+                                    {
+                                        "name": "a",
+                                        "type": 3, // u8
+                                    },
+                                    {
+                                        "name": "b",
+                                        "type": 4, // u32
+                                    },
+                                    {
+                                        "name": "c",
+                                        "type": 6, // [u8; 32]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                }
+            },
+        ]
+    });
 
-	assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
+    assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }


### PR DESCRIPTION
Copies `.rustfmt.toml` and `.editorconfig` from the `ink!` repo.