### PR TITLE
Optional serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 cfg-if = "1.0"
 scale-info-derive = { version = "0.2.1", path = "derive", default-features = false, optional = true }
-serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = [
+    "scale/std",
     "serde/std",
-    "scale/std"
 ]
 derive = [
     "scale-info-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ scale = { package = "parity-scale-codec", version = "1.3", default-features = fa
 default = ["std"]
 std = [
     "scale/std",
-    "serde/std",
 ]
 derive = [
     "scale-info-derive"

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The type registry can be encoded as:
 The following optional `cargo` features are available:
 
 - **serde** includes support for json serialization/deserialization of the type registry. See example [here](https://github.com/paritytech/scale-info/blob/master/test_suite/tests/json.rs).
-- **derive** reexports the [`scale-info-derive`](https://crates.io/crates/scale-info-derive) crate
+- **derive** reexports the [`scale-info-derive`](https://crates.io/crates/scale-info-derive) crate.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -99,13 +99,15 @@ impl<T> TypeInfo for Foo<T>
 where
     T: TypeInfo + 'static,
 {
+    type Identity = Self;
+
     fn type_info() -> Type {
         Type::builder()
             .path(Path::new("Foo", module_path!()))
             .type_params(vec![MetaType::new::<T>()])
             .composite(Fields::named()
-                .field_of::<T>("bar")
-                .field_of::<u64>("data")
+                .field_of::<T>("bar", "T")
+                .field_of::<u64>("data", "u64")
             )
     }
 }
@@ -117,12 +119,14 @@ where
 struct Foo(u32, bool);
 
 impl TypeInfo for Foo {
+    type Identity = Self;
+
     fn type_info() -> Type {
         Type::builder()
             .path(Path::new("Foo", module_path!()))
             .composite(Fields::unnamed()
-                .field_of::<u32>()
-                .field_of::<bool>()
+                .field_of::<u32>("u32")
+                .field_of::<bool>("bool")
             )
     }
 }
@@ -144,14 +148,16 @@ impl<T> TypeInfo for Foo<T>
 where
     T: TypeInfo + 'static,
 {
+    type Identity = Self;
+
     fn type_info() -> Type {
         Type::builder()
             .path(Path::new("Foo", module_path!()))
             .type_params(vec![MetaType::new::<T>()])
             .variant(
                 Variants::with_fields()
-                    .variant("A", Fields::unnamed().field_of::<T>())
-                    .variant("B", Fields::named().field_of::<u32>("f"))
+                    .variant("A", Fields::unnamed().field_of::<T>("T"))
+                    .variant("B", Fields::named().field_of::<u32>("f", "u32"))
                     .variant("C", Fields::unit())
             )
     }
@@ -169,6 +175,8 @@ enum Foo {
 }
 
 impl TypeInfo for Foo {
+    type Identity = Self;
+
     fn type_info() -> Type {
         Type::builder()
             .path(Path::new("Foo", module_path!()))

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ registered types are utilized to allow consumers to resolve the types.
 
 The type registry can be encoded as:
 
-- JSON (with the "serde" feature enabled)
-- SCALE itself (using `parity-scale-codec`)
+- JSON (with the "serde" feature enabled).
+- SCALE itself (using `parity-scale-codec`).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -209,13 +209,19 @@ After compactification all type definitions are stored in the type registry.
 Note that the type registry should be serialized as part of the metadata structure where the
 registered types are utilized to allow consumers to resolve the types.
 
-## Serialization
+## Encoding
 
-Currently the only supported serialization format is JSON, an example of which can be found
-[here](https://github.com/paritytech/scale-info/blob/master/test_suite/tests/json.rs).
+The type registry can be encoded as:
 
-Future support for binary formats is planned, either SCALE itself or a more compressed format where
-the monomorphization of Rust generic types could potentially result in very large files.
+- JSON (with the "serde" feature enabled)
+- SCALE itself (using `parity-scale-codec`)
+
+## Features
+
+The following optional `cargo` features are available:
+
+- **serde** includes support for json serialization/deserialization of the type registry. See example [here](https://github.com/paritytech/scale-info/blob/master/test_suite/tests/json.rs).
+- **derive** reexports the [`scale-info-derive`](https://crates.io/crates/scale-info-derive) crate
 
 ## Resources
 

--- a/src/form.rs
+++ b/src/form.rs
@@ -41,7 +41,7 @@ use crate::{
     meta_type::MetaType,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 /// Trait to control the internal structures of type definitions.
@@ -61,7 +61,7 @@ pub trait Form {
 /// Allows to be converted into other forms such as compact form
 /// through the registry and `IntoCompact`.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum MetaForm {}
 
 impl Form for MetaForm {
@@ -79,7 +79,7 @@ impl Form for MetaForm {
 ///
 /// `type String` is owned in order to enable decoding
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct CompactForm<S = &'static str>(PhantomData<S>);
 
 impl<S> Form for CompactForm<S>

--- a/src/form.rs
+++ b/src/form.rs
@@ -60,8 +60,8 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as compact form
 /// through the registry and `IntoCompact`.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
 
 impl Form for MetaForm {

--- a/src/form.rs
+++ b/src/form.rs
@@ -33,7 +33,7 @@
 use crate::prelude::{
     any::TypeId,
     fmt::Debug,
-    marker::PhantomData,
+    string::String,
 };
 
 use crate::{
@@ -80,12 +80,9 @@ impl Form for MetaForm {
 /// `type String` is owned in order to enable decoding
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
-pub struct CompactForm<S = &'static str>(PhantomData<S>);
+pub enum CompactForm {}
 
-impl<S> Form for CompactForm<S>
-where
-    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug
-{
+impl Form for CompactForm {
     type Type = UntrackedSymbol<TypeId>;
-    type String = S;
+    type String = String;
 }

--- a/src/form.rs
+++ b/src/form.rs
@@ -33,13 +33,15 @@
 use crate::prelude::{
     any::TypeId,
     fmt::Debug,
-    string::String,
+    marker::PhantomData,
 };
 
 use crate::{
     interner::UntrackedSymbol,
     meta_type::MetaType,
 };
+
+#[cfg(feature = "std")]
 use serde::Serialize;
 
 /// Trait to control the internal structures of type definitions.
@@ -51,14 +53,15 @@ pub trait Form {
     /// The type representing the type.
     type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
     /// The string type.
-    type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+    type String: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
 }
 
 /// A meta meta-type.
 ///
 /// Allows to be converted into other forms such as compact form
 /// through the registry and `IntoCompact`.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Serialize))]
 pub enum MetaForm {}
 
 impl Form for MetaForm {
@@ -75,10 +78,14 @@ impl Form for MetaForm {
 /// underlying data.
 ///
 /// `type String` is owned in order to enable decoding
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
-pub enum CompactForm {}
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+pub struct CompactForm<S = &'static str>(PhantomData<S>);
 
-impl Form for CompactForm {
+impl<S> Form for CompactForm<S>
+where
+    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug
+{
     type Type = UntrackedSymbol<TypeId>;
-    type String = String;
+    type String = S;
 }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -31,6 +31,7 @@ use crate::prelude::{
     vec::Vec,
 };
 
+#[cfg(feature = "std")]
 use serde::{
     Deserialize,
     Serialize,
@@ -40,12 +41,13 @@ use serde::{
 ///
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(transparent))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     id: NonZeroU32,
-    #[serde(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     marker: PhantomData<fn() -> T>,
 }
 
@@ -79,11 +81,12 @@ impl<T> UntrackedSymbol<T> {
 /// A symbol from an interner.
 ///
 /// Can be used to resolve to the associated instance.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(transparent))]
 pub struct Symbol<'a, T> {
     id: NonZeroU32,
-    #[serde(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     marker: PhantomData<fn() -> &'a T>,
 }
 
@@ -120,15 +123,16 @@ impl<T> Symbol<'_, T> {
 ///
 /// This is used in order to quite efficiently cache strings and type
 /// definitions uniquely identified by their associated type identifiers.
-#[derive(Debug, PartialEq, Eq, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(transparent))]
 pub struct Interner<T> {
     /// A mapping from the interned elements to their respective compact
     /// identifiers.
     ///
     /// The idenfitiers can be used to retrieve information about the original
     /// element from the interner.
-    #[serde(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     map: BTreeMap<T, usize>,
     /// The ordered sequence of cached elements.
     ///

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -31,7 +31,7 @@ use crate::prelude::{
     vec::Vec,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     Deserialize,
     Serialize,
@@ -42,12 +42,12 @@ use serde::{
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     id: NonZeroU32,
-    #[cfg_attr(feature = "std", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     marker: PhantomData<fn() -> T>,
 }
 
@@ -82,11 +82,11 @@ impl<T> UntrackedSymbol<T> {
 ///
 /// Can be used to resolve to the associated instance.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "std", derive(Serialize))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Symbol<'a, T> {
     id: NonZeroU32,
-    #[cfg_attr(feature = "std", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     marker: PhantomData<fn() -> &'a T>,
 }
 
@@ -124,15 +124,15 @@ impl<T> Symbol<'_, T> {
 /// This is used in order to quite efficiently cache strings and type
 /// definitions uniquely identified by their associated type identifiers.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Serialize))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Interner<T> {
     /// A mapping from the interned elements to their respective compact
     /// identifiers.
     ///
     /// The idenfitiers can be used to retrieve information about the original
     /// element from the interner.
-    #[cfg_attr(feature = "std", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     map: BTreeMap<T, usize>,
     /// The ordered sequence of cached elements.
     ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -210,9 +210,9 @@ pub struct RegistryReadOnly {
 
 impl From<Registry> for RegistryReadOnly {
     fn from(registry: Registry) -> Self {
-        let encoded = registry.encode();
-        Decode::decode(&mut &encoded[..])
-            .expect("Encoded registry should be decodable as a read-only version")
+        RegistryReadOnly {
+            types: registry.types.values().cloned().collect::<Vec<_>>(),
+        }
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -30,6 +30,7 @@ use crate::prelude::{
     mem,
     num::NonZeroU32,
     vec::Vec,
+    string::ToString,
 };
 
 use crate::{

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -30,7 +30,6 @@ use crate::prelude::{
     mem,
     num::NonZeroU32,
     vec::Vec,
-    string::String,
 };
 
 use crate::{
@@ -68,7 +67,7 @@ impl IntoCompact for &'static str {
     type Output = <CompactForm as Form>::String;
 
     fn into_compact(self, _registry: &mut Registry) -> Self::Output {
-        self
+        self.to_string()
     }
 }
 
@@ -206,7 +205,7 @@ impl Registry {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Decode)]
 pub struct RegistryReadOnly {
-    types: Vec<Type<CompactForm<String>>>,
+    types: Vec<Type<CompactForm>>,
 }
 
 impl From<Registry> for RegistryReadOnly {
@@ -219,12 +218,12 @@ impl From<Registry> for RegistryReadOnly {
 
 impl RegistryReadOnly {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
-    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm<String>>> {
+    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
         self.types.get((id.get() - 1) as usize)
     }
 
     /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
-    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm<String>>)> {
+    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm>)> {
         self.types.iter().enumerate().map(|(i, ty)| {
             let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
             (id, ty)

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -29,8 +29,8 @@ use crate::prelude::{
     collections::BTreeMap,
     mem,
     num::NonZeroU32,
-    vec::Vec,
     string::ToString,
+    vec::Vec,
 };
 
 use crate::{

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -49,7 +49,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     Deserialize,
     Serialize,
@@ -85,24 +85,24 @@ impl IntoCompact for &'static str {
 /// A type can be a sub-type of itself. In this case the registry has a builtin
 /// mechanism to stop recursion before going into an infinite loop.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Registry {
     /// The cache for already registered types.
     ///
     /// This is just an accessor to the actual database
     /// for all types found in the `types` field.
-    #[cfg_attr(feature = "std", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     type_table: Interner<TypeId>,
     /// The database where registered types actually reside.
     ///
     /// This is going to be serialized upon serlialization.
-    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_registry_types"))]
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_registry_types"))]
     types: BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
 }
 
 /// Serializes the types of the registry by removing their unique IDs
 /// and instead serialize them in order of their removed unique ID.
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 fn serialize_registry_types<S>(
     types: &BTreeMap<UntrackedSymbol<core::any::TypeId>, Type<CompactForm>>,
     serializer: S,
@@ -203,7 +203,7 @@ impl Registry {
 }
 
 /// A read-only registry, to be used for decoding/deserializing
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Decode)]
 pub struct RegistryReadOnly {
     types: Vec<Type<CompactForm<String>>>,

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -29,6 +29,7 @@ use scale::{
     Decode,
     Encode,
 };
+#[cfg(feature = "std")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -69,19 +70,18 @@ use serde::{
     Clone,
     Debug,
     From,
-    Serialize,
-    Deserialize,
     Encode,
     Decode,
 )]
-#[serde(bound(
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
-#[serde(rename_all = "lowercase")]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
     fields: Vec<Field<T>>,
 }
 

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -62,7 +62,6 @@ use serde::{
 /// ```
 /// struct JustAMarker;
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -72,6 +71,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.
     #[cfg_attr(

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -29,7 +29,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -73,15 +73,15 @@ use serde::{
     Encode,
     Decode,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
     fields: Vec<Field<T>>,
 }
 

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -62,26 +62,22 @@ use serde::{
 /// ```
 /// struct JustAMarker;
 /// ```
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    Debug,
-    From,
-    Encode,
-    Decode,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Vec::is_empty", default)
+    )]
     fields: Vec<Field<T>>,
 }
 

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -27,7 +27,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -63,18 +63,18 @@ use serde::{
 /// is possible to infer certain properties e.g. whether a type name is a type alias,
 /// there are no guarantees provided, and the type name representation may change.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     name: Option<T::String>,
     /// The type of the field.
-    #[cfg_attr(feature = "std", serde(rename = "type"))]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     ty: T::Type,
     /// The name of the type of the field as it appears in the source code.
     type_name: T::String,

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -64,14 +64,20 @@ use serde::{
 /// there are no guarantees provided, and the type name representation may change.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
     name: Option<T::String>,
     /// The type of the field.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -27,6 +27,7 @@ use scale::{
     Decode,
     Encode,
 };
+#[cfg(feature = "std")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -61,20 +62,19 @@ use serde::{
 /// This is intended for informational and diagnostic purposes only. Although it
 /// is possible to infer certain properties e.g. whether a type name is a type alias,
 /// there are no guarantees provided, and the type name representation may change.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode,
-)]
-#[serde(bound(
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
-#[serde(rename_all = "camelCase")]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
     name: Option<T::String>,
     /// The type of the field.
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "std", serde(rename = "type"))]
     ty: T::Type,
     /// The name of the type of the field as it appears in the source code.
     type_name: T::String,

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -62,7 +62,6 @@ use serde::{
 /// This is intended for informational and diagnostic purposes only. Although it
 /// is possible to infer certain properties e.g. whether a type name is a type alias,
 /// there are no guarantees provided, and the type name representation may change.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -72,6 +71,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.
     #[cfg_attr(

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -54,29 +54,28 @@ pub use self::{
 };
 
 /// A [`Type`] definition with optional metadata.
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    From,
-    Debug,
-    Encode,
-    Decode,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Path::is_empty", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Path::is_empty", default)
+    )]
     path: Path<T>,
     /// The generic type parameters of the type in use. Empty for non generic types
-    #[cfg_attr(feature = "serde", serde(rename = "params", skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)
+    )]
     type_params: Vec<T::Type>,
     /// The actual type definition
     #[cfg_attr(feature = "serde", serde(rename = "def"))]
@@ -159,22 +158,15 @@ where
 }
 
 /// The possible types a SCALE encodable Rust value could have.
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    From,
-    Debug,
-    Encode,
-    Decode,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -245,10 +237,13 @@ pub enum TypeDefPrimitive {
 
 /// An array type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -294,10 +289,13 @@ where
 
 /// A type to refer to tuple types.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
@@ -345,10 +343,13 @@ where
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -34,6 +34,7 @@ use scale::{
     Decode,
     Encode,
 };
+#[cfg(feature = "std")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -61,24 +62,24 @@ pub use self::{
     Clone,
     From,
     Debug,
-    Serialize,
-    Deserialize,
     Encode,
     Decode,
 )]
-#[serde(bound(
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
-    #[serde(skip_serializing_if = "Path::is_empty", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Path::is_empty", default))]
     path: Path<T>,
     /// The generic type parameters of the type in use. Empty for non generic types
-    #[serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(feature = "std", serde(rename = "params", skip_serializing_if = "Vec::is_empty", default))]
     type_params: Vec<T::Type>,
     /// The actual type definition
-    #[serde(rename = "def")]
+    #[cfg_attr(feature = "std", serde(rename = "def"))]
     type_def: TypeDef<T>,
 }
 
@@ -166,16 +167,15 @@ where
     Clone,
     From,
     Debug,
-    Serialize,
-    Deserialize,
     Encode,
     Decode,
 )]
-#[serde(bound(
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
-#[serde(rename_all = "camelCase")]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
     Composite(TypeDefComposite<T>),
@@ -207,10 +207,9 @@ impl IntoCompact for TypeDef {
 }
 
 /// A primitive Rust type.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
-)]
-#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
 pub enum TypeDefPrimitive {
     /// `bool` type
     Bool,
@@ -245,18 +244,17 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
-)]
-#[serde(bound(
-    serialize = "T::Type: Serialize",
-    deserialize = "T::Type: DeserializeOwned"
-))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
     len: u32,
     /// The element type of the array type.
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "std", serde(rename = "type"))]
     type_param: T::Type,
 }
 
@@ -295,14 +293,13 @@ where
 }
 
 /// A type to refer to tuple types.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
-)]
-#[serde(bound(
-    serialize = "T::Type: Serialize",
-    deserialize = "T::Type: DeserializeOwned"
-))]
-#[serde(transparent)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(transparent))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
     fields: Vec<T::Type>,
@@ -346,16 +343,15 @@ where
 }
 
 /// A type to refer to a sequence of elements of the same type.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode, Debug,
-)]
-#[serde(bound(
-    serialize = "T::Type: Serialize",
-    deserialize = "T::Type: DeserializeOwned"
-))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
+    serialize = "T::Type: Serialize, T::String: Serialize",
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "std", serde(rename = "type"))]
     type_param: T::Type,
 }
 

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -54,7 +54,6 @@ pub use self::{
 };
 
 /// A [`Type`] definition with optional metadata.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -64,6 +63,7 @@ pub use self::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
     #[cfg_attr(
