### PR TITLE
Add a new TypeDef variant to handle PhantomData

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -245,7 +245,7 @@ impl<T> TypeInfo for PhantomData<T>
 where
     T: TypeInfo + ?Sized + 'static,
 {
-    type Identity = T;
+    type Identity = Self;
 
     fn type_info() -> Type {
         TypeDefPhantom::new(MetaType::new::<T>()).into()

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -17,17 +17,16 @@ use crate::prelude::{
     collections::BTreeMap,
     marker::PhantomData,
     string::String,
-    vec,
     vec::Vec,
 };
 
 use crate::{
     build::*,
-    meta_type,
     MetaType,
     Path,
     Type,
     TypeDefArray,
+    TypeDefPhantom,
     TypeDefPrimitive,
     TypeDefSequence,
     TypeDefTuple,
@@ -240,12 +239,9 @@ impl<T> TypeInfo for PhantomData<T>
 where
     T: TypeInfo + ?Sized + 'static,
 {
-    type Identity = Self;
+    type Identity = T;
 
     fn type_info() -> Type {
-        Type::builder()
-            .path(Path::prelude("PhantomData"))
-            .type_params(vec![meta_type::<T>()])
-            .composite(Fields::unit())
+        TypeDefPhantom::new(MetaType::new::<T>()).into()
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,13 +74,7 @@ fn prelude_items() {
                     .variant("Err", Fields::unnamed().field_of::<String>("E"))
             )
     );
-    assert_type!(
-        PhantomData<i32>,
-        Type::builder()
-            .path(Path::prelude("PhantomData"))
-            .type_params(tuple_meta_type!(i32))
-            .composite(Fields::unit())
-    );
+    assert_type!(PhantomData<i32>, TypeDefPhantom::new(meta_type::<i32>()));
 }
 
 #[test]
@@ -153,4 +147,34 @@ fn struct_with_generics() {
         .type_params(tuple_meta_type!(Box<MyStruct<bool>>))
         .composite(Fields::named().field_of::<Box<MyStruct<bool>>>("data", "T"));
     assert_type!(SelfTyped, expected_type);
+}
+
+#[test]
+fn basic_struct_with_phantoms() {
+    #[allow(unused)]
+    struct SomeStruct<T> {
+        a: u8,
+        marker: PhantomData<T>,
+    }
+
+    impl<T> TypeInfo for SomeStruct<T>
+    where
+        T: TypeInfo + 'static,
+    {
+        type Identity = Self;
+
+        fn type_info() -> Type {
+            Type::builder()
+                .path(Path::new("SomeStruct", module_path!()))
+                .type_params(tuple_meta_type!(T))
+                .composite(Fields::named().field_of::<u8>("a", "u8"))
+        }
+    }
+
+    let struct_bool_type_info = Type::builder()
+        .path(Path::from_segments(vec!["scale_info", "tests", "SomeStruct"]).unwrap())
+        .type_params(tuple_meta_type!(bool))
+        .composite(Fields::named().field_of::<u8>("a", "u8"));
+
+    assert_type!(SomeStruct<bool>, struct_bool_type_info);
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -410,6 +410,15 @@ where
 }
 
 /// A type describing a `PhantomData<T>` type.
+///
+/// In the context of SCALE encoded types, including `PhantomData<T>` types in
+/// the type info  might seem surprising. The reason to include this information
+/// is that there could be situations where it's useful and because removing
+/// `PhantomData` items from the derive input quickly becomes a messy
+/// syntax-level hack (see PR https://github.com/paritytech/scale-info/pull/31).
+/// Instead we take the same approach as `parity-scale-codec` where users are
+/// required to explicitly skip fields that cannot be represented in SCALE
+/// encoding, using the `#[codec(skip)]` attribute.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -414,8 +414,8 @@ where
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "T::Type: Serialize, T::String: Serialize",
-        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+        serialize = "T::Type: Serialize",
+        deserialize = "T::Type: DeserializeOwned",
     ))
 )]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -118,6 +118,16 @@ impl From<TypeDefTuple> for Type {
     }
 }
 
