### PR TITLE
Parameterize CompactForm String for optional SCALE impl

### DIFF
--- a/src/form.rs
+++ b/src/form.rs
@@ -34,6 +34,7 @@ use crate::prelude::{
     any::TypeId,
     fmt::Debug,
     marker::PhantomData,
+    string::String,
 };
 
 use crate::{
@@ -53,8 +54,17 @@ pub trait Form {
     /// The type representing the type.
     type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
     /// The string type.
-    type String: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+    type String: FormString;
 }
+
+/// Trait for types which can be used to represent strings in type definitions.
+pub trait FormString:
+    AsRef<str> + PartialEq + Eq + PartialOrd + Ord + Clone + Debug
+{
+}
+
+impl FormString for &'static str {}
+impl FormString for String {}
 
 /// A meta meta-type.
 ///
@@ -84,7 +94,7 @@ pub struct CompactForm<S = &'static str>(PhantomData<S>);
 
 impl<S> Form for CompactForm<S>
 where
-    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+    S: FormString,
 {
     type Type = UntrackedSymbol<TypeId>;
     type String = S;

--- a/src/form.rs
+++ b/src/form.rs
@@ -78,7 +78,8 @@ impl Form for MetaForm {
 /// underlying data.
 ///
 /// `type String` is owned in order to enable decoding
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub struct CompactForm<S = &'static str>(PhantomData<S>);
 
 impl<S> Form for CompactForm<S>

--- a/src/form.rs
+++ b/src/form.rs
@@ -33,7 +33,7 @@
 use crate::prelude::{
     any::TypeId,
     fmt::Debug,
-    string::String,
+    marker::PhantomData,
 };
 
 use crate::{
@@ -51,7 +51,7 @@ pub trait Form {
     /// The type representing the type.
     type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
     /// The string type.
-    type String: Serialize + PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+    type String: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
 }
 
 /// A meta meta-type.
@@ -76,9 +76,12 @@ impl Form for MetaForm {
 ///
 /// `type String` is owned in order to enable decoding
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Debug)]
-pub enum CompactForm {}
+pub struct CompactForm<S = &'static str>(PhantomData<S>);
 
-impl Form for CompactForm {
+impl<S> Form for CompactForm<S>
+where
+    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+{
     type Type = UntrackedSymbol<TypeId>;
-    type String = String;
+    type String = S;
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -206,7 +206,10 @@ impl Registry {
 /// A read-only registry, to be used for decoding/deserializing
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Decode)]
-#[cfg_attr(feature = "serde", serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned")))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
+)]
 pub struct RegistryReadOnly<S = &'static str>
 where
     S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -204,8 +204,9 @@ impl Registry {
 }
 
 /// A read-only registry, to be used for decoding/deserializing
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Decode)]
-#[serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned",))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Decode)]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned")))]
 pub struct RegistryReadOnly<S = &'static str>
 where
     S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -27,9 +27,9 @@
 use crate::prelude::{
     any::TypeId,
     collections::BTreeMap,
+    fmt::Debug,
     mem,
     num::NonZeroU32,
-    string::ToString,
     vec::Vec,
 };
 
@@ -50,6 +50,7 @@ use scale::{
     Encode,
 };
 use serde::{
+    de::DeserializeOwned,
     Deserialize,
     Serialize,
 };
@@ -67,7 +68,7 @@ impl IntoCompact for &'static str {
     type Output = <CompactForm as Form>::String;
 
     fn into_compact(self, _registry: &mut Registry) -> Self::Output {
-        self.to_string()
+        self
     }
 }
 
@@ -201,8 +202,12 @@ impl Registry {
 
 /// A read-only registry, to be used for decoding/deserializing
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Decode)]
-pub struct RegistryReadOnly {
-    types: Vec<Type<CompactForm>>,
+#[serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned",))]
+pub struct RegistryReadOnly<S = &'static str>
+where
+    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+{
+    types: Vec<Type<CompactForm<S>>>,
 }
 
 impl From<Registry> for RegistryReadOnly {
@@ -213,14 +218,17 @@ impl From<Registry> for RegistryReadOnly {
     }
 }
 
-impl RegistryReadOnly {
+impl<S> RegistryReadOnly<S>
+where
+    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+{
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
-    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm>> {
+    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm<S>>> {
         self.types.get((id.get() - 1) as usize)
     }
 
     /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
-    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm>)> {
+    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<CompactForm<S>>)> {
         self.types.iter().enumerate().map(|(i, ty)| {
             let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
             (id, ty)

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -37,6 +37,7 @@ use crate::{
     form::{
         CompactForm,
         Form,
+        FormString,
     },
     interner::{
         Interner,
@@ -212,7 +213,7 @@ impl Registry {
 )]
 pub struct RegistryReadOnly<S = &'static str>
 where
-    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+    S: FormString,
 {
     types: Vec<Type<CompactForm<S>>>,
 }
@@ -227,7 +228,7 @@ impl From<Registry> for RegistryReadOnly {
 
 impl<S> RegistryReadOnly<S>
 where
-    S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+    S: FormString,
 {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
     pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<CompactForm<S>>> {

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -28,6 +28,7 @@ use scale_info::{
     form::CompactForm,
     prelude::{
         num::NonZeroU32,
+        string::String,
         vec,
         vec::Vec,
     },
@@ -60,7 +61,7 @@ fn scale_encode_then_decode_to_readonly() {
     let mut encoded = registry.encode();
     let original_serialized = serde_json::to_value(registry).unwrap();
 
-    let readonly_decoded = RegistryReadOnly::decode(&mut &encoded[..]).unwrap();
+    let readonly_decoded = RegistryReadOnly::<String>::decode(&mut &encoded[..]).unwrap();
     assert!(readonly_decoded
         .resolve(NonZeroU32::new(1).unwrap())
         .is_some());
@@ -76,7 +77,7 @@ fn json_serialize_then_deserialize_to_readonly() {
 
     let original_serialized = serde_json::to_value(registry).unwrap();
     // assert_eq!(original_serialized, serde_json::Value::Null);
-    let readonly_deserialized: RegistryReadOnly =
+    let readonly_deserialized: RegistryReadOnly<String> =
         serde_json::from_value(original_serialized.clone()).unwrap();
     assert!(readonly_deserialized
         .resolve(NonZeroU32::new(1).unwrap())


### PR DESCRIPTION
By default, parity-scale-codec does not provide Encode/Decode impls for an owned String.
This is only provided under the "full" feature which is not used by the substrate runtime,
because it should not be used for consensus critical code. So in order for the CompactForm
to be integrated into the substrate runtime, or wherever the "full" feature cannot be used,
then we must parameterize the `String` type so that it can be both an `&'static str` on the
runtime side where it is encoded, and a `String` in client/consuming code where it is decoded.

Note that previously I had done something similar with `OwnedForm` discussed with @Robbepop [here](https://github.com/paritytech/scale-info/pull/19#discussion_r472238289). But this or something similar is now required in case we want to generate the metadata directly inside the substrate runtime where `String`s are not allowed.