@@ -158,7 +158,6 @@ where
 }
 
 /// The possible types a SCALE encodable Rust value could have.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -168,6 +167,7 @@ where
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
     Composite(TypeDefComposite<T>),
@@ -199,8 +199,8 @@ impl IntoCompact for TypeDef {
 }
 
 /// A primitive Rust type.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -236,6 +236,7 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -244,7 +245,6 @@ pub enum TypeDefPrimitive {
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
     len: u32,
@@ -341,7 +341,6 @@ where
 }
 
 /// A type to refer to a sequence of elements of the same type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -350,6 +349,7 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -34,7 +34,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -65,21 +65,21 @@ pub use self::{
     Encode,
     Decode,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Path::is_empty", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Path::is_empty", default))]
     path: Path<T>,
     /// The generic type parameters of the type in use. Empty for non generic types
-    #[cfg_attr(feature = "std", serde(rename = "params", skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(feature = "serde", serde(rename = "params", skip_serializing_if = "Vec::is_empty", default))]
     type_params: Vec<T::Type>,
     /// The actual type definition
-    #[cfg_attr(feature = "std", serde(rename = "def"))]
+    #[cfg_attr(feature = "serde", serde(rename = "def"))]
     type_def: TypeDef<T>,
 }
 
@@ -170,12 +170,12 @@ where
     Encode,
     Decode,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
     Composite(TypeDefComposite<T>),
