### PR TITLE
Add feature for enabling decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ std = [
 derive = [
     "scale-info-derive"
 ]
+# enables decoding and deserialization of portable scale-info type metadata
+decode = []
 
 [workspace]
 members = [

--- a/src/form.rs
+++ b/src/form.rs
@@ -32,7 +32,6 @@
 use crate::prelude::{
     any::TypeId,
     fmt::Debug,
-    string::String,
 };
 
 use crate::{
@@ -84,7 +83,7 @@ cfg_if::cfg_if! {
         impl Form for PortableForm {
             type Type = UntrackedSymbol<TypeId>;
             // Owned string required for decoding/deserialization
-            type String = String;
+            type String = crate::prelude::string::String;
         }
     } else {
         impl Form for PortableForm {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -43,10 +43,7 @@ use crate::{
     meta_type::MetaType,
     Type,
 };
-use scale::{
-    Decode,
-    Encode
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     Deserialize,
@@ -169,7 +166,7 @@ impl Registry {
 
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     types: Vec<Type<PortableForm>>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -34,7 +34,6 @@ use crate::prelude::{
 use crate::{
     form::{
         Form,
-        FormString,
         PortableForm,
     },
     interner::{
@@ -50,7 +49,6 @@ use scale::{
 };
 #[cfg(feature = "serde")]
 use serde::{
-    de::DeserializeOwned,
     Deserialize,
     Serialize,
 };
@@ -68,7 +66,7 @@ impl IntoPortable for &'static str {
     type Output = <PortableForm as Form>::String;
 
     fn into_portable(self, _registry: &mut Registry) -> Self::Output {
-        self
+        self.into()
     }
 }
 
@@ -172,15 +170,8 @@ impl Registry {
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
-)]
-pub struct PortableRegistry<S = &'static str>
-where
-    S: FormString,
-{
-    types: Vec<Type<PortableForm<S>>>,
+pub struct PortableRegistry {
+    types: Vec<Type<PortableForm>>,
 }
 
 impl From<Registry> for PortableRegistry {
@@ -191,19 +182,16 @@ impl From<Registry> for PortableRegistry {
     }
 }
 
-impl<S> PortableRegistry<S>
-where
-    S: FormString,
-{
+impl PortableRegistry {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
-    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<PortableForm<S>>> {
+    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<PortableForm>> {
         self.types.get((id.get() - 1) as usize)
     }
 
     /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
     pub fn enumerate(
         &self,
-    ) -> impl Iterator<Item = (NonZeroU32, &Type<PortableForm<S>>)> {
+    ) -> impl Iterator<Item = (NonZeroU32, &Type<PortableForm>)> {
         self.types.iter().enumerate().map(|(i, ty)| {
             let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
             (id, ty)

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -43,7 +43,10 @@ use crate::{
     meta_type::MetaType,
     Type,
 };
-use scale::Encode;
+use scale::{
+    Decode,
+    Encode
+};
 #[cfg(feature = "serde")]
 use serde::{
     Deserialize,
@@ -166,7 +169,7 @@ impl Registry {
 
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     types: Vec<Type<PortableForm>>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -189,9 +189,7 @@ impl PortableRegistry {
     }
 
     /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
-    pub fn enumerate(
-        &self,
-    ) -> impl Iterator<Item = (NonZeroU32, &Type<PortableForm>)> {
+    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<PortableForm>)> {
         self.types.iter().enumerate().map(|(i, ty)| {
             let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
             (id, ty)

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -43,10 +43,7 @@ use crate::{
     meta_type::MetaType,
     Type,
 };
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     Deserialize,
@@ -169,7 +166,8 @@ impl Registry {
 
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     types: Vec<Type<PortableForm>>,
 }

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -25,10 +25,7 @@ use crate::{
     Registry,
 };
 use derive_more::From;
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
@@ -71,7 +68,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -71,7 +71,8 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.
     #[cfg_attr(

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -23,10 +23,7 @@ use crate::{
     Registry,
     TypeInfo,
 };
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
@@ -73,7 +70,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -73,7 +73,8 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.
     #[cfg_attr(

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -30,10 +30,7 @@ use crate::{
     TypeInfo,
 };
 use derive_more::From;
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
@@ -63,7 +60,7 @@ pub use self::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
@@ -174,7 +171,7 @@ where
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -212,7 +209,7 @@ impl IntoPortable for TypeDef {
 /// A primitive Rust type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -256,7 +253,7 @@ pub enum TypeDefPrimitive {
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -310,7 +307,7 @@ where
     ))
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -363,7 +360,7 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
@@ -429,7 +426,7 @@ where
         deserialize = "T::Type: DeserializeOwned",
     ))
 )]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefPhantom<T: Form = MetaForm> {
     /// The PhantomData type parameter

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -387,8 +387,9 @@ where
 }
 
 /// A type wrapped in [`Compact`].
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -63,7 +63,8 @@ pub use self::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
     #[cfg_attr(
@@ -173,7 +174,8 @@ where
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
     Composite(TypeDefComposite<T>),
@@ -208,9 +210,10 @@ impl IntoPortable for TypeDef {
 }
 
 /// A primitive Rust type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
     Bool,
@@ -245,7 +248,6 @@ pub enum TypeDefPrimitive {
 }
 
 /// An array type.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -254,6 +256,8 @@ pub enum TypeDefPrimitive {
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
     len: u32,
@@ -306,7 +310,8 @@ where
     ))
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
     fields: Vec<T::Type>,
@@ -358,7 +363,8 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
@@ -423,7 +429,8 @@ where
         deserialize = "T::Type: DeserializeOwned",
     ))
 )]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefPhantom<T: Form = MetaForm> {
     /// The PhantomData type parameter
     #[cfg_attr(feature = "serde", serde(rename = "type"))]

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -32,10 +32,7 @@ use crate::{
     IntoPortable,
     Registry,
 };
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
@@ -59,7 +56,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -50,7 +50,6 @@ use serde::{
 /// has been defined. The last
 ///
 /// Rust prelude type may have an empty namespace definition.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -60,6 +59,8 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.
     segments: Vec<T::String>,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -84,7 +84,8 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
     #[cfg_attr(
@@ -149,7 +150,8 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.
     name: T::String,

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -26,10 +26,7 @@ use crate::{
     Registry,
 };
 use derive_more::From;
-use scale::{
-    Decode,
-    Encode,
-};
+use scale::Encode;
 #[cfg(feature = "serde")]
 use serde::{
     de::DeserializeOwned,
@@ -84,7 +81,7 @@ use serde::{
     ))
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
@@ -150,7 +147,7 @@ where
         deserialize = "T::Type: DeserializeOwned, T::String: DeserializeOwned",
     ))
 )]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(Decode))]
+#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -62,7 +62,7 @@ fn scale_encode_then_decode_to_readonly() {
     let mut encoded = registry.encode();
     let original_serialized = serde_json::to_value(registry).unwrap();
 
-    let readonly_decoded = PortableRegistry::<String>::decode(&mut &encoded[..]).unwrap();
+    let readonly_decoded = PortableRegistry::decode(&mut &encoded[..]).unwrap();
     assert!(readonly_decoded
         .resolve(NonZeroU32::new(1).unwrap())
         .is_some());
@@ -79,7 +79,7 @@ fn json_serialize_then_deserialize_to_readonly() {
     let registry: PortableRegistry = registry.into();
     let original_serialized = serde_json::to_value(registry).unwrap();
     // assert_eq!(original_serialized, serde_json::Value::Null);
-    let readonly_deserialized: PortableRegistry<String> =
+    let readonly_deserialized: PortableRegistry =
         serde_json::from_value(original_serialized.clone()).unwrap();
     assert!(readonly_deserialized
         .resolve(NonZeroU32::new(1).unwrap())


### PR DESCRIPTION
Possible solution for #58, reverting #35

If the `decode` or `std` feature is enabled then `PortableForm::String` will be an owned `String` which allow decoding. Otherwise it will be a `&'static str` (this is required for substrate runtimes).

## todo

- [x] test it out with substrate
- [x] test it out with `ink!` 