### PR TITLE
TypeInfo for up to 16 tuples, Clone PortableRegistry

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -112,6 +112,12 @@ impl_metadata_for_tuple!(A, B, C, D, E, F, G);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
 impl<T> TypeInfo for Vec<T>
 where

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -171,7 +171,7 @@ impl Registry {
 
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(
     feature = "serde",
     serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))


### PR DESCRIPTION
Substrate extrinsic signed extensions can be up to 12 tuples, so increasing here from 10 to 16.

`Clone` for `PortableRegistry` added for convenience.