@@ -207,9 +207,9 @@ impl IntoCompact for TypeDef {
 }
 
 /// A primitive Rust type.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum TypeDefPrimitive {
     /// `bool` type
     Bool,
@@ -244,8 +244,8 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
@@ -254,7 +254,7 @@ pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
     len: u32,
     /// The element type of the array type.
-    #[cfg_attr(feature = "std", serde(rename = "type"))]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     type_param: T::Type,
 }
 
@@ -293,12 +293,12 @@ where
 }
 
 /// A type to refer to tuple types.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -344,14 +344,14 @@ where
 
 /// A type to refer to a sequence of elements of the same type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
-    #[cfg_attr(feature = "std", serde(rename = "type"))]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     type_param: T::Type,
 }
 

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -52,10 +52,13 @@ use serde::{
 /// Rust prelude type may have an empty namespace definition.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -36,7 +36,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -51,12 +51,12 @@ use serde::{
 ///
 /// Rust prelude type may have an empty namespace definition.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.
     segments: Vec<T::String>,

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -36,6 +36,7 @@ use scale::{
     Decode,
     Encode,
 };
+#[cfg(feature = "std")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -49,14 +50,13 @@ use serde::{
 /// has been defined. The last
 ///
 /// Rust prelude type may have an empty namespace definition.
-#[derive(
-    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, Encode, Decode,
-)]
-#[serde(transparent)]
-#[serde(bound(
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(transparent))]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.
     segments: Vec<T::String>,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -75,26 +75,22 @@ use serde::{
 /// ```
 /// enum JustAMarker {}
 /// ```
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    Debug,
-    From,
-    Encode,
-    Decode,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Vec::is_empty", default)
+    )]
     variants: Vec<Variant<T>>,
 }
 
