### PR TITLE
Trybuild tests for scale attributes

### DIFF
--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -304,6 +304,9 @@ fn ui_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/fail_missing_derive.rs");
     t.compile_fail("tests/ui/fail_unions.rs");
+    t.compile_fail("tests/ui/fail_use_codec_attrs_without_deriving_encode.rs");
+    t.compile_fail("tests/ui/fail_with_invalid_codec_attrs.rs");
+    t.pass("tests/ui/pass_with_valid_codec_attrs.rs");
     t.pass("tests/ui/pass_non_static_lifetime.rs");
     t.pass("tests/ui/pass_self_referential.rs");
     t.pass("tests/ui/pass_basic_generic_type.rs");

--- a/test_suite/tests/ui/fail_use_codec_attrs_without_deriving_encode.rs
+++ b/test_suite/tests/ui/fail_use_codec_attrs_without_deriving_encode.rs
@@ -1,0 +1,14 @@
+use scale_info::TypeInfo;
+
+#[derive(TypeInfo)]
+struct AttrValidation {
+    a: u8,
+    #[codec(skip)]
+    b: u16,
+}
+
+fn assert_type_info<T: TypeInfo + 'static>() {}
+
+fn main() {
+    assert_type_info::<AttrValidation>();
+}

--- a/test_suite/tests/ui/fail_use_codec_attrs_without_deriving_encode.stderr
+++ b/test_suite/tests/ui/fail_use_codec_attrs_without_deriving_encode.stderr
@@ -1,0 +1,5 @@
+error: cannot find attribute `codec` in this scope
+ --> $DIR/fail_use_codec_attrs_without_deriving_encode.rs:6:7
+  |
+6 |     #[codec(skip)]
+  |       ^^^^^

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.rs
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.rs
@@ -1,0 +1,23 @@
+use scale_info::TypeInfo;
+use scale::Encode;
+
+#[derive(TypeInfo, Encode)]
+struct AttrValidation {
+    a: u8,
+    #[codec(skip, compact)]
+    b: u16,
+}
+
+#[derive(TypeInfo, Encode)]
+enum EnumsAttrValidation {
+    Thing(#[codec(index = 3, compact)] u32),
+    #[codec(encode_as = u8, compact)]
+    Thong(bool),
+    Theng(AttrValidation),
+}
+
+fn assert_type_info<T: TypeInfo + 'static>() {}
+
+fn main() {
+    assert_type_info::<AttrValidation>();
+}

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
@@ -1,0 +1,11 @@
+error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` and `#[codec(encoded_as = "$EncodeAs")]` are accepted.
+ --> $DIR/fail_with_invalid_codec_attrs.rs:7:7
+  |
+7 |     #[codec(skip, compact)]
+  |       ^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` and `#[codec(encoded_as = "$EncodeAs")]` are accepted.
+  --> $DIR/fail_with_invalid_codec_attrs.rs:13:13
+   |
+13 |     Thing(#[codec(index = 3, compact)] u32),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test_suite/tests/ui/pass_with_valid_codec_attrs.rs
+++ b/test_suite/tests/ui/pass_with_valid_codec_attrs.rs
@@ -1,0 +1,31 @@
+use scale_info::TypeInfo;
+use scale::{Encode, HasCompact};
+
+#[derive(TypeInfo, Encode)]
+struct ValidStruct {
+    #[codec(skip)]
+    a: u8,
+    #[codec(compact)]
+    b: u16,
+    #[codec(encoded_as = "<u32 as HasCompact>::Type")]
+    c: u32,
+}
+
+#[derive(TypeInfo, Encode)]
+enum ValidEnum {
+    #[allow(unused)]
+    #[codec(index = 3)]
+    Thing(u32),
+    #[allow(unused)]
+    #[codec(skip)]
+    Thong(bool),
+    #[allow(unused)]
+    Theng(ValidStruct),
+}
+
+fn assert_type_info<T: TypeInfo + 'static>() {}
+
+fn main() {
+    assert_type_info::<ValidStruct>();
+    assert_type_info::<ValidEnum>();
+}


### PR DESCRIPTION
Add trybuild tests to ensure scale-info stays aligned with parity-scale-codec derive macro attribute validation. Follow up to https://github.com/paritytech/scale-info/pull/53#discussion_r568524935.﻿
