### PR TITLE
Update codec to 2.0 and release new version (before primitive-types release a new version for codec 2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.0 (2021-01-27)
+
+* Bump `parity-scale-codec` from 1.0 to 2.0 [(#55)](https://github.com/paritytech/scale-info/pull/55)
+
 # Version 0.4.1 (2020-10-11)
 
 * Add missing `extern crate proc_macro;` [(#22)](https://github.com/paritytech/scale-info/pull/24)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 cfg-if = "1.0"
-scale-info-derive = { version = "0.2.1", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "0.3.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.2.1", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -53,7 +53,7 @@ pub struct UntrackedSymbol<T> {
 }
 
 impl<T> scale::Encode for UntrackedSymbol<T> {
-    fn encode_to<W: scale::Output>(&self, dest: &mut W) {
+    fn encode_to<W: scale::Output + ?Sized>(&self, dest: &mut W) {
         self.id.get().encode_to(dest)
     }
 }

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde"] }
 
-scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "1.3", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2.0", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
I'm not sure about this version bump:

substrate doesn't depend on scale-info, but primitive-types does depend optionally on scale-info, and primitive-types will get soon upgraded to 2.0 thus I think it is better if it also update scale-info to 0.5.

Apart from this, it seems we don't need to bump the derive crate, but I'm not sure, maybe it is better not to mix different version of scale-codec when deriving scale-info.
you can take a look at the changelog to make your mind https://github.com/paritytech/parity-scale-codec/blob/master/CHANGELOG.md