@@ -147,15 +143,21 @@ where
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(
-    serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
-)))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.
     name: T::String,
     /// The fields of the variant.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Vec::is_empty", default)
+    )]
     fields: Vec<Field<T>>,
     /// The discriminant of the variant.
     ///
@@ -164,7 +166,10 @@ pub struct Variant<T: Form = MetaForm> {
     /// Even though setting the discriminant is optional
     /// every C-like enum variant has a discriminant specified
     /// upon compile-time.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
     discriminant: Option<u64>,
 }
 

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -75,7 +75,6 @@ use serde::{
 /// ```
 /// enum JustAMarker {}
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -85,6 +84,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
     #[cfg_attr(
@@ -141,7 +141,6 @@ where
 /// //  ^^^^^^^^^^^^^^^^^^^^^ this is a struct enum variant
 /// }
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -150,6 +149,7 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.
     name: T::String,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -30,7 +30,7 @@ use scale::{
     Decode,
     Encode,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -86,15 +86,15 @@ use serde::{
     Encode,
     Decode,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
     variants: Vec<Variant<T>>,
 }
 
@@ -146,8 +146,8 @@ where
 /// }
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(bound(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
     deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
 )))]
@@ -155,7 +155,7 @@ pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.
     name: T::String,
     /// The fields of the variant.
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
     fields: Vec<Field<T>>,
     /// The discriminant of the variant.
     ///
