### PR TITLE
CI: use latest nightly, refactor derive trait bounds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,36 +13,39 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: setup
-      run: |
-        rustup install nightly-2020-03-11
-        rustup component add rustfmt --toolchain nightly-2020-03-11
-        rustup component add clippy --toolchain nightly-2020-03-11
-        
+      uses: actions-rs/toolchain@v1
+      with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+
     - name: fmt
       run: |
-        cargo +nightly-2020-03-11 fmt --version
-        cargo +nightly-2020-03-11 fmt --all -- --check
-        
+        cargo fmt --version
+        cargo fmt --all -- --check
+
     - name: clippy
       run: |
-        cargo +nightly-2020-03-11 clippy --version
-        cargo +nightly-2020-03-11 clippy --all -- -D warnings
-        
+        cargo clippy --version
+        cargo clippy --all -- -D warnings
+
     - name: build
       run: |
         cargo --version --verbose
         cargo build --all
         cargo build --all --no-default-features
-        
+
     - name: test
       run: |
         cargo test --all
-        
+
     - name: test no-std
       run: |
         cd ./test_suite/derive_tests_no_std
-        cargo +nightly-2020-03-11 build --no-default-features
-  
-    
+        cargo build --no-default-features
+
+

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -70,13 +70,13 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     let mut ast: DeriveInput = syn::parse2(input.clone())?;
 
     let ident = &ast.ident;
