### PR TITLE
Use PortableRegistry for encoding and serializing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub use self::{
     registry::{
         IntoPortable,
         Registry,
-        RegistryReadOnly,
+        PortableRegistry,
     },
     ty::*,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,8 @@ pub use self::{
     meta_type::MetaType,
     registry::{
         IntoPortable,
-        Registry,
         PortableRegistry,
+        Registry,
     },
     ty::*,
 };

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -169,29 +169,29 @@ impl Registry {
     }
 }
 
-/// A read-only registry, to be used for decoding/deserializing
+/// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(
     feature = "serde",
     serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
 )]
-pub struct RegistryReadOnly<S = &'static str>
+pub struct PortableRegistry<S = &'static str>
 where
     S: FormString,
 {
     types: Vec<Type<PortableForm<S>>>,
 }
 
-impl From<Registry> for RegistryReadOnly {
+impl From<Registry> for PortableRegistry {
     fn from(registry: Registry) -> Self {
-        RegistryReadOnly {
+        PortableRegistry {
             types: registry.types.values().cloned().collect::<Vec<_>>(),
         }
     }
 }
 
-impl<S> RegistryReadOnly<S>
+impl<S> PortableRegistry<S>
 where
     S: FormString,
 {
@@ -229,7 +229,7 @@ mod tests {
         registry.register_type(&MetaType::new::<bool>());
         registry.register_type(&MetaType::new::<Option<(u32, bool)>>());
 
-        let readonly: RegistryReadOnly = registry.into();
+        let readonly: PortableRegistry = registry.into();
 
         assert_eq!(4, readonly.enumerate().count());
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -28,7 +28,6 @@ use crate::prelude::{
     any::TypeId,
     collections::BTreeMap,
     fmt::Debug,
-    mem,
     num::NonZeroU32,
     vec::Vec,
 };
@@ -172,7 +171,7 @@ impl Registry {
 
 /// A read-only registry, to be used for decoding/deserializing
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Decode)]
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(
     feature = "serde",
     serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -58,6 +58,7 @@ fn scale_encode_then_decode_to_readonly() {
     let mut registry = Registry::new();
     registry.register_type(&MetaType::new::<A<B>>());
 
+    let registry: RegistryReadOnly = registry.into();
     let mut encoded = registry.encode();
     let original_serialized = serde_json::to_value(registry).unwrap();
 
@@ -75,6 +76,7 @@ fn json_serialize_then_deserialize_to_readonly() {
     let mut registry = Registry::new();
     registry.register_type(&MetaType::new::<A<B>>());
 
+    let registry: RegistryReadOnly = registry.into();
     let original_serialized = serde_json::to_value(registry).unwrap();
     // assert_eq!(original_serialized, serde_json::Value::Null);
     let readonly_deserialized: RegistryReadOnly<String> =

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -35,7 +35,7 @@ use scale_info::{
     IntoPortable as _,
     MetaType,
     Registry,
-    RegistryReadOnly,
+    PortableRegistry,
     TypeInfo,
 };
 
@@ -58,11 +58,11 @@ fn scale_encode_then_decode_to_readonly() {
     let mut registry = Registry::new();
     registry.register_type(&MetaType::new::<A<B>>());
 
-    let registry: RegistryReadOnly = registry.into();
+    let registry: PortableRegistry = registry.into();
     let mut encoded = registry.encode();
     let original_serialized = serde_json::to_value(registry).unwrap();
 
-    let readonly_decoded = RegistryReadOnly::<String>::decode(&mut &encoded[..]).unwrap();
+    let readonly_decoded = PortableRegistry::<String>::decode(&mut &encoded[..]).unwrap();
     assert!(readonly_decoded
         .resolve(NonZeroU32::new(1).unwrap())
         .is_some());
@@ -76,10 +76,10 @@ fn json_serialize_then_deserialize_to_readonly() {
     let mut registry = Registry::new();
     registry.register_type(&MetaType::new::<A<B>>());
 
-    let registry: RegistryReadOnly = registry.into();
+    let registry: PortableRegistry = registry.into();
     let original_serialized = serde_json::to_value(registry).unwrap();
     // assert_eq!(original_serialized, serde_json::Value::Null);
-    let readonly_deserialized: RegistryReadOnly<String> =
+    let readonly_deserialized: PortableRegistry<String> =
         serde_json::from_value(original_serialized.clone()).unwrap();
     assert!(readonly_deserialized
         .resolve(NonZeroU32::new(1).unwrap())

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -34,8 +34,8 @@ use scale_info::{
     },
     IntoPortable as _,
     MetaType,
-    Registry,
     PortableRegistry,
+    Registry,
     TypeInfo,
 };
 

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -32,7 +32,7 @@ use scale_info::{
     meta_type,
     IntoPortable as _,
     Registry,
-    RegistryReadOnly,
+    PortableRegistry,
     TypeInfo,
 };
 use serde_json::json;
@@ -297,7 +297,7 @@ fn test_recursive_type_with_box() {
         ]
     });
 
-    let registry: RegistryReadOnly = registry.into();
+    let registry: PortableRegistry = registry.into();
     assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }
 
@@ -498,6 +498,6 @@ fn test_registry() {
         ]
     });
 
-    let registry: RegistryReadOnly = registry.into();
+    let registry: PortableRegistry = registry.into();
     assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -32,6 +32,7 @@ use scale_info::{
     meta_type,
     IntoCompact as _,
     Registry,
+    RegistryReadOnly,
     TypeInfo,
 };
 use serde_json::json;
@@ -296,6 +297,7 @@ fn test_recursive_type_with_box() {
         ]
     });
 
+    let registry: RegistryReadOnly = registry.into();
     assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }
 
@@ -496,5 +498,6 @@ fn test_registry() {
         ]
     });
 
+    let registry: RegistryReadOnly = registry.into();
     assert_eq!(serde_json::to_value(registry).unwrap(), expected_json,);
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -31,8 +31,8 @@ use scale_info::{
     form::PortableForm,
     meta_type,
     IntoPortable as _,
-    Registry,
     PortableRegistry,
+    Registry,
     TypeInfo,
 };
 use serde_json::json;


### PR DESCRIPTION
Removes custom encoding/serialization from the `Registry` and instead uses the `PortableRegistry` which already provides a `From<Registry>` impl.