+impl From<TypeDefPhantom> for Type {
+    fn from(phantom: TypeDefPhantom) -> Self {
+        Self::new(
+            Path::prelude("PhantomData"),
+            vec![phantom.type_param],
+            phantom
+        )
+    }
+}
+
 impl Type {
     /// Create a [`TypeBuilder`](`crate::build::TypeBuilder`) the public API for constructing a [`Type`]
     pub fn builder() -> TypeBuilder {
@@ -181,6 +191,8 @@ pub enum TypeDef<T: Form = MetaForm> {
     Tuple(TypeDefTuple<T>),
     /// A Rust primitive type.
     Primitive(TypeDefPrimitive),
+    /// A PhantomData type.
+    Phantom(TypeDefPhantom<T>),
 }
 
 impl IntoPortable for TypeDef {
@@ -194,6 +206,7 @@ impl IntoPortable for TypeDef {
             TypeDef::Array(array) => array.into_portable(registry).into(),
             TypeDef::Tuple(tuple) => tuple.into_portable(registry).into(),
             TypeDef::Primitive(primitive) => primitive.into(),
+            TypeDef::Phantom(phantom) => phantom.into_portable(registry).into(),
         }
     }
 }
@@ -391,6 +404,49 @@ where
     T: Form,
 {
     /// Returns the element type of the sequence type.
+    pub fn type_param(&self) -> &T::Type {
+        &self.type_param
+    }
+}
+
+/// A type describing a `PhantomData<T>` type.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T::Type: Serialize, T::String: Serialize",
+        deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
+    ))
+)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+pub struct TypeDefPhantom<T: Form = MetaForm> {
+    /// The PhantomData type parameter
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    type_param: T::Type,
+}
+
+impl IntoPortable for TypeDefPhantom {
+    type Output = TypeDefPhantom<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        TypeDefPhantom {
+            type_param: registry.register_type(&self.type_param),
+        }
+    }
+}
+
+impl TypeDefPhantom {
+    /// Creates a new phantom type.
+    pub fn new(type_param: MetaType) -> Self {
+        Self { type_param }
+    }
+}
+
+impl<T> TypeDefPhantom<T>
+where
+    T: Form,
+{
+    /// Returns the type parameter type of the phantom type.
     pub fn type_param(&self) -> &T::Type {
         &self.type_param
     }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -445,7 +445,7 @@ impl IntoPortable for TypeDefPhantom {
 }
 
 impl TypeDefPhantom {
-    /// Creates a new phantom type.
+    /// Creates a new phantom type definition.
     pub fn new(type_param: MetaType) -> Self {
         Self { type_param }
     }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -123,7 +123,7 @@ impl From<TypeDefPhantom> for Type {
         Self::new(
             Path::prelude("PhantomData"),
             vec![phantom.type_param],
-            phantom
+            phantom,
         )
     }
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -120,11 +120,7 @@ impl From<TypeDefTuple> for Type {
 
 impl From<TypeDefPhantom> for Type {
     fn from(phantom: TypeDefPhantom) -> Self {
-        Self::new(
-            Path::prelude("PhantomData"),
-            vec![phantom.type_param],
-            phantom,
-        )
+        Self::new(Path::voldemort(), Vec::new(), phantom)
     }
 }
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -76,7 +76,6 @@ fn struct_derive() {
     assert_type!(SelfTyped, self_typed_type);
 }
 
-// TODO: dp – no need to keep all of these tests; pick one and toss the rest.
 #[test]
 fn phantom_types_in_structs() {
     #[allow(unused)]
@@ -96,105 +95,6 @@ fn phantom_types_in_structs() {
         );
 
     assert_type!(P<bool>, ty);
-}
-
-#[test]
-fn phantom_types_are_derived_in_tuple_structs() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct Tuppy<T>(u8, PhantomData<T>);
-
-    let tuppy = Type::builder()
-        .path(Path::new("Tuppy", "derive"))
-        .type_params(tuple_meta_type!(()))
-        .composite(
-            Fields::unnamed()
-                .field_of::<u8>("u8")
-                .field_of::<()>("PhantomData<T>"),
-        );
-
-    assert_type!(Tuppy<()>, tuppy);
-}
-
-#[test]
-fn phantoms_are_derived_in_struct_with_tuple_members() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct WithTuples<TT, UU> {
-        a: (u8, PhantomData<TT>, u32, PhantomData<UU>),
-    }
-
-    let ty = Type::builder()
-        .path(Path::new("WithTuples", "derive"))
-        .type_params(tuple_meta_type!(u16, u64))
-        .composite(
-            Fields::named().field_of::<(u8, PhantomData<u16>, u32, PhantomData<u64>)>(
-                "a",
-                "(u8, PhantomData<TT>, u32, PhantomData<UU>)",
-            ),
-        );
-
-    assert_type!(WithTuples<u16, u64>, ty);
-}
-
-#[test]
-fn phantom_types_are_derived_in_enums() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct Chocolate<Flavour> {
-        flavour: PhantomData<Flavour>,
-    }
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    enum Choices<F> {
-        Nutella,
-        RealThing(Chocolate<F>),
-        Marshmallow(PhantomData<F>),
-    }
-
-    let ty = Type::builder()
-        .path(Path::new("Choices", "derive"))
-        .type_params(tuple_meta_type!(bool))
-        .variant(
-            Variants::with_fields()
-                .variant_unit("Nutella")
-                .variant(
-                    "RealThing",
-                    Fields::unnamed().field_of::<Chocolate<bool>>("Chocolate<F>"),
-                )
-                .variant(
-                    "Marshmallow",
-                    Fields::unnamed().field_of::<bool>("PhantomData<F>"),
-                ),
-        );
-
-    assert_type!(Choices<bool>, ty);
-}
-
-#[test]
-fn complex_enum_with_phantoms() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    enum Cake<Icing, Topping, Filling> {
-        A((PhantomData<Icing>, u8, PhantomData<Topping>, Filling)),
-        B,
-    }
-
-    let ty = Type::builder()
-        .path(Path::new("Cake", "derive"))
-        .type_params(tuple_meta_type!(bool, bool, u16))
-        .variant(
-            Variants::with_fields()
-                .variant(
-                    "A",
-                    Fields::unnamed()
-                        .field_of::<(PhantomData<bool>, u8, PhantomData<bool>, u16)>(
-                            "(PhantomData<Icing>, u8, PhantomData<Topping>, Filling)",
-                        ),
-                )
-                .variant_unit("B"),
-        );
-    assert_type!(Cake<bool, bool, u16>, ty);
 }
 
 #[test]