-    trait_bounds::add(ident, &mut ast.generics, &ast.data)?;
 
     ast.generics
         .lifetimes_mut()
         .for_each(|l| *l = parse_quote!('static));
 
-    let (_, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let (ty_generics, where_clause) = trait_bounds::add(ident, &ast.generics, &ast.data)?;
+
     let generic_type_ids = ast.generics.type_params().map(|ty| {
         let ty_ident = &ty.ident;
         quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -217,7 +217,10 @@ fn is_c_like_enum(variants: &VariantList) -> bool {
     // any variant has an explicit discriminant
     variants.iter().any(|v| v.discriminant.is_some()) ||
         // all variants are unit
-        variants.iter().all(|v| matches!(v.fields, Fields::Unit))
+        variants.iter().all(|v| match v.fields {
+            Fields::Unit => true,
+            _ => false,
+        })
 }
 
 fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -75,7 +75,8 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
         .lifetimes_mut()
         .for_each(|l| *l = parse_quote!('static));
 
-    let (ty_generics, where_clause) = trait_bounds::add(ident, &ast.generics, &ast.data)?;
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
+    let where_clause = trait_bounds::make_where_clause(ident, &ast.generics, &ast.data)?;
 
     let generic_type_ids = ast.generics.type_params().map(|ty| {
         let ty_ident = &ty.ident;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -217,10 +217,7 @@ fn is_c_like_enum(variants: &VariantList) -> bool {
     // any variant has an explicit discriminant
     variants.iter().any(|v| v.discriminant.is_some()) ||
         // all variants are unit
-        variants.iter().all(|v| match v.fields {
-            Fields::Unit => true,
-            _ => false,
-        })
+        variants.iter().all(|v| matches!(v.fields, Fields::Unit))
 }
 
 fn generate_variant_type(data_enum: &DataEnum) -> TokenStream2 {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -38,7 +38,8 @@ pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Re
     }
 
     let types = collect_types_to_bind(input_ident, data, &ty_params_ids)?;
-    let mut where_clause = generics.make_where_clause().clone();
+    let type_params = generics.type_params().cloned().collect::<Vec<_>>();
+    let where_clause = generics.make_where_clause();
 
     types.into_iter().for_each(|ty| {
         where_clause
@@ -46,9 +47,9 @@ pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Re
             .push(parse_quote!(#ty : ::scale_info::TypeInfo + 'static))
     });
 
-    generics.type_params().into_iter().for_each(|type_param| {
-        let ident = type_param.ident.clone();
-        let mut bounds = type_param.bounds.clone();
+    type_params.into_iter().for_each(|type_param| {
+        let ident = type_param.ident;
+        let mut bounds = type_param.bounds;
         bounds.push(parse_quote!(::scale_info::TypeInfo));
         bounds.push(parse_quote!('static));
         where_clause

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -22,24 +22,36 @@ use syn::{
     Generics,
     Result,
     Type,
+    TypeGenerics,
+    WhereClause,
 };
 
 /// Adds a `TypeInfo + 'static` bound to all relevant generic types including
 /// associated types (e.g. `T::A: TypeInfo`), correctly dealing with
 /// self-referential types.
-pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Result<()> {
-    let ty_params_ids = generics
-        .type_params()
+pub fn add<'a>(
+    input_ident: &'a Ident,
+    generics: &'a Generics,
+    data: &'a syn::Data,
+) -> Result<(TypeGenerics<'a>, WhereClause)> {
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+    let mut where_clause = where_clause.cloned().unwrap_or_else(|| {
+        WhereClause {
+            where_token: <syn::Token![where]>::default(),
+            predicates: Punctuated::new(),
+        }
+    });
+
+    let type_params = generics.type_params();
+    let ty_params_ids = type_params
         .map(|type_param| type_param.ident.clone())
         .collect::<Vec<Ident>>();
 
     if ty_params_ids.is_empty() {
-        return Ok(())
+        return Ok((ty_generics, where_clause))
     }
 
     let types = collect_types_to_bind(input_ident, data, &ty_params_ids)?;
-    let type_params = generics.type_params().cloned().collect::<Vec<_>>();
-    let where_clause = generics.make_where_clause();
 
     types.into_iter().for_each(|ty| {
         where_clause
@@ -47,16 +59,17 @@ pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Re
             .push(parse_quote!(#ty : ::scale_info::TypeInfo + 'static))
     });
 
-    type_params.into_iter().for_each(|type_param| {
-        let ident = type_param.ident;
-        let mut bounds = type_param.bounds;
+    generics.type_params().into_iter().for_each(|type_param| {
+        let ident = type_param.ident.clone();
+        let mut bounds = type_param.bounds.clone();
         bounds.push(parse_quote!(::scale_info::TypeInfo));
         bounds.push(parse_quote!('static));
         where_clause
             .predicates
             .push(parse_quote!( #ident : #bounds));
     });
-    Ok(())
+
+    Ok((ty_generics, where_clause))
 }
 
 /// Visits the ast and checks if the given type contains one of the given

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -38,8 +38,7 @@ pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Re
     }
 
     let types = collect_types_to_bind(input_ident, data, &ty_params_ids)?;
-    let type_params = generics.type_params().cloned().collect::<Vec<_>>();
-    let where_clause = generics.make_where_clause();
+    let mut where_clause = generics.make_where_clause().clone();
 
     types.into_iter().for_each(|ty| {
         where_clause
@@ -47,9 +46,9 @@ pub fn add(input_ident: &Ident, generics: &mut Generics, data: &syn::Data) -> Re
             .push(parse_quote!(#ty : ::scale_info::TypeInfo + 'static))
     });
 
-    type_params.into_iter().for_each(|type_param| {
-        let ident = type_param.ident;
-        let mut bounds = type_param.bounds;
+    generics.type_params().into_iter().for_each(|type_param| {
+        let ident = type_param.ident.clone();
+        let mut bounds = type_param.bounds.clone();
         bounds.push(parse_quote!(::scale_info::TypeInfo));
         bounds.push(parse_quote!('static));
         where_clause

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,12 +92,11 @@
 macro_rules! tuple_meta_type {
     ( $($ty:ty),* ) => {
         {
-            #[allow(unused_mut)]
-            let mut v = $crate::prelude::vec![];
-            $(
-                v.push($crate::MetaType::new::<$ty>());
-            )*
-            v
+            $crate::prelude::vec![
+                $(
+                    $crate::MetaType::new::<$ty>(),
+                )*
+            ]
         }
     }
 }


### PR DESCRIPTION
- uses latest nightly with the required components
- includes a refactoring of `derive/trait_bounds` in order to make clippy happy :paperclip: 