### PR TITLE
Add informational field type name

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -19,7 +19,7 @@ extern crate proc_macro;
 
 mod impl_wrapper;
 
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -91,15 +91,39 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
 		.iter()
 		.map(|f| {
 			let (ty, ident) = (&f.ty, &f.ident);
-			if let Some(i) = ident {
-				quote! {
-					.field_of::<#ty>(stringify!(#i))
-				}
-			} else {
-				quote! {
-					.field_of::<#ty>()
-				}
-			}
+
+			let display_name =
+				if let syn::Type::Path(type_path) = ty {
+					if type_path.qself.is_some() || type_path.path.segments.is_empty() {
+						quote! {}
+					} else {
+						let segs = type_path
+							.path
+							.segments
+							.iter()
+							.map(|seg| seg.ident.to_string())
+							.collect::<Vec<_>>();
+						quote! {
+							.with_type_display_name(
+								vec![#(#segs),*].into_iter().map(AsRef::as_ref)
+							)
+						}
+					}
+				} else {
+					quote! {}
+				};
+
+			let field =
+				if let Some(i) = ident {
+					quote! {
+						_scale_info::Field::named_of::<#ty>(stringify!(#i))#display_name
+					}
+				} else {
+					quote! {
+						_scale_info::Field::unnamed_of::<#ty>()#display_name
+					}
+				};
+			quote! { .field(#field) }
 		})
 		.collect()
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -19,7 +19,13 @@ extern crate proc_macro;
 
 mod impl_wrapper;
 
-use alloc::vec::Vec;
+use alloc::{
+    string::{
+        String,
+        ToString,
+    },
+    vec::Vec,
+};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -104,18 +110,36 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
         .iter()
         .map(|f| {
             let (ty, ident) = (&f.ty, &f.ident);
+            let type_name = clean_type_string(&quote!(#ty).to_string());
 
             if let Some(i) = ident {
                 quote! {
-                    .field_of::<#ty>(stringify!(#i), stringify!(#ty))
+                    .field_of::<#ty>(stringify!(#i), #type_name)
                 }
             } else {
                 quote! {
-                    .field_of::<#ty>(stringify!(#ty))
+                    .field_of::<#ty>(#type_name)
                 }
             }
         })
         .collect()
+}
+
+fn clean_type_string(input: &str) -> String {
+    input
+        .replace(" ::", "::")
+        .replace(":: ", "::")
+        .replace(" ,", ",")
+        .replace(" ;", ";")
+        .replace(" [", "[")
+        .replace("[ ", "[")
+        .replace(" ]", "]")
+        .replace(" (", "(")
+        .replace("( ", "(")
+        .replace(" )", ")")
+        .replace(" <", "<")
+        .replace("< ", "<")
+        .replace(" >", ">")
 }
 
 fn generate_composite_type(data_struct: &DataStruct) -> TokenStream2 {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -105,7 +105,7 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
 						.collect::<Vec<_>>();
 					quote! {
 						.with_type_display_name(
-							vec![#(#segs),*].into_iter().map(AsRef::as_ref)
+							__core::vec![#(#segs),*].into_iter().map(AsRef::as_ref)
 						)
 					}
 				}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -19,10 +19,7 @@ extern crate proc_macro;
 
 mod impl_wrapper;
 
-use alloc::{
-    string::ToString,
-    vec::Vec,
-};
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -108,36 +105,15 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
         .map(|f| {
             let (ty, ident) = (&f.ty, &f.ident);
 
-            let display_name = if let syn::Type::Path(type_path) = ty {
-                if type_path.qself.is_some() || type_path.path.segments.is_empty() {
-                    quote! {}
-                } else {
-                    let segs = type_path
-                        .path
-                        .segments
-                        .iter()
-                        .map(|seg| seg.ident.to_string())
-                        .collect::<Vec<_>>();
-                    quote! {
-                        .with_type_display_name(
-                            __core::vec![#(#segs),*].into_iter().map(AsRef::as_ref)
-                        )
-                    }
-                }
-            } else {
-                quote! {}
-            };
-
-            let field = if let Some(i) = ident {
+            if let Some(i) = ident {
                 quote! {
-                    _scale_info::Field::named_of::<#ty>(stringify!(#i))#display_name
+                    .field_of::<#ty>(stringify!(#i), stringify!(#ty))
                 }
             } else {
                 quote! {
-                    _scale_info::Field::unnamed_of::<#ty>()#display_name
+                    .field_of::<#ty>(stringify!(#ty))
                 }
-            };
-            quote! { .field(#field) }
+            }
         })
         .collect()
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -93,37 +93,35 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
 		.map(|f| {
 			let (ty, ident) = (&f.ty, &f.ident);
 
-			let display_name =
-				if let syn::Type::Path(type_path) = ty {
-					if type_path.qself.is_some() || type_path.path.segments.is_empty() {
-						quote! {}
-					} else {
-						let segs = type_path
-							.path
-							.segments
-							.iter()
-							.map(|seg| seg.ident.to_string())
-							.collect::<Vec<_>>();
-						quote! {
-							.with_type_display_name(
-								vec![#(#segs),*].into_iter().map(AsRef::as_ref)
-							)
-						}
-					}
-				} else {
+			let display_name = if let syn::Type::Path(type_path) = ty {
+				if type_path.qself.is_some() || type_path.path.segments.is_empty() {
 					quote! {}
-				};
-
-			let field =
-				if let Some(i) = ident {
-					quote! {
-						_scale_info::Field::named_of::<#ty>(stringify!(#i))#display_name
-					}
 				} else {
+					let segs = type_path
+						.path
+						.segments
+						.iter()
+						.map(|seg| seg.ident.to_string())
+						.collect::<Vec<_>>();
 					quote! {
-						_scale_info::Field::unnamed_of::<#ty>()#display_name
+						.with_type_display_name(
+							vec![#(#segs),*].into_iter().map(AsRef::as_ref)
+						)
 					}
-				};
+				}
+			} else {
+				quote! {}
+			};
+
+			let field = if let Some(i) = ident {
+				quote! {
+					_scale_info::Field::named_of::<#ty>(stringify!(#i))#display_name
+				}
+			} else {
+				quote! {
+					_scale_info::Field::unnamed_of::<#ty>()#display_name
+				}
+			};
 			quote! { .field(#field) }
 		})
 		.collect()

--- a/src/build.rs
+++ b/src/build.rs
@@ -177,12 +177,12 @@ impl TypeBuilder<state::PathAssigned> {
 
     /// Construct a "variant" type i.e an `enum`
     pub fn variant<V>(self, builder: VariantsBuilder<V>) -> Type {
-        self.build(builder.done())
+        self.build(builder.finalize())
     }
 
     /// Construct a "composite" type i.e. a `struct`
     pub fn composite<F>(self, fields: FieldsBuilder<F>) -> Type {
-        self.build(TypeDefComposite::new(fields.done()))
+        self.build(TypeDefComposite::new(fields.finalize()))
     }
 }
 
@@ -247,8 +247,8 @@ impl<T> FieldsBuilder<T> {
     }
 
     /// Complete building and return the set of fields
-    pub fn done(mut self) -> Vec<Field<MetaForm>> {
-        self.fields.drain(..).map(|field| field.done()).collect()
+    pub fn finalize(mut self) -> Vec<Field<MetaForm>> {
+        self.fields.drain(..).map(|field| field.finalize()).collect()
     }
 }
 
@@ -304,7 +304,7 @@ impl<T> FieldBuilder<T> {
     }
 
     /// Complete building the field.
-    pub fn done(self) -> Field {
+    pub fn finalize(self) -> Field {
         Field::new(self.name, self.ty, self.ty_display_name)
     }
 }
@@ -378,7 +378,7 @@ impl<T> VariantsBuilder<T> {
         }
     }
 
-    fn done(self) -> TypeDefVariant {
+    fn finalize(self) -> TypeDefVariant {
         TypeDefVariant::new(self.variants)
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -121,7 +121,7 @@ where
             .variant(
                 Variants::with_fields()
                     .variant_unit("None")
-                    .variant("Some", Fields::unnamed().field_of::<T>()),
+                    .variant("Some", Fields::unnamed().field_of::<T>("T")),
             )
     }
 }
@@ -139,8 +139,8 @@ where
             .type_params(tuple_meta_type!(T, E))
             .variant(
                 Variants::with_fields()
-                    .variant("Ok", Fields::unnamed().field_of::<T>())
-                    .variant("Err", Fields::unnamed().field_of::<E>()),
+                    .variant("Ok", Fields::unnamed().field_of::<T>("T"))
+                    .variant("Err", Fields::unnamed().field_of::<E>("E")),
             )
     }
 }
@@ -156,7 +156,7 @@ where
         Type::builder()
             .path(Path::prelude("BTreeMap"))
             .type_params(tuple_meta_type![(K, V)])
-            .composite(Fields::unnamed().field_of::<[(K, V)]>())
+            .composite(Fields::unnamed().field_of::<[(K, V)]>("[(K, V)]"))
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -266,10 +266,17 @@ mod tests {
                     .path(Path::new("RecursiveRefs", module_path!()))
                     .composite(
                         Fields::named()
-                            .field_of::<Box<RecursiveRefs>>("boxed")
-                            .field_of::<&'static RecursiveRefs<'static>>("reference")
+                            .field_of::<Box<RecursiveRefs>>(
+                                "boxed",
+                                "Box < RecursiveRefs >",
+                            )
+                            .field_of::<&'static RecursiveRefs<'static>>(
+                                "reference",
+                                "&RecursiveRefs",
+                            )
                             .field_of::<&'static mut RecursiveRefs<'static>>(
                                 "mutable_reference",
+                                "&mut RecursiveRefs",
                             ),
                     )
                     .into()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,7 +60,7 @@ fn prelude_items() {
             .variant(
                 Variants::with_fields()
                     .variant_unit("None")
-                    .variant("Some", Fields::unnamed().field_of::<u128>())
+                    .variant("Some", Fields::unnamed().field_of::<u128>("T"))
             )
     );
     assert_type!(
@@ -70,8 +70,8 @@ fn prelude_items() {
             .type_params(tuple_meta_type!(bool, String))
             .variant(
                 Variants::with_fields()
-                    .variant("Ok", Fields::unnamed().field_of::<bool>())
-                    .variant("Err", Fields::unnamed().field_of::<String>())
+                    .variant("Ok", Fields::unnamed().field_of::<bool>("T"))
+                    .variant("Err", Fields::unnamed().field_of::<String>("E"))
             )
     );
     assert_type!(
@@ -133,7 +133,7 @@ fn struct_with_generics() {
             Type::builder()
                 .path(Path::new("MyStruct", module_path!()))
                 .type_params(tuple_meta_type!(T))
-                .composite(Fields::named().field_of::<T>("data"))
+                .composite(Fields::named().field_of::<T>("data", "T"))
                 .into()
         }
     }
@@ -142,7 +142,7 @@ fn struct_with_generics() {
     let struct_bool_type_info = Type::builder()
         .path(Path::from_segments(vec!["scale_info", "tests", "MyStruct"]).unwrap())
         .type_params(tuple_meta_type!(bool))
-        .composite(Fields::named().field_of::<bool>("data"));
+        .composite(Fields::named().field_of::<bool>("data", "T"));
 
     assert_type!(MyStruct<bool>, struct_bool_type_info);
 
@@ -151,6 +151,6 @@ fn struct_with_generics() {
     let expected_type = Type::builder()
         .path(Path::new("MyStruct", "scale_info::tests"))
         .type_params(tuple_meta_type!(Box<MyStruct<bool>>))
-        .composite(Fields::named().field_of::<Box<MyStruct<bool>>>("data"));
+        .composite(Fields::named().field_of::<Box<MyStruct<bool>>>("data", "T"));
     assert_type!(SelfTyped, expected_type);
 }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -147,7 +147,11 @@ where
         &self.ty
     }
 
-    /// The name of the type of the field as it appears in the source code.
+    /// Returns a string which is the name of the type of the field as it
+    /// appears in the source code. The exact contents and format of the type
+    /// name are not specified, but in practice will be the name of any valid
+    /// type for a field. This is intended for informational and diagnostic
+    /// purposes only.
     pub fn type_name(&self) -> &T::String {
         &self.type_name
     }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -15,11 +15,6 @@
 use crate::tm_std::*;
 
 use crate::{
-    build::{
-        FieldBuilder,
-        NamedFields,
-        UnnamedFields,
-    },
     form::{
         CompactForm,
         Form,
@@ -27,7 +22,6 @@ use crate::{
     },
     IntoCompact,
     MetaType,
-    Path,
     Registry,
     TypeInfo,
 };
@@ -45,7 +39,30 @@ use serde::{
 ///
 /// Name is optional so it can represent both named and unnamed fields.
 ///
-/// This can be a named field of a struct type or a struct variant.
+/// This can be a named field of a struct type or an enum struct variant.
+///
+/// # Type name
+///
+/// The `type_name` field contains a string which is the name of the type of the
+/// field as it appears in the source code. The exact contents and format of the
+/// type name are not specified, but in practice will be the name of any valid
+/// type for a field e.g.
+///
+///   - Concrete types e.g `"u32"`, `"bool"`, `"Foo"` etc.
+///   - Type parameters e.g `"T"`, `"U"`
+///   - Generic types e.g `"Vec<u32>"`, `"Vec<T>"`
+///   - Associated types e.g. `"T::MyType"`, `"<T as MyTrait>::MyType"`
+///   - Type aliases e.g. `"MyTypeAlias"`, `"MyTypeAlias<T>"`
+///   - Other built in Rust types e.g. arrays, references etc.
+///
+/// Note that the type name doesn't correspond to the underlying type of the
+/// field, unless using a concrete type directly. Any given type may be referred
+/// to by multiple field type names, when using generic type parameters and type
+/// aliases.
+///
+/// This is intended for informational and diagnostic purposes only. Although it
+/// is possible to infer certain properties e.g. whether a type name is a type alias,
+/// there are no guarantees provided, and the type name representation may change.
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode,
 )]
@@ -61,12 +78,8 @@ pub struct Field<T: Form = MetaForm> {
     /// The type of the field.
     #[serde(rename = "type")]
     ty: T::Type,
-    /// The compile-time known displayed representation of the type of the field. This will be the
-    /// actual name of the type or an alias of it.
-    ///
-    /// Will be `None` if the type has a qualified type path e.g. `<T as Trait>::AssociatedItem`.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    display_name: Option<Path<T>>,
+    /// The name of the type of the field as it appears in the source code.
+    type_name: T::String,
 }
 
 impl IntoCompact for Field {
@@ -76,9 +89,7 @@ impl IntoCompact for Field {
         Field {
             name: self.name.map(|name| name.into_compact(registry)),
             ty: registry.register_type(&self.ty),
-            display_name: self
-                .display_name
-                .map(|display_name| display_name.into_compact(registry)),
+            type_name: self.type_name.into_compact(registry),
         }
     }
 }
@@ -90,12 +101,12 @@ impl Field {
     pub fn new(
         name: Option<&'static str>,
         ty: MetaType,
-        display_name: Option<Path>,
+        type_name: &'static str,
     ) -> Self {
         Self {
             name,
             ty,
-            display_name,
+            type_name,
         }
     }
 
@@ -103,22 +114,22 @@ impl Field {
     ///
     /// Use this constructor if you want to instantiate from a given
     /// compile-time type.
-    pub fn named_of<T>(name: &'static str) -> FieldBuilder<NamedFields>
+    pub fn named_of<T>(name: &'static str, type_name: &'static str) -> Field
     where
         T: TypeInfo + ?Sized + 'static,
     {
-        FieldBuilder::<NamedFields>::new(MetaType::new::<T>()).with_name(name)
+        Self::new(Some(name), MetaType::new::<T>(), type_name)
     }
 
     /// Creates a new unnamed field.
     ///
     /// Use this constructor if you want to instantiate an unnamed field from a
     /// given compile-time type.
-    pub fn unnamed_of<T>() -> FieldBuilder<UnnamedFields>
+    pub fn unnamed_of<T>(type_name: &'static str) -> Field
     where
         T: TypeInfo + ?Sized + 'static,
     {
-        FieldBuilder::<UnnamedFields>::new(MetaType::new::<T>())
+        Self::new(None, MetaType::new::<T>(), type_name)
     }
 }
 
@@ -134,5 +145,10 @@ where
     /// Returns the type of the field.
     pub fn ty(&self) -> &T::Type {
         &self.ty
+    }
+
+    /// The name of the type of the field as it appears in the source code.
+    pub fn type_name(&self) -> &T::String {
+        &self.type_name
     }
 }

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -186,7 +186,7 @@ impl Variant {
     pub fn with_fields<F>(name: &'static str, fields: FieldsBuilder<F>) -> Self {
         Self {
             name,
-            fields: fields.done(),
+            fields: fields.finalize(),
             discriminant: None,
         }
     }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -159,8 +159,8 @@ fn recursive_type_derive() {
             .variant(
                 "Node",
                 Fields::named()
-                    .field_of::<Box<Tree>>("right", "Box < Tree >")
-                    .field_of::<Box<Tree>>("left", "Box < Tree >"),
+                    .field_of::<Box<Tree>>("right", "Box<Tree>")
+                    .field_of::<Box<Tree>>("left", "Box<Tree>"),
             ),
     );
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -147,12 +147,12 @@ fn recursive_type_derive() {
 
 	let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
 		Variants::with_fields()
-			.variant("Leaf", Fields::named().field_of::<i32>("value"))
+			.variant("Leaf", Fields::named().field(Field::named_of::<i32>("value").with_type_display_name(vec!["i32"])))
 			.variant(
 				"Node",
 				Fields::named()
-					.field_of::<Box<Tree>>("right")
-					.field_of::<Box<Tree>>("left"),
+					.field(Field::named_of::<Box<Tree>>("right").with_type_display_name(vec!["Box"]))
+					.field(Field::named_of::<Box<Tree>>("left").with_type_display_name(vec!["Box"])),
 			),
 	);
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -18,16 +18,12 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    vec,
-};
+use alloc::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::{
     build::*,
     tuple_meta_type,
-    Field,
     Path,
     Type,
     TypeInfo,
@@ -61,8 +57,8 @@ fn struct_derive() {
         .type_params(tuple_meta_type!(bool, u8))
         .composite(
             Fields::named()
-                .field(Field::named_of::<bool>("t").with_type_display_name(vec!["T"]))
-                .field(Field::named_of::<u8>("u").with_type_display_name(vec!["U"])),
+                .field_of::<bool>("t", "T")
+                .field_of::<u8>("u", "U"),
         );
 
     assert_type!(S<bool, u8>, struct_type);
@@ -76,11 +72,8 @@ fn struct_derive() {
         .type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
         .composite(
             Fields::named()
-                .field(
-                    Field::named_of::<Box<S<bool, u8>>>("t")
-                        .with_type_display_name(vec!["T"]),
-                )
-                .field(Field::named_of::<bool>("u").with_type_display_name(vec!["U"])),
+                .field_of::<Box<S<bool, u8>>>("t", "T")
+                .field_of::<bool>("u", "U"),
         );
     assert_type!(SelfTyped, self_typed_type);
 }
@@ -94,10 +87,7 @@ fn tuple_struct_derive() {
     let ty = Type::builder()
         .path(Path::new("S", "derive"))
         .type_params(tuple_meta_type!(bool))
-        .composite(
-            Fields::unnamed()
-                .field(Field::unnamed_of::<bool>().with_type_display_name(vec!["T"])),
-        );
+        .composite(Fields::unnamed().field_of::<bool>("T"));
 
     assert_type!(S<bool>, ty);
 }
@@ -146,18 +136,8 @@ fn enum_derive() {
         .type_params(tuple_meta_type!(bool))
         .variant(
             Variants::with_fields()
-                .variant(
-                    "A",
-                    Fields::unnamed().field(
-                        Field::unnamed_of::<bool>().with_type_display_name(vec!["T"]),
-                    ),
-                )
-                .variant(
-                    "B",
-                    Fields::named().field(
-                        Field::named_of::<bool>("b").with_type_display_name(vec!["T"]),
-                    ),
-                )
+                .variant("A", Fields::unnamed().field_of::<bool>("T"))
+                .variant("B", Fields::named().field_of::<bool>("b", "T"))
                 .variant_unit("C"),
         );
 
@@ -175,23 +155,12 @@ fn recursive_type_derive() {
 
     let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
         Variants::with_fields()
-            .variant(
-                "Leaf",
-                Fields::named().field(
-                    Field::named_of::<i32>("value").with_type_display_name(vec!["i32"]),
-                ),
-            )
+            .variant("Leaf", Fields::named().field_of::<i32>("value", "i32"))
             .variant(
                 "Node",
                 Fields::named()
-                    .field(
-                        Field::named_of::<Box<Tree>>("right")
-                            .with_type_display_name(vec!["Box"]),
-                    )
-                    .field(
-                        Field::named_of::<Box<Tree>>("left")
-                            .with_type_display_name(vec!["Box"]),
-                    ),
+                    .field_of::<Box<Tree>>("right", "Box < Tree >")
+                    .field_of::<Box<Tree>>("left", "Box < Tree >"),
             ),
     );
 
@@ -208,15 +177,9 @@ fn fields_with_type_alias() {
         a: BoolAlias,
     }
 
-    let ty =
-        Type::builder()
-            .path(Path::new("S", "derive"))
-            .composite(
-                Fields::named().field(
-                    Field::named_of::<BoolAlias>("a")
-                        .with_type_display_name(vec!["BoolAlias"]),
-                ),
-            );
+    let ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .composite(Fields::named().field_of::<BoolAlias>("a", "BoolAlias"));
 
     assert_type!(S, ty);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -53,7 +53,7 @@ fn struct_derive() {
 		.composite(
 			Fields::named()
 				.field(Field::named_of::<bool>("t").with_type_display_name(vec!["T"]))
-				.field(Field::named_of::<u8>("u").with_type_display_name(vec!["U"]))
+				.field(Field::named_of::<u8>("u").with_type_display_name(vec!["U"])),
 		);
 
 	assert_type!(S<bool, u8>, struct_type);
@@ -65,9 +65,10 @@ fn struct_derive() {
 	let self_typed_type = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
-		.composite(Fields::named()
-			.field(Field::named_of::<Box<S<bool, u8>>>("t").with_type_display_name(vec!["T"]))
-			.field(Field::named_of::<bool>("u").with_type_display_name(vec!["U"]))
+		.composite(
+			Fields::named()
+				.field(Field::named_of::<Box<S<bool, u8>>>("t").with_type_display_name(vec!["T"]))
+				.field(Field::named_of::<bool>("u").with_type_display_name(vec!["U"])),
 		);
 	assert_type!(SelfTyped, self_typed_type);
 }
@@ -128,8 +129,14 @@ fn enum_derive() {
 		.type_params(tuple_meta_type!(bool))
 		.variant(
 			Variants::with_fields()
-				.variant("A", Fields::unnamed().field(Field::unnamed_of::<bool>().with_type_display_name(vec!["T"])))
-				.variant("B", Fields::named().field(Field::named_of::<bool>("b").with_type_display_name(vec!["T"])))
+				.variant(
+					"A",
+					Fields::unnamed().field(Field::unnamed_of::<bool>().with_type_display_name(vec!["T"])),
+				)
+				.variant(
+					"B",
+					Fields::named().field(Field::named_of::<bool>("b").with_type_display_name(vec!["T"])),
+				)
 				.variant_unit("C"),
 		);
 
@@ -147,7 +154,10 @@ fn recursive_type_derive() {
 
 	let ty = Type::builder().path(Path::new("Tree", "derive")).variant(
 		Variants::with_fields()
-			.variant("Leaf", Fields::named().field(Field::named_of::<i32>("value").with_type_display_name(vec!["i32"])))
+			.variant(
+				"Leaf",
+				Fields::named().field(Field::named_of::<i32>("value").with_type_display_name(vec!["i32"])),
+			)
 			.variant(
 				"Node",
 				Fields::named()

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -18,11 +18,11 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec};
 
 use pretty_assertions::assert_eq;
 use scale_info::build::*;
-use scale_info::{tuple_meta_type, Path, Type, TypeInfo};
+use scale_info::{tuple_meta_type, Field, Path, Type, TypeInfo};
 
 fn assert_type<T, E>(expected: E)
 where
@@ -127,4 +127,21 @@ fn enum_derive() {
 		);
 
 	assert_type!(E<bool>, ty);
+}
+
+#[test]
+fn fields_with_type_alias() {
+	type BoolAlias = bool;
+
+	#[allow(unused)]
+	#[derive(TypeInfo)]
+	struct S {
+		a: BoolAlias,
+	}
+
+	let ty = Type::builder()
+		.path(Path::new("S", "derive"))
+		.composite(Fields::named().field(Field::named_of::<BoolAlias>("a").with_type_display_name(vec!["BoolAlias"])));
+
+	assert_type!(S, ty);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -50,7 +50,11 @@ fn struct_derive() {
 	let struct_type = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(bool, u8))
-		.composite(Fields::named().field_of::<bool>("t").field_of::<u8>("u"));
+		.composite(
+			Fields::named()
+				.field_of::<bool>("t")
+				.field_of::<u8>("u")
+		);
 
 	assert_type!(S<bool, u8>, struct_type);
 
@@ -121,8 +125,8 @@ fn enum_derive() {
 		.type_params(tuple_meta_type!(bool))
 		.variant(
 			Variants::with_fields()
-				.variant("A", Fields::unnamed().field_of::<bool>())
-				.variant("B", Fields::named().field_of::<bool>("b"))
+				.variant("A", Fields::unnamed().field(Field::unnamed_of::<bool>().with_type_display_name(vec!["T"])))
+				.variant("B", Fields::named().field(Field::named_of::<bool>("b").with_type_display_name(vec!["T"])))
 				.variant_unit("C"),
 		);
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -52,8 +52,8 @@ fn struct_derive() {
 		.type_params(tuple_meta_type!(bool, u8))
 		.composite(
 			Fields::named()
-				.field_of::<bool>("t")
-				.field_of::<u8>("u")
+				.field(Field::named_of::<bool>("t").with_type_display_name(vec!["T"]))
+				.field(Field::named_of::<u8>("u").with_type_display_name(vec!["U"]))
 		);
 
 	assert_type!(S<bool, u8>, struct_type);
@@ -65,7 +65,10 @@ fn struct_derive() {
 	let self_typed_type = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(Box<S<bool, u8>>, bool))
-		.composite(Fields::named().field_of::<Box<S<bool, u8>>>("t").field_of::<bool>("u"));
+		.composite(Fields::named()
+			.field(Field::named_of::<Box<S<bool, u8>>>("t").with_type_display_name(vec!["T"]))
+			.field(Field::named_of::<bool>("u").with_type_display_name(vec!["U"]))
+		);
 	assert_type!(SelfTyped, self_typed_type);
 }
 
@@ -78,7 +81,7 @@ fn tuple_struct_derive() {
 	let ty = Type::builder()
 		.path(Path::new("S", "derive"))
 		.type_params(tuple_meta_type!(bool))
-		.composite(Fields::unnamed().field_of::<bool>());
+		.composite(Fields::unnamed().field(Field::unnamed_of::<bool>().with_type_display_name(vec!["T"])));
 
 	assert_type!(S<bool>, ty);
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -146,9 +146,9 @@ fn test_tuplestruct() {
 		"def": {
 			"composite": {
 				"fields": [
-					{ "type": 1 },
+					{ "type": 1, "displayName": ["i32"] },
 					{ "type": 2 },
-					{ "type": 4 },
+					{ "type": 4, "displayName": ["bool"] },
 				],
 			},
 		}
@@ -169,9 +169,9 @@ fn test_struct() {
 		"def": {
 			"composite": {
 				"fields": [
-					{ "name": "a", "type": 1, },
-					{ "name": "b", "type": 2, },
-					{ "name": "c", "type": 4, },
+					{ "name": "a", "type": 1, "displayName": ["i32"] },
+					{ "name": "b", "type": 2 },
+					{ "name": "c", "type": 4, "displayName": ["bool"] },
 				],
 			},
 		}
@@ -219,16 +219,16 @@ fn test_enum() {
 					{
 						"name": "TupleStructVariant",
 						"fields": [
-							{ "type": 1 },
-							{ "type": 2 },
+							{ "type": 1, "displayName": ["u32"] },
+							{ "type": 2, "displayName": ["bool"] },
 						],
 					},
 					{
 						"name": "StructVariant",
 						"fields": [
-							{ "name": "a", "type": 1, },
-							{ "name": "b", "type": 3, },
-							{ "name": "c", "type": 5, },
+							{ "name": "a", "type": 1, "displayName": ["u32"] },
+							{ "name": "b", "type": 3 },
+							{ "name": "c", "type": 5, "displayName": ["char"] },
 						],
 					}
 				],
@@ -294,8 +294,8 @@ fn test_registry() {
 				"def": {
 					"composite": {
 						"fields": [
-							{ "type": 3 },
-							{ "type": 4 },
+							{ "type": 3, "displayName": ["u8"] },
+							{ "type": 4, "displayName": ["u32"] },
 						],
 					},
 				}
@@ -316,11 +316,13 @@ fn test_registry() {
 						"fields": [
 							{
 								"name": "a",
-								"type": 3, // u8
+								"type": 3,
+								"displayName": ["u8"]
 							},
 							{
 								"name": "b",
-								"type": 4, // u32
+								"type": 4,
+								"displayName": ["u32"]
 							},
 							{
 								"name": "c",
@@ -349,6 +351,7 @@ fn test_registry() {
 							{
 								"name": "rec",
 								"type": 8, // Vec<RecursiveStruct>
+								"displayName": ["Vec"]
 							}
 						]
 					},
@@ -399,8 +402,8 @@ fn test_registry() {
 							{
 								"name": "B",
 								"fields": [
-									{ "type": 3 }, // u8
-									{ "type": 4 }, // u32
+									{ "type": 3, "displayName": ["u8"] }, // u8
+									{ "type": 4, "displayName": ["u32"] }, // u32
 								]
 							},
 							{
@@ -409,10 +412,12 @@ fn test_registry() {
 									{
 										"name": "a",
 										"type": 3, // u8
+										"displayName": ["u8"]
 									},
 									{
 										"name": "b",
 										"type": 4, // u32
+										"displayName": ["u32"]
 									},
 									{
 										"name": "c",

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -172,7 +172,7 @@ fn test_tuplestruct() {
             "composite": {
                 "fields": [
                     { "type": 1, "typeName": "i32" },
-                    { "type": 2, "typeName": "[u8 ; 32]" },
+                    { "type": 2, "typeName": "[u8; 32]" },
                     { "type": 4, "typeName": "bool" },
                 ],
             },
@@ -195,7 +195,7 @@ fn test_struct() {
             "composite": {
                 "fields": [
                     { "name": "a", "type": 1, "typeName": "i32" },
-                    { "name": "b", "type": 2, "typeName": "[u8 ; 32]" },
+                    { "name": "b", "type": 2, "typeName": "[u8; 32]" },
                     { "name": "c", "type": 4, "typeName": "bool" },
                 ],
             },
@@ -252,7 +252,7 @@ fn test_enum() {
                         "name": "StructVariant",
                         "fields": [
                             { "name": "a", "type": 1, "typeName": "u32" },
-                            { "name": "b", "type": 3, "typeName": "[u8 ; 32]" },
+                            { "name": "b", "type": 3, "typeName": "[u8; 32]" },
                             { "name": "c", "type": 5, "typeName": "char" },
                         ],
                     }
@@ -289,8 +289,8 @@ fn test_recursive_type_with_box() {
                             {
                                 "name": "Node",
                                 "fields": [
-                                    { "name": "right", "type": 1, "typeName": "Box < Tree >" },
-                                    { "name": "left", "type": 1, "typeName": "Box < Tree >" },
+                                    { "name": "right", "type": 1, "typeName": "Box<Tree>" },
+                                    { "name": "left", "type": 1, "typeName": "Box<Tree>" },
                                 ],
                             }
                         ],
@@ -396,7 +396,7 @@ fn test_registry() {
                             {
                                 "name": "c",
                                 "type": 6,
-                                "typeName": "[u8 ; 32]"
+                                "typeName": "[u8; 32]"
                             }
                         ]
                     },
@@ -421,7 +421,7 @@ fn test_registry() {
                             {
                                 "name": "rec",
                                 "type": 8,
-                                "typeName": "Vec < RecursiveStruct >"
+                                "typeName": "Vec<RecursiveStruct>"
                             }
                         ]
                     },
@@ -492,7 +492,7 @@ fn test_registry() {
                                     {
                                         "name": "c",
                                         "type": 6,
-                                        "typeName": "[u8 ; 32]"
+                                        "typeName": "[u8; 32]"
                                     }
                                 ]
                             }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -103,7 +103,7 @@ fn test_builtins() {
                     },
                     {
                         "name": "Some",
-                        "fields": [ { "type": 1 } ]
+                        "fields": [ { "type": 1, "typeName": "T" } ]
                     },
                 ]
             }
@@ -117,11 +117,11 @@ fn test_builtins() {
                 "variants": [
                     {
                         "name": "Ok",
-                        "fields": [ { "type": 1 } ]
+                        "fields": [ { "type": 1, "typeName": "T" } ]
                     },
                     {
                         "name": "Err",
-                        "fields": [ { "type": 2 } ]
+                        "fields": [ { "type": 2, "typeName": "E" } ]
                     }
                 ]
             }
@@ -171,9 +171,9 @@ fn test_tuplestruct() {
         "def": {
             "composite": {
                 "fields": [
-                    { "type": 1, "displayName": ["i32"] },
-                    { "type": 2 },
-                    { "type": 4, "displayName": ["bool"] },
+                    { "type": 1, "typeName": "i32" },
+                    { "type": 2, "typeName": "[u8 ; 32]" },
+                    { "type": 4, "typeName": "bool" },
                 ],
             },
         }
@@ -194,9 +194,9 @@ fn test_struct() {
         "def": {
             "composite": {
                 "fields": [
-                    { "name": "a", "type": 1, "displayName": ["i32"] },
-                    { "name": "b", "type": 2 },
-                    { "name": "c", "type": 4, "displayName": ["bool"] },
+                    { "name": "a", "type": 1, "typeName": "i32" },
+                    { "name": "b", "type": 2, "typeName": "[u8 ; 32]" },
+                    { "name": "c", "type": 4, "typeName": "bool" },
                 ],
             },
         }
@@ -244,16 +244,16 @@ fn test_enum() {
                     {
                         "name": "TupleStructVariant",
                         "fields": [
-                            { "type": 1, "displayName": ["u32"] },
-                            { "type": 2, "displayName": ["bool"] },
+                            { "type": 1, "typeName": "u32" },
+                            { "type": 2, "typeName": "bool" },
                         ],
                     },
                     {
                         "name": "StructVariant",
                         "fields": [
-                            { "name": "a", "type": 1, "displayName": ["u32"] },
-                            { "name": "b", "type": 3 },
-                            { "name": "c", "type": 5, "displayName": ["char"] },
+                            { "name": "a", "type": 1, "typeName": "u32" },
+                            { "name": "b", "type": 3, "typeName": "[u8 ; 32]" },
+                            { "name": "c", "type": 5, "typeName": "char" },
                         ],
                     }
                 ],
@@ -283,14 +283,14 @@ fn test_recursive_type_with_box() {
                             {
                                 "name": "Leaf",
                                 "fields": [
-                                    { "name": "value", "type": 2, "displayName": ["i32"] },
+                                    { "name": "value", "type": 2, "typeName": "i32" },
                                 ],
                             },
                             {
                                 "name": "Node",
                                 "fields": [
-                                    { "name": "right", "type": 1, "displayName": ["Box"] },
-                                    { "name": "left", "type": 1, "displayName": ["Box"] },
+                                    { "name": "right", "type": 1, "typeName": "Box < Tree >" },
+                                    { "name": "left", "type": 1, "typeName": "Box < Tree >" },
                                 ],
                             }
                         ],
@@ -363,8 +363,8 @@ fn test_registry() {
                 "def": {
                     "composite": {
                         "fields": [
-                            { "type": 3, "displayName": ["u8"] },
-                            { "type": 4, "displayName": ["u32"] },
+                            { "type": 3, "typeName": "u8" },
+                            { "type": 4, "typeName": "u32" },
                         ],
                     },
                 }
@@ -386,16 +386,17 @@ fn test_registry() {
                             {
                                 "name": "a",
                                 "type": 3,
-                                "displayName": ["u8"]
+                                "typeName": "u8"
                             },
                             {
                                 "name": "b",
                                 "type": 4,
-                                "displayName": ["u32"]
+                                "typeName": "u32"
                             },
                             {
                                 "name": "c",
-                                "type": 6, // [u8; 32]
+                                "type": 6,
+                                "typeName": "[u8 ; 32]"
                             }
                         ]
                     },
@@ -419,8 +420,8 @@ fn test_registry() {
                         "fields": [
                             {
                                 "name": "rec",
-                                "type": 8, // Vec<RecursiveStruct>
-                                "displayName": ["Vec"]
+                                "type": 8,
+                                "typeName": "Vec < RecursiveStruct >"
                             }
                         ]
                     },
@@ -471,8 +472,8 @@ fn test_registry() {
                             {
                                 "name": "B",
                                 "fields": [
-                                    { "type": 3, "displayName": ["u8"] }, // u8
-                                    { "type": 4, "displayName": ["u32"] }, // u32
+                                    { "type": 3, "typeName": "u8" }, // u8
+                                    { "type": 4, "typeName": "u32" }, // u32
                                 ]
                             },
                             {
@@ -481,16 +482,17 @@ fn test_registry() {
                                     {
                                         "name": "a",
                                         "type": 3, // u8
-                                        "displayName": ["u8"]
+                                        "typeName": "u8"
                                     },
                                     {
                                         "name": "b",
                                         "type": 4, // u32
-                                        "displayName": ["u32"]
+                                        "typeName": "u32"
                                     },
                                     {
                                         "name": "c",
-                                        "type": 6, // [u8; 32]
+                                        "type": 6,
+                                        "typeName": "[u8 ; 32]"
                                     }
                                 ]
                             }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -258,14 +258,14 @@ fn test_recursive_type_with_box() {
 							{
 								"name": "Leaf",
 								"fields": [
-									{ "name": "value", "type": 2 },
+									{ "name": "value", "type": 2, "displayName": ["i32"] },
 								],
 							},
 							{
 								"name": "Node",
 								"fields": [
-									{ "name": "right", "type": 1, },
-									{ "name": "left", "type": 1, },
+									{ "name": "right", "type": 1, "displayName": ["Box"] },
+									{ "name": "left", "type": 1, "displayName": ["Box"] },
 								],
 							}
 						],


### PR DESCRIPTION
Given a complex type which incorporates a field with a type alias, we currently lose the information about the use of a type alias. e.g.

```
type Balance = u128

#[derive(TypeInfo)]
struct S { b: Balance }
```

This currently results in the field type being resolved to `u128` in the type registry, and we have no way to distinguish between a plain `u128` and an aliased `u128`, which we may want to treat differently, e.g. some custom decoding or display logic for that type.

This PR adds the optional `type_name` property to `Field`, and updates the derive macro to extract the field type names e,g, in the above example the underlying type is `u128` but the type name is `Balance`.

Note that this will add a `type_name` even if it is non-aliased, e.g. `a: u32` will still have the type display name `"u32"` as part of the field definition. Even though this is redundant, and it is possible to remove non aliased display names (I implemented then removed it), I have left them in for the sake of simplicity and flexibility, leaving it up to consumers to do the lookup to determine whether an alias is being used or not.

This is required for https://github.com/paritytech/cargo-contract/pull/79 in order for custom encoding/decoding for aliased `Balance` types.