### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2021-02-05
 ### Added
+- Add a TypeDef to handle Compact types [(#53)](https://github.com/paritytech/scale-info/pull/53)
+- Add feature for enabling decoding [(#59)](https://github.com/paritytech/scale-info/pull/59)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a TypeDef to handle Compact types [(#53)](https://github.com/paritytech/scale-info/pull/53)
 - Add feature for enabling decoding [(#59)](https://github.com/paritytech/scale-info/pull/59)
 
-### Changed
-
 ### Fixed
 - Derive: use known crate name aliases [(#61)](https://github.com/paritytech/scale-info/pull/61)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 cfg-if = "1.0"
-scale-info-derive = { version = "0.3.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ The following optional `cargo` features are available:
 - **serde** includes support for json serialization/deserialization of the type registry. See example [here](https://github.com/paritytech/scale-info/blob/master/test_suite/tests/json.rs).
 - **derive** reexports the [`scale-info-derive`](https://crates.io/crates/scale-info-derive) crate.
 
+## Known issues
+
+When deriving `TypeInfo` for a type with generic compact fields e.g.
+
+```rust
+#[derive(Encode, TypeInfo)]
+struct Foo<S> { #[codec(compact)] a: S }
+```
+
+You may experience the following error when using this generic type without the correct bounds:
+
+```
+error[E0275]: overflow evaluating the requirement `_::_parity_scale_codec::Compact<_>: Decode`
+```
+
+See https://github.com/paritytech/scale-info/issues/65 for more information.
+
 ## Resources
 
 - See usage for describing types for [`ink!`](https://github.com/paritytech/ink/blob/master/crates/metadata/src/specs.rs) smart contracts metadata.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,6 +16,6 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = { version = "1.0", features = ["derive", "visit", "visit-mut"] }
+syn = { version = "1.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
 proc-macro2 = "1.0"
 proc-macro-crate = "0.1.5"


### PR DESCRIPTION
## [0.6.0] - 2021-02-05
### Added
- Add a TypeDef to handle Compact types [(#53)](https://github.com/paritytech/scale-info/pull/53)
- Add feature for enabling decoding [(#59)](https://github.com/paritytech/scale-info/pull/59)

### Fixed
- Derive: use known crate name aliases [(#61)](https://github.com/paritytech/scale-info/pull/61)

### Known Issues

This release includes a known issue with generic compact fields which we have noted and judged to be an acceptable corner case, see https://github.com/paritytech/scale-info/issues/65.