@@ -164,7 +164,7 @@ pub struct Variant<T: Form = MetaForm> {
     /// Even though setting the discriminant is optional
     /// every C-like enum variant has a discriminant specified
     /// upon compile-time.
-    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     discriminant: Option<u64>,
 }
 

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -30,6 +30,7 @@ use scale::{
     Decode,
     Encode,
 };
+#[cfg(feature = "std")]
 use serde::{
     de::DeserializeOwned,
     Deserialize,
@@ -82,19 +83,18 @@ use serde::{
     Clone,
     Debug,
     From,
-    Serialize,
-    Deserialize,
     Encode,
     Decode,
 )]
-#[serde(bound(
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
-#[serde(rename_all = "lowercase")]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
+#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
     variants: Vec<Variant<T>>,
 }
 
@@ -145,18 +145,17 @@ where
 /// //  ^^^^^^^^^^^^^^^^^^^^^ this is a struct enum variant
 /// }
 /// ```
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize, Encode, Decode,
-)]
-#[serde(bound(
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(
     serialize = "T::Type: Serialize, T::String: Serialize",
-    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned"
-))]
+    deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+)))]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.
     name: T::String,
     /// The fields of the variant.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty", default))]
     fields: Vec<Field<T>>,
     /// The discriminant of the variant.
     ///
@@ -165,7 +164,7 @@ pub struct Variant<T: Form = MetaForm> {
     /// Even though setting the discriminant is optional
     /// every C-like enum variant has a discriminant specified
     /// upon compile-time.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none", default))]
     discriminant: Option<u64>,
 }
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scale-info = { path = "..", features = ["derive"] }
+scale-info = { path = "..", features = ["derive", "serde"] }
 
 scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
 serde = "1.0"


### PR DESCRIPTION
Makes the `serde` dependency optional, as per the convention. 

Integrating into the substrate runtime, we don't want or need a dependency on serde since it will be using SCALE encoding to marshal the metadata from the runtime.