@@ -233,8 +133,6 @@ fn phantoms_in_nested_tuples() {
         teeth: (u8, u16, (u32, (PhantomData<T>, bool))),
     }
 
-    // rustc thinks `(u32, (bool))` is the same as `(u32, bool)`
-    #[allow(unused_parens)]
     let ty = Type::builder()
         .path(Path::new("A", "derive"))
         .type_params(tuple_meta_type!(u64))
@@ -243,7 +141,7 @@ fn phantoms_in_nested_tuples() {
                 .field_of::<bool>("is_a", "bool")
                 .field_of::<(u8, u16, (u32, (PhantomData<u64>, bool)))>(
                     "teeth",
-                    "(u8, u16,(u32,(PhantomData<T>, bool)))",
+                    "(u8, u16, (u32, (PhantomData<T>, bool)))",
                 ),
         );
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -77,7 +77,7 @@ fn struct_derive() {
 }
 
 #[test]
-fn phantom_types_in_structs() {
+fn phantom_data_is_part_of_the_type_info() {
     #[allow(unused)]
     #[derive(TypeInfo)]
     struct P<T> {
@@ -95,57 +95,6 @@ fn phantom_types_in_structs() {
         );
 
     assert_type!(P<bool>, ty);
-}
-
-#[test]
-fn nested_phantom_types_are_derived_in_structs() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct Door<Size> {
-        size: PhantomData<Size>,
-        b: u16,
-    }
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct House<TDoor> {
-        a: u8,
-        door: TDoor,
-    }
-
-    let house = Type::builder()
-        .path(Path::new("House", "derive"))
-        .type_params(tuple_meta_type!(Door<u16>))
-        .composite(
-            Fields::named()
-                .field_of::<u8>("a", "u8")
-                .field_of::<Door<u16>>("door", "TDoor"),
-        );
-
-    assert_type!(House<Door<u16>>, house);
-}
-
-#[test]
-fn phantoms_in_nested_tuples() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct A<T> {
-        is_a: bool,
-        teeth: (u8, u16, (u32, (PhantomData<T>, bool))),
-    }
-
-    let ty = Type::builder()
-        .path(Path::new("A", "derive"))
-        .type_params(tuple_meta_type!(u64))
-        .composite(
-            Fields::named()
-                .field_of::<bool>("is_a", "bool")
-                .field_of::<(u8, u16, (u32, (PhantomData<u64>, bool)))>(
-                    "teeth",
-                    "(u8, u16, (u32, (PhantomData<T>, bool)))",
-                ),
-        );
-
-    assert_type!(A<u64>, ty);
 }
 
 #[test]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -91,7 +91,7 @@ fn phantom_types_in_structs() {
         .composite(
             Fields::named()
                 .field_of::<u8>("a", "u8")
-                .field_of::<bool>("m", "PhantomData<T>"),
+                .field_of::<PhantomData<bool>>("m", "PhantomData<T>"),
         );
 
     assert_type!(P<bool>, ty);

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -211,7 +211,6 @@ fn test_struct_with_phantom() {
         "def": {
             "composite": {
                 "fields": [
-                    // TODO: dp – I was expecting "a" to be type 1 and "b" to be type 2; what am I missing?
                     { "name": "a", "type": 2, "typeName": "i32" },
                     { "name": "b", "type": 1, "typeName": "PhantomData<T>" },
                 ],

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -135,7 +135,6 @@ fn test_builtins() {
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
     assert_json_for_type::<PhantomData<bool>>(json!({
-        // TODO: dp – Not sure this is right, doesn't seem very useful?
         "path": ["PhantomData"],
         "def": { "phantom": { "type": 1 } },
         "params": [1]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -134,11 +134,7 @@ fn test_builtins() {
     assert_json_for_type::<String>(json!({ "def": { "primitive": "str" } }));
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
-    assert_json_for_type::<PhantomData<bool>>(json!({
-        "path": ["PhantomData"],
-        "def": { "phantom": { "type": 1 } },
-        "params": [1]
-    }))
+    assert_json_for_type::<PhantomData<bool>>(json!({ "def": { "phantom": { "type": 1 } }, }))
 }
 
 #[test]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -134,7 +134,9 @@ fn test_builtins() {
     assert_json_for_type::<String>(json!({ "def": { "primitive": "str" } }));
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
-    assert_json_for_type::<PhantomData<bool>>(json!({ "def": { "phantom": { "type": 1 } }, }))
+    assert_json_for_type::<PhantomData<bool>>(
+        json!({ "def": { "phantom": { "type": 1 } }, }),
+    )
 }
 
 #[test]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -212,7 +212,8 @@ fn test_struct_with_phantom() {
             "composite": {
                 "fields": [
                     { "name": "a", "type": 2, "typeName": "i32" },
-                    { "name": "b", "type": 1, "typeName": "PhantomData<T>" },
+                    // type 1 is the `u8` in the `PhantomData`
+                    { "name": "b", "type": 3, "typeName": "PhantomData<T>" },
                 ],
             },
         }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -18,6 +18,7 @@
 
 use scale_info::prelude::{
     boxed::Box,
+    marker::PhantomData,
     string::String,
     vec,
     vec::Vec,
@@ -133,12 +134,11 @@ fn test_builtins() {
     assert_json_for_type::<String>(json!({ "def": { "primitive": "str" } }));
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
-    assert_json_for_type::<core::marker::PhantomData<bool>>(json!({
+    assert_json_for_type::<PhantomData<bool>>(json!({
+        // TODO: dp – Not sure this is right, doesn't seem very useful?
         "path": ["PhantomData"],
-        "params": [1],
-        "def": {
-            "composite": {},
-        }
+        "def": { "phantom": { "type": 1 } },
+        "params": [1]
     }))
 }
 
@@ -191,6 +191,30 @@ fn test_struct() {
                     { "name": "a", "type": 1, "typeName": "i32" },
                     { "name": "b", "type": 2, "typeName": "[u8; 32]" },
                     { "name": "c", "type": 4, "typeName": "bool" },
+                ],
+            },
+        }
+    }));
+}
+
+#[test]
+fn test_struct_with_phantom() {
+    use scale_info::prelude::marker::PhantomData;
+    #[derive(TypeInfo)]
+    struct Struct<T> {
+        a: i32,
+        b: PhantomData<T>,
+    }
+
+    assert_json_for_type::<Struct<u8>>(json!({
+        "path": ["json", "Struct"],
+        "params": [1],
+        "def": {
+            "composite": {
+                "fields": [
+                    // TODO: dp – I was expecting "a" to be type 1 and "b" to be type 2; what am I missing?
+                    { "name": "a", "type": 2, "typeName": "i32" },
+                    { "name": "b", "type": 1, "typeName": "PhantomData<T>" },
                 ],
             },
         }


### PR DESCRIPTION
See https://github.com/paritytech/scale-info/pull/31#issuecomment-754722413 for the background.


Supersedes #31
Closes #7 
﻿
Note that we do not yet have support for `#[codec(skip)]` (implemented in PR #44) so when that lands we'll want to amend the tests here (or there, if this lands first).