### PR TITLE
Remove unused function `MetaType::of()`

### DIFF
--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -96,14 +96,6 @@ impl MetaType {
         }
     }
 
-    /// Creates a new meta types from the type of the given reference.
-    pub fn of<T>(_elem: &T) -> Self
-    where
-        T: TypeInfo + ?Sized + 'static,
-    {
-        Self::new::<T>()
-    }
-
     /// Returns the meta type information.
     pub fn type_info(&self) -> Type<MetaForm> {
         (self.fn_type_info)()


### PR DESCRIPTION
More of a question really. Just noticed this function is not used anywhere and not tested. Should it be removed perhaps? Otherwise I'll add a test for it.﻿
