### PR TITLE
Consolidate common prelude for std and no_std and usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["no-std", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
+cfg-if = "1.0"
 scale-info-derive = { version = "0.2.1", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }

--- a/derive/src/impl_wrapper.rs
+++ b/derive/src/impl_wrapper.rs
@@ -37,11 +37,6 @@ pub fn wrap(
     quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
-            // #[allow(unknown_lints)]
-            // #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-            // #[allow(rust_2018_idioms)]
-            // use scale_info as _scale_info;
-
             #impl_quote;
         };
     }

--- a/derive/src/impl_wrapper.rs
+++ b/derive/src/impl_wrapper.rs
@@ -37,25 +37,10 @@ pub fn wrap(
     quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const #dummy_const: () = {
-            #[allow(unknown_lints)]
-            #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-            #[allow(rust_2018_idioms)]
-            use scale_info as _scale_info;
-
-            #[cfg(not(feature = "std"))]
-            extern crate alloc;
-
-            #[cfg(feature = "std")]
-            mod __core {
-                pub use ::core::*;
-                pub use ::std::{vec, vec::Vec};
-            }
-
-            #[cfg(not(feature = "std"))]
-            mod __core {
-                pub use ::core::*;
-                pub use ::alloc::{vec, vec::Vec};
-            }
+            // #[allow(unknown_lints)]
+            // #[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
+            // #[allow(rust_2018_idioms)]
+            // use scale_info as _scale_info;
 
             #impl_quote;
         };

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -67,7 +67,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     let mut ast: DeriveInput = syn::parse2(input.clone())?;
 
     ast.generics.type_params_mut().for_each(|p| {
-        p.bounds.push(parse_quote!(_scale_info::TypeInfo));
+        p.bounds.push(parse_quote!(::scale_info::TypeInfo));
         p.bounds.push(parse_quote!('static));
     });
 
@@ -93,7 +93,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
             fn type_info() -> ::scale_info::Type {
                 ::scale_info::Type::builder()
                     .path(::scale_info::Path::new(stringify!(#ident), module_path!()))
-                    .type_params(::scale_info::prelude::alloc::vec![ #( #generic_type_ids ),* ])
+                    .type_params(::scale_info::prelude::vec![ #( #generic_type_ids ),* ])
                     .#build_type
                     .into()
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -76,7 +76,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     let generic_type_ids = ast.generics.type_params().map(|ty| {
         let ty_ident = &ty.ident;
         quote! {
-            _scale_info::meta_type::<#ty_ident>()
+            ::scale_info::meta_type::<#ty_ident>()
         }
     });
 
@@ -88,12 +88,12 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     };
 
     let type_info_impl = quote! {
-        impl #impl_generics _scale_info::TypeInfo for #ident #ty_generics #where_clause {
+        impl #impl_generics ::scale_info::TypeInfo for #ident #ty_generics #where_clause {
             type Identity = Self;
-            fn type_info() -> _scale_info::Type {
-                _scale_info::Type::builder()
-                    .path(_scale_info::Path::new(stringify!(#ident), module_path!()))
-                    .type_params(__core::vec![ #( #generic_type_ids ),* ])
+            fn type_info() -> ::scale_info::Type {
+                ::scale_info::Type::builder()
+                    .path(::scale_info::Path::new(stringify!(#ident), module_path!()))
+                    .type_params(::scale_info::prelude::alloc::vec![ #( #generic_type_ids ),* ])
                     .#build_type
                     .into()
             }
@@ -159,7 +159,7 @@ fn generate_composite_type(data_struct: &DataStruct) -> TokenStream2 {
         }
     };
     quote! {
-        composite(_scale_info::build::Fields::#fields)
+        composite(::scale_info::build::Fields::#fields)
     }
 }
 
@@ -189,7 +189,7 @@ fn generate_c_like_enum_def(variants: &VariantList) -> TokenStream2 {
     });
     quote! {
         variant(
-            _scale_info::build::Variants::fieldless()
+            ::scale_info::build::Variants::fieldless()
                 #( #variants )*
         )
     }
@@ -221,7 +221,7 @@ fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {
                 quote! {
                     .variant(
                         #v_name,
-                        _scale_info::build::Fields::named()
+                        ::scale_info::build::Fields::named()
                             #( #fields)*
                     )
                 }
@@ -231,7 +231,7 @@ fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {
                 quote! {
                     .variant(
                         #v_name,
-                        _scale_info::build::Fields::unnamed()
+                        ::scale_info::build::Fields::unnamed()
                             #( #fields)*
                     )
                 }
@@ -245,7 +245,7 @@ fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {
     });
     quote! {
         variant(
-            _scale_info::build::Variants::with_fields()
+            ::scale_info::build::Variants::with_fields()
                 #( #variants)*
         )
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -118,7 +118,7 @@
 
 use crate::{
     form::MetaForm,
-    tm_std::*,
+    prelude::*,
     Field,
     MetaType,
     Path,

--- a/src/build.rs
+++ b/src/build.rs
@@ -116,9 +116,13 @@
 //! }
 //! ```
 
+use crate::prelude::{
+    marker::PhantomData,
+    vec::Vec,
+};
+
 use crate::{
     form::MetaForm,
-    prelude::*,
     Field,
     MetaType,
     Path,

--- a/src/form.rs
+++ b/src/form.rs
@@ -30,10 +30,15 @@
 //! Other forms, such as a compact form that is still bound to the registry
 //! (also via lifetime tracking) are possible but current not needed.
 
+use crate::prelude::{
+    any::TypeId,
+    fmt::Debug,
+    string::String,
+};
+
 use crate::{
     interner::UntrackedSymbol,
     meta_type::MetaType,
-    prelude::*,
 };
 use serde::Serialize;
 
@@ -44,9 +49,9 @@ use serde::Serialize;
 /// interning data structures.
 pub trait Form {
     /// The type representing the type.
-    type Type: PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+    type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
     /// The string type.
-    type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + core::fmt::Debug;
+    type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
 }
 
 /// A meta meta-type.

--- a/src/form.rs
+++ b/src/form.rs
@@ -33,7 +33,7 @@
 use crate::{
     interner::UntrackedSymbol,
     meta_type::MetaType,
-    tm_std::*,
+    prelude::*,
 };
 use serde::Serialize;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -12,10 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::prelude::{
+    boxed::Box,
+    collections::BTreeMap,
+    marker::PhantomData,
+    string::String,
+    vec::Vec,
+    vec,
+};
+
 use crate::{
     build::*,
-    prelude::*,
-    *,
+    TypeInfo,
+    Type,
+    TypeDefArray,
+    TypeDefPrimitive,
+    TypeDefSequence,
+    TypeDefTuple,
+    Path,
+    MetaType,
+    meta_type,
 };
 
 macro_rules! impl_metadata_for_primitives {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -17,21 +17,21 @@ use crate::prelude::{
     collections::BTreeMap,
     marker::PhantomData,
     string::String,
-    vec::Vec,
     vec,
+    vec::Vec,
 };
 
 use crate::{
     build::*,
-    TypeInfo,
+    meta_type,
+    MetaType,
+    Path,
     Type,
     TypeDefArray,
     TypeDefPrimitive,
     TypeDefSequence,
     TypeDefTuple,
-    Path,
-    MetaType,
-    meta_type,
+    TypeInfo,
 };
 
 macro_rules! impl_metadata_for_primitives {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     build::*,
-    tm_std::*,
+    prelude::*,
     *,
 };
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -21,7 +21,7 @@
 //! The interners provide a strict ordered sequence of cached (aka interned)
 //! elements and is later used for compact serialization within the registry.
 
-use crate::tm_std::*;
+use crate::prelude::*;
 use serde::{
     Deserialize,
     Serialize,

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -21,7 +21,13 @@
 //! The interners provide a strict ordered sequence of cached (aka interned)
 //! elements and is later used for compact serialization within the registry.
 
-use crate::prelude::*;
+use crate::prelude::{
+    collections::btree_map::{BTreeMap, Entry},
+    marker::PhantomData,
+    num::NonZeroU32,
+    vec::Vec,
+};
+
 use serde::{
     Deserialize,
     Serialize,

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,7 +22,10 @@
 //! elements and is later used for compact serialization within the registry.
 
 use crate::prelude::{
-    collections::btree_map::{BTreeMap, Entry},
+    collections::btree_map::{
+        BTreeMap,
+        Entry,
+    },
     marker::PhantomData,
     num::NonZeroU32,
     vec::Vec,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,16 +91,8 @@ extern crate alloc;
 macro_rules! tuple_meta_type {
     ( $($ty:ty),* ) => {
         {
-            #[cfg(not(feature = "std"))]
-            extern crate alloc as _alloc;
-            #[cfg(not(feature = "std"))]
             #[allow(unused_mut)]
-            let mut v = _alloc::vec![];
-
-            #[cfg(feature = "std")]
-            #[allow(unused_mut)]
-            let mut v = std::vec![];
-
+            let mut v = $crate::prelude::vec![];
             $(
                 v.push($crate::MetaType::new::<$ty>());
             )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! tuple_meta_type {
     }
 }
 
-mod tm_std;
+mod prelude;
 
 pub mod build;
 pub mod form;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,6 @@
 //! A usage example can be found in ink! here:
 //! https://github.com/paritytech/ink/blob/master/abi/src/specs.rs
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 /// Takes a number of types and returns a vector that contains their respective
 /// [`MetaType`](`crate::MetaType`) instances.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! tuple_meta_type {
     }
 }
 
-mod prelude;
+pub mod prelude;
 
 pub mod build;
 pub mod form;

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::prelude::{
+    any::TypeId,
+    cmp::Ordering,
+    fmt::{Debug, Formatter, Error as FmtError},
+    hash::{Hash, Hasher},
+};
+
 use crate::{
     form::MetaForm,
-    prelude::*,
     Type,
     TypeInfo,
 };

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     form::MetaForm,
-    tm_std::*,
+    prelude::*,
     Type,
     TypeInfo,
 };

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -15,8 +15,15 @@
 use crate::prelude::{
     any::TypeId,
     cmp::Ordering,
-    fmt::{Debug, Formatter, Error as FmtError},
-    hash::{Hash, Hasher},
+    fmt::{
+        Debug,
+        Error as FmtError,
+        Formatter,
+    },
+    hash::{
+        Hash,
+        Hasher,
+    },
 };
 
 use crate::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,9 @@
 
 //! Exports from `std`, `core` and `alloc` crates.
 
+// #[cfg(not(feature = "std"))]
+// extern crate alloc;
+
 mod core {
     #[cfg(not(feature = "std"))]
     pub use core::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,52 +13,47 @@
 // limitations under the License.
 
 //! Exports from `std`, `core` and `alloc` crates.
+//!
+//! Guarantees a stable interface between `std` and `no_std` modes.
 
-// #[cfg(not(feature = "std"))]
-// extern crate alloc;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
-mod core {
-    #[cfg(not(feature = "std"))]
-    pub use core::*;
+use cfg_if::cfg_if;
 
-    #[cfg(feature = "std")]
-    pub use std::*;
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub use std::{
+            any,
+            boxed,
+            cmp,
+            collections,
+            fmt,
+            format,
+            hash,
+            marker,
+            mem,
+            num,
+            string,
+            vec,
+        };
+    } else {
+        pub use alloc::{
+            boxed,
+            collections,
+            format,
+            string,
+            vec,
+        };
+
+        pub use core::{
+            any,
+            cmp,
+            fmt,
+            hash,
+            marker,
+            mem,
+            num,
+        };
+    }
 }
-
-#[rustfmt::skip]
-pub use self::core::{
-    i8, i16, i32, i64, i128,
-    u8, u16, u32, u64, u128,
-
-    marker::PhantomData,
-    num::NonZeroU32,
-    option::Option,
-    result::Result,
-
-    any::TypeId,
-
-    clone::{Clone},
-    cmp::{Eq, PartialEq, Ordering},
-    convert::{From, Into},
-    fmt::{Debug, Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
-    iter,
-    mem,
-    write,
-};
-
-mod alloc {
-    #[cfg(not(feature = "std"))]
-    pub use ::alloc::*;
-
-    #[cfg(feature = "std")]
-    pub use std::*;
-}
-
-#[rustfmt::skip]
-pub use self::alloc::{
-    boxed::Box,
-    collections::btree_map::{BTreeMap, Entry},
-    string::{String, ToString},
-    vec, vec::Vec,
-};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -34,7 +34,7 @@ use crate::{
         UntrackedSymbol,
     },
     meta_type::MetaType,
-    tm_std::*,
+    prelude::*,
     Type,
 };
 use scale::{

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,6 +24,15 @@
 //! has been defined. Rust prelude types live within the so-called root
 //! namespace that is just empty.
 
+use crate::prelude::{
+    any::TypeId,
+    collections::BTreeMap,
+    mem,
+    num::NonZeroU32,
+    string::ToString,
+    vec::Vec,
+};
+
 use crate::{
     form::{
         CompactForm,
@@ -34,7 +43,6 @@ use crate::{
         UntrackedSymbol,
     },
     meta_type::MetaType,
-    prelude::*,
     Type,
 };
 use scale::{

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
+use crate::prelude::vec::Vec;
 
 use crate::{
     form::{

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tm_std::*;
+use crate::prelude::*;
 
 use crate::{
     form::{

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tm_std::*;
+use crate::prelude::*;
 
 use crate::{
     form::{

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
-
 use crate::{
     form::{
         CompactForm,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tm_std::*;
+use crate::prelude::*;
 
 use crate::{
     build::TypeBuilder,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
+use crate::prelude::{vec, vec::Vec};
 
 use crate::{
     build::TypeBuilder,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::{vec, vec::Vec};
+use crate::prelude::{
+    vec,
+    vec::Vec,
+};
 
 use crate::{
     build::TypeBuilder,

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 use crate::prelude::{
-    fmt::{Formatter, Display, Error as FmtError},
+    fmt::{
+        Display,
+        Error as FmtError,
+        Formatter,
+    },
     vec,
     vec::Vec,
 };

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -18,7 +18,7 @@ use crate::{
         Form,
         MetaForm,
     },
-    tm_std::*,
+    prelude::*,
     utils::is_rust_identifier,
     IntoCompact,
     Registry,

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::prelude::{
+    fmt::{Formatter, Display, Error as FmtError},
+    vec,
+    vec::Vec,
+};
+
 use crate::{
     form::{
         CompactForm,
         Form,
         MetaForm,
     },
-    prelude::*,
     utils::is_rust_identifier,
     IntoCompact,
     Registry,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
+use crate::prelude::vec::Vec;
 
 use crate::{
     build::FieldsBuilder,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tm_std::*;
+use crate::prelude::*;
 
 use crate::{
     build::FieldsBuilder,

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -15,8 +15,6 @@
 
 #![no_std]
 
-// extern crate alloc;
-
 use scale_info::TypeInfo;
 
 #[allow(unused)]

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -15,7 +15,7 @@
 
 #![no_std]
 
-extern crate alloc;
+// extern crate alloc;
 
 use scale_info::TypeInfo;
 

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -16,15 +16,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-use alloc::{
+use scale_info::prelude::{
+    num::NonZeroU32,
     vec,
     vec::Vec,
 };
-use core::num::NonZeroU32;
 use pretty_assertions::{
     assert_eq,
     assert_ne,

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -16,11 +16,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-use scale_info::prelude::{
-    num::NonZeroU32,
-    vec,
-    vec::Vec,
-};
 use pretty_assertions::{
     assert_eq,
     assert_ne,
@@ -31,6 +26,11 @@ use scale::{
 };
 use scale_info::{
     form::CompactForm,
+    prelude::{
+        num::NonZeroU32,
+        vec,
+        vec::Vec,
+    },
     IntoCompact as _,
     MetaType,
     Registry,

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -14,11 +14,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use scale_info::prelude::{
+    boxed::Box,
+};
 
 use pretty_assertions::assert_eq;
 use scale_info::{

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -14,9 +14,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use scale_info::prelude::{
-    boxed::Box,
-};
+use scale_info::prelude::boxed::Box;
 
 use pretty_assertions::assert_eq;
 use scale_info::{

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -16,12 +16,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-use alloc::{
+use scale_info::prelude::{
     boxed::Box,
+    string::String,
     vec,
     vec::Vec,
 };
@@ -130,11 +127,11 @@ fn test_builtins() {
     // references
     assert_json_for_type::<&bool>(json!({ "def": { "primitive": "bool" } }));
     assert_json_for_type::<&mut str>(json!({ "def": { "primitive": "str" } }));
-    assert_json_for_type::<alloc::boxed::Box<u32>>(
+    assert_json_for_type::<Box<u32>>(
         json!({ "def": { "primitive": "u32" } }),
     );
     // strings
-    assert_json_for_type::<alloc::string::String>(
+    assert_json_for_type::<String>(
         json!({ "def": { "primitive": "str" } }),
     );
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -127,13 +127,9 @@ fn test_builtins() {
     // references
     assert_json_for_type::<&bool>(json!({ "def": { "primitive": "bool" } }));
     assert_json_for_type::<&mut str>(json!({ "def": { "primitive": "str" } }));
-    assert_json_for_type::<Box<u32>>(
-        json!({ "def": { "primitive": "u32" } }),
-    );
+    assert_json_for_type::<Box<u32>>(json!({ "def": { "primitive": "u32" } }));
     // strings
-    assert_json_for_type::<String>(
-        json!({ "def": { "primitive": "str" } }),
-    );
+    assert_json_for_type::<String>(json!({ "def": { "primitive": "str" } }));
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
     assert_json_for_type::<core::marker::PhantomData<bool>>(json!({


### PR DESCRIPTION
Ideas copied from [ink!'s prelude](https://github.com/paritytech/ink/blob/master/crates/prelude/src/lib.rs).

- Fixes issue which required `extern crate alloc` to be present in root of `no_std` consumer
- Rename `tm_std` -> prelude
- Explicitly export common modules
- Use cfg_if for std and no_std environments
- Explicit prelude imports instead of `*`
- Use `::scale_info` in derive instead of `_scale_info::`
- Use `::scale_info` prelude from derive macro