### PR TITLE
Trait bounds for generic compact types

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,4 +19,3 @@ quote = "1.0"
 syn = { version = "1.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
 proc-macro2 = "1.0"
 proc-macro-crate = "0.1.5"
-hashbrown = "0.9.1"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,3 +19,4 @@ quote = "1.0"
 syn = { version = "1.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
 proc-macro2 = "1.0"
 proc-macro-crate = "0.1.5"
+hashbrown = "0.9.1"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -285,7 +285,7 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
 
     let variants = variants.into_iter().map(|v| {
         let ident = &v.ident;
-        let v_name = quote! {stringify!(#ident) };
+        let v_name = quote! { stringify!(#ident) };
         match v.fields {
             Fields::Named(ref fs) => {
                 let fields = generate_fields(&fs.named);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 extern crate alloc;
 extern crate proc_macro;
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 extern crate proc_macro;
@@ -80,7 +80,6 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     let parity_scale_codec = crate_name_ident("parity-scale-codec")?;
 
     let ident = &ast.ident;
-    println!("[generate_type] START {:?}", ident);
     ast.generics
         .lifetimes_mut()
         .for_each(|l| *l = parse_quote!('static));
@@ -93,19 +92,15 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
         &scale_info,
         &parity_scale_codec,
     )?;
-    println!("[generate_type]   compact_types={:?}", compact_types);
     let generic_type_ids = ast.generics.type_params().map(|ty| {
-        // If this is used in a Compact field, then the call must be: ::scale_info::meta_type::<<#ty_ident as HasCompact>::Type>()
         let ty_ident = &ty.ident;
-        // let is_compact = types.as_ref().unwrap().iter().filter(|infos| if let Some(i) = &infos.2 { i == ty_ident } else {false}).any(|infos| infos.1 );
-        // if is_compact {
+        // If this type param is used as a parameter in a Compact field, then the call must be:
+        //  ::scale_info::meta_type::<<#ty_ident as HasCompact>::Type>()
         if compact_types.contains(ty_ident) {
-            println!("[generate_type]   Adding call to meta_type with as HasCompact");
             quote! {
                 :: #scale_info ::meta_type::<<#ty_ident as :: #parity_scale_codec :: HasCompact>::Type>()
             }
         } else {
-            println!("[generate_type]   Adding normal call to meta_type");
             quote! {
                 :: #scale_info ::meta_type::<#ty_ident>()
             }

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use alloc::vec::Vec;
 use proc_macro2::Ident;
 use syn::{
@@ -29,12 +31,13 @@ use syn::{
 /// relevant generic types including associated types (e.g. `T::A: TypeInfo`), correctly dealing
 /// with self-referential types.
 pub fn make_where_clause<'a>(
-    input_ident: &'a Ident,
-    generics: &'a Generics,
-    data: &'a syn::Data,
-    scale_info: &Ident,
-    parity_scale_codec: &Ident,
-) -> Result<(WhereClause, Option<Vec<(Type, bool, Option<Ident>)>>)> {
+    input_ident: &'a Ident, // The type we're deriving TypeInfo for
+    generics: &'a Generics, // The type params to our type
+    data: &'a syn::Data,    // The body of the type
+    scale_info: &Ident,     // Crate name
+    parity_scale_codec: &Ident, /* Crate name
+                             * ) -> Result<(WhereClause, Option<Vec<(Type, bool, Option<Ident>)>>)> { */
+) -> Result<(WhereClause, HashSet<Ident>)> {
     let mut where_clause = generics.where_clause.clone().unwrap_or_else(|| {
         WhereClause {
             where_token: <syn::Token![where]>::default(),
@@ -48,65 +51,162 @@ pub fn make_where_clause<'a>(
         .collect::<Vec<Ident>>();
 
     if ty_params_ids.is_empty() {
-        return Ok((where_clause, None))
+        return Ok((where_clause, HashSet::new()))
     }
 
     let types = collect_types_to_bind(input_ident, data, &ty_params_ids)?;
-    let types2 = types.clone();
-    println!("[DDD] nr types appearing in source={:?}", types.len());
+    // println!("[DDD] nr types appearing in source={:?}", types.len());
+    let mut need_compact_bounds: HashSet<Ident> = HashSet::new();
+    let mut need_normal_bounds: HashSet<Ident> = HashSet::new();
+    use syn::WherePredicate;
+    let mut where_predicates: HashSet<WherePredicate> = HashSet::new();
     types.into_iter().for_each(|(ty, is_compact, _)| {
-        // Compact types need extra bounds, T: HasCompact and <T as
-        // HasCompact>::Type: TypeInfo + 'static
+        // Compact types need two bounds: `T: HasCompact` and `<T as
+        // HasCompact>::Type: TypeInfo + 'static`
+
+        // TODO: should pass in a `&mut HashSet` from outside the loop to ensure we avoid repetitions
+        let type_params_in_type = collect_type_params(&ty);
         if is_compact {
-            println!("[DDD] ty={:?} is Compact, adding HasCompact bounds", ty);
-            where_clause
-                .predicates
-                .push(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
-            where_clause
-                .predicates
-                .push(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
+            println!("[make_where_clause]   is Compact, ty={:?}  adding HasCompact bounds", ty);
+            println!("[make_where_clause]   is Compact, type_params_in_type={:?}", type_params_in_type);
+            where_predicates.insert(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
+            where_predicates.insert(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
+
+            // where_clause
+            //     .predicates
+            //     .push(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
+            // where_clause
+            //     .predicates
+            //     .push(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
+            // for tp in type_params_in_type {
+            //     where_clause.predicates.push(parse_quote!( #tp : 'static ))
+            // }
+            need_compact_bounds.extend(type_params_in_type);
         } else {
-            println!("[DDD] ty={:?} is NOT Compact, adding TypeInfo bound", ty);
-            where_clause
-                .predicates
-                .push(parse_quote!(#ty : :: #scale_info ::TypeInfo + 'static));
+            // println!("[DDD] ty={:?} is NOT Compact, adding TypeInfo bound", ty);
+            where_predicates.insert(parse_quote!(#ty : :: #scale_info ::TypeInfo + 'static));
+
+            // where_clause
+            //     .predicates
+            //     .push(parse_quote!(#ty : :: #scale_info ::TypeInfo + 'static));
+            // for tp in type_params_in_type {
+            //     where_clause.predicates.push(parse_quote!( #tp : :: #scale_info ::TypeInfo + 'static ))
+            // }
+            need_normal_bounds.extend(type_params_in_type);
         }
     });
+    println!(
+        "[make_where_clause]   need_compact_bounds={:?}",
+        need_compact_bounds
+    );
+    println!(
+        "[make_where_clause]   need_normal_bounds={:?}",
+        need_normal_bounds
+    );
+    // TODO: make issue:
+    // Loop over the type params given to the type and add `TypeInfo` and
+    // `'static` bounds. Type params that are used in fields/variants that are
+    // `Compact` need only the `'static` bound.
+    // Note that if a type parameter appears "naked" in a field/variant, e.g.
+    // `struct A<T> { one: T }`, we will end up adding the bounds twice, once
+    // above as it appears in a field and once again below as it's one of the
+    // type params of `A`. Type params that appear as parameters to other types,
+    // e.g. `struct A<T> { one: PhantomData<T> }` do not get double bounds.
+
+    // The reason we do this "double looping" over first generics in used in
+    // fields/variants and then generics is that a type can have a type
+    // parameter bound to a trait, e.g. `T: SomeTrait`, that is not used as-is
+    // in the fields/variants but whose associated type **is**. Something like
+    // this:
+    // `struct A<T: SomeTrait> { one: T::SomeAssoc, }`
+    // When deriving `TypeInfo` for `A`, the first loop above adds
+    // `T::SomeAssoc: TypeInfo + 'static`, but we also need
+    // `T: TypeInfo + 'static`.
+    // Hence the second loop.
     generics.type_params().into_iter().for_each(|type_param| {
         let ident = type_param.ident.clone();
-        // Find `ident` in `types`, check if it is Compact. If yes, skip, else add bounds
-        let is_compact = types2.iter().filter(|ty| if let Some(i) = &ty.2 { i == &ident } else {false}).any(|ty| ty.1 );
-        if is_compact {
-            println!("[DDD] ident {:?} is used for a field that is Compact; not adding TypeInfo bound", ident);
-            let mut bounds = type_param.bounds.clone();
-            bounds.push(parse_quote!('static));
-            where_clause
-                .predicates
-                .push(parse_quote!( #ident : #bounds));
+        // Find the type parameter in the list of types that appear in the
+        // fields/variants and check if it is used in a `Compact` field/variant.
+        // If yes, only add the `'static` bound, else add both `TypeInfo` and
+        // `'static` bounds.
 
+        let mut bounds = type_param.bounds.clone();
+        if need_compact_bounds.contains(&ident) {
+            bounds.push(parse_quote!('static));
         } else {
-            // I wonder if we need further checks. As is this leads to double bounds, as the bound is added as part of the generics too. Investigate.
-            println!("[DDD] ident {:?} is used for a field that is NOT Compact. Adding bounds", ident);
-            let mut bounds = type_param.bounds.clone();
             bounds.push(parse_quote!(:: #scale_info ::TypeInfo));
             bounds.push(parse_quote!('static));
-            where_clause
-                .predicates
-                .push(parse_quote!( #ident : #bounds));
         }
+        where_predicates.insert(parse_quote!( #ident : #bounds));
+
+        // let mut bounds = type_param.bounds.clone();
+        // if need_compact_bounds.contains(&ident) {
+        //     bounds.push(parse_quote!('static));
+        //     where_clause
+        //         .predicates
+        //         .push(parse_quote!( #ident : #bounds));
+        // } else {
+        //     // let mut bounds = type_param.bounds.clone();
+        //     bounds.push(parse_quote!(:: #scale_info ::TypeInfo));
+        //     bounds.push(parse_quote!('static));
+        //     where_clause
+        //         .predicates
+        //         .push(parse_quote!( #ident : #bounds));
+        // }
+
+        // let is_compact = types2
+        //     .iter()
+        //     .filter(|ty| {
+        //         if let Some(i) = &ty.2 {
+        //             i == &ident
+        //         } else {
+        //             false
+        //         }
+        //     })
+        //     .any(|ty| ty.1 );
+        // if is_compact {
+        //     // println!("[DDD] ident {:?} is used for a field that is Compact; not adding TypeInfo bound", ident);
+        //     let mut bounds = type_param.bounds.clone();
+        //     bounds.push(parse_quote!('static));
+        //     where_clause
+        //         .predicates
+        //         .push(parse_quote!( #ident : #bounds));
+
+        // } else {
+        //     // println!("[DDD] ident {:?} is used for a field that is NOT Compact. Adding bounds", ident);
+        //     let mut bounds = type_param.bounds.clone();
+        //     bounds.push(parse_quote!(:: #scale_info ::TypeInfo));
+        //     bounds.push(parse_quote!('static));
+        //     where_clause
+        //         .predicates
+        //         .push(parse_quote!( #ident : #bounds));
+        // }
     });
 
-    Ok((where_clause, Some(types2)))
+    where_predicates.extend(
+        need_compact_bounds
+            .iter()
+            .map(|tp_ident| parse_quote!( #tp_ident : 'static )),
+    );
+    where_predicates.extend(
+        need_normal_bounds.iter().map(
+            |tp_ident| parse_quote!( #tp_ident : :: #scale_info ::TypeInfo + 'static ),
+        ),
+    );
+    where_clause.predicates.extend(where_predicates);
+
+    Ok((where_clause, need_compact_bounds))
 }
 
 /// Visits the ast and checks if the given type contains one of the given
 /// idents.
+// TODO: what if the type contains more than one of the idents?
+// TODO: return just `Option<Ident>`?
 fn type_contains_idents(ty: &Type, idents: &[Ident]) -> (bool, Option<Ident>) {
     struct ContainIdents<'a> {
         result: (bool, Option<Ident>),
         idents: &'a [Ident],
     }
-
     impl<'a, 'ast> Visit<'ast> for ContainIdents<'a> {
         fn visit_ident(&mut self, i: &'ast Ident) {
             if self.idents.iter().any(|id| id == i) {
@@ -123,6 +223,80 @@ fn type_contains_idents(ty: &Type, idents: &[Ident]) -> (bool, Option<Ident>) {
     visitor.result
 }
 
+// Should call this on a syn:Field instead so we have access to the Attributes, that way we could collect both `Compact` and generics usage?
+// fn collect_type_params(ty: &Type) -> Vec<Ident> {
+fn collect_type_params(ty: &Type) -> HashSet<Ident> {
+    use syn::{
+        GenericArgument,
+        Variant,
+    };
+    println!("[collect_type_params]  ty={:?}", ty);
+    struct Bla {
+        result: HashSet<Ident>,
+    }
+    impl<'ast> Visit<'ast> for Bla {
+        fn visit_generic_argument(&mut self, g: &'ast GenericArgument) {
+            println!("visit_generic_argument={:?}", g);
+            if let GenericArgument::Type(syn::Type::Path(syn::TypePath {
+                path: t, ..
+            })) = g
+            {
+                println!("visit_generic_argument, type={:?}", t.get_ident());
+
+                if let Some(ident) = t.get_ident() {
+                    self.result.insert(ident.clone());
+                }
+            }
+        }
+    }
+    let mut visitor = Bla {
+        result: HashSet::new(),
+    };
+    visitor.visit_type(ty);
+    println!(
+        "[collect_type_params]  found type params={:?}",
+        visitor.result
+    );
+
+    visitor.result
+}
+
+fn visit_fields(ident: &Ident, data: &syn::Data) {
+    use syn::{
+        Attribute,
+        Field,
+        Fields,
+    };
+    struct Bla {
+        result: HashSet<Ident>,
+    }
+
+    impl<'ast> Visit<'ast> for Bla {
+        fn visit_fields(&mut self, fs: &'ast Fields) {
+            println!("visit_fields={:#?}", fs);
+            for f in fs {
+                self.visit_field(f)
+            }
+        }
+        // Nope
+        fn visit_attribute(&mut self, node: &'ast Attribute) {
+            println!("visit_attribute={:#?}", node);
+        }
+        // Nope
+        fn visit_field(&mut self, i: &'ast Field) {
+            println!("visit_field (sing)={:#?}", i);
+            for attr in &i.attrs {
+                self.visit_attribute(&attr);
+            }
+        }
+    }
+
+    let mut visitor = Bla {
+        result: HashSet::new(),
+    };
+    visitor.visit_data(data);
+}
+
 /// Returns all types that must be added to the where clause with a boolean
 /// indicating if the field is [`scale::Compact`] or not.
 fn collect_types_to_bind(
@@ -130,20 +304,29 @@ fn collect_types_to_bind(
     data: &syn::Data,
     ty_params: &[Ident],
 ) -> Result<Vec<(Type, bool, Option<Ident>)>> {
-    let types_from_fields = |fields: &Punctuated<syn::Field, _>| -> Vec<(Type, bool, Option<Ident>)> {
-        fields
-            .iter()
-            .filter(|field| {
-                // Only add a bound if the type uses a generic.
-                type_contains_idents(&field.ty, &ty_params).0
+    // Experiment:
+    // visit_fields(input_ident, data);
+    let types_from_fields =
+        |fields: &Punctuated<syn::Field, _>| -> Vec<(Type, bool, Option<Ident>)> {
+            fields
+                .iter()
+                .filter(|field| {
+                    // Only add a bound if the type uses a generic.
+                    type_contains_idents(&field.ty, &ty_params).0
                 &&
                 // Remove all remaining types that start/contain the input ident
                 // to not have them in the where clause.
                 !type_contains_idents(&field.ty, &[input_ident.clone()]).0
-            })
-            .map(|f| (f.ty.clone(), super::is_compact(f), type_contains_idents(&f.ty, &ty_params).1))
-            .collect()
-    };
+                })
+                .map(|f| {
+                    (
+                        f.ty.clone(),
+                        super::is_compact(f),
+                        type_contains_idents(&f.ty, &ty_params).1,
+                    )
+                })
+                .collect()
+        };
 
     let types = match *data {
         syn::Data::Struct(ref data) => {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -79,7 +79,7 @@ pub fn make_where_clause<'a>(
     // `'static` bounds. Type params that are used in fields/variants that are
     // `Compact` need only the `'static` bound.
     // The reason we do this "double looping", first over generics used in
-    // fields/variants and then the generics given in the type definition
+    // fields/variants and then over the generics given in the type definition
     // itself, is that a type can have a type parameter bound to a trait, e.g.
     // `T: SomeTrait`, that is not used as-is in the fields/variants but whose
     // associated type **is**. Something like this:
@@ -145,8 +145,8 @@ fn type_contains_idents(ty: &Type, idents: &[Ident]) -> Option<Ident> {
 }
 
 /// Visit a `Type` and collect generic type params used.
-/// Given `struct A<T> { thing: SomeType<T> }`, will return `T`.
-/// Given `struct A<T> { thing: T }`, will **not** return `T`.
+/// Given `struct A<T> { thing: SomeType<T> }`, will include `T` in the set.
+/// Given `struct A<T> { thing: T }`, will **not** include `T` in the set.
 fn collect_generic_arguments(ty: &Type) -> HashSet<Ident> {
     struct GenericsVisitor {
         found: HashSet<Ident>,

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 
 use alloc::vec::Vec;
+use hashbrown::HashSet;
 use proc_macro2::Ident;
 use syn::{
     parse_quote,
@@ -22,20 +22,25 @@ use syn::{
     spanned::Spanned,
     visit::Visit,
     Generics,
+    GenericArgument,
     Result,
     Type,
     WhereClause,
+    WherePredicate,
 };
 
 /// Generates a where clause for a `TypeInfo` impl, adding `TypeInfo + 'static` bounds to all
 /// relevant generic types including associated types (e.g. `T::A: TypeInfo`), correctly dealing
 /// with self-referential types.
+/// Returns a tuple with a where clause and the set of type params that appear
+/// in `Compact` fields/variants in the form `Something<T>` (type params that
+/// appear as just `T` are not included)
 pub fn make_where_clause<'a>(
-    input_ident: &'a Ident, // The type we're deriving TypeInfo for
-    generics: &'a Generics, // The type params to our type
-    data: &'a syn::Data,    // The body of the type
-    scale_info: &Ident,     // Crate name
-    parity_scale_codec: &Ident, // Crate name
+    input_ident: &'a Ident,
+    generics: &'a Generics,
+    data: &'a syn::Data,
+    scale_info: &Ident,
+    parity_scale_codec: &Ident,
 ) -> Result<(WhereClause, HashSet<Ident>)> {
     let mut where_clause = generics.where_clause.clone().unwrap_or_else(|| {
         WhereClause {
@@ -54,77 +59,40 @@ pub fn make_where_clause<'a>(
     }
 
     let types = collect_types_to_bind(input_ident, data, &ty_params_ids)?;
-    // println!("[DDD] nr types appearing in source={:?}", types.len());
     let mut need_compact_bounds: HashSet<Ident> = HashSet::new();
     let mut need_normal_bounds: HashSet<Ident> = HashSet::new();
-    use syn::WherePredicate;
     let mut where_predicates: HashSet<WherePredicate> = HashSet::new();
     types.into_iter().for_each(|(ty, is_compact, _)| {
-        // Compact types need two bounds: `T: HasCompact` and `<T as
-        // HasCompact>::Type: TypeInfo + 'static`
-
-        // TODO: should pass in a `&mut HashSet` from outside the loop to ensure we avoid repetitions
-        let type_params_in_type = collect_generic_arguments(&ty);
+        // Compact types need two bounds:
+        //  `T: HasCompact` and
+        //  `<T as HasCompact>::Type: TypeInfo + 'static`
+        let generic_arguments = collect_generic_arguments(&ty);
         if is_compact {
-            println!("[make_where_clause]   is Compact, ty={:?}  adding HasCompact bounds", ty);
-            println!("[make_where_clause]   is Compact, type_params_in_type={:?}", type_params_in_type);
             where_predicates.insert(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
             where_predicates.insert(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
-
-            // where_clause
-            //     .predicates
-            //     .push(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
-            // where_clause
-            //     .predicates
-            //     .push(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
-            // for tp in type_params_in_type {
-            //     where_clause.predicates.push(parse_quote!( #tp : 'static ))
-            // }
-            need_compact_bounds.extend(type_params_in_type);
+            need_compact_bounds.extend(generic_arguments);
         } else {
-            // println!("[DDD] ty={:?} is NOT Compact, adding TypeInfo bound", ty);
             where_predicates.insert(parse_quote!(#ty : :: #scale_info ::TypeInfo + 'static));
-
-            // where_clause
-            //     .predicates
-            //     .push(parse_quote!(#ty : :: #scale_info ::TypeInfo + 'static));
-            // for tp in type_params_in_type {
-            //     where_clause.predicates.push(parse_quote!( #tp : :: #scale_info ::TypeInfo + 'static ))
-            // }
-            need_normal_bounds.extend(type_params_in_type);
+            need_normal_bounds.extend(generic_arguments);
         }
     });
-    println!(
-        "[make_where_clause]   need_compact_bounds={:?}",
-        need_compact_bounds
-    );
-    println!(
-        "[make_where_clause]   need_normal_bounds={:?}",
-        need_normal_bounds
-    );
-    // TODO: make issue:
     // Loop over the type params given to the type and add `TypeInfo` and
     // `'static` bounds. Type params that are used in fields/variants that are
     // `Compact` need only the `'static` bound.
-    // Note that if a type parameter appears "naked" in a field/variant, e.g.
-    // `struct A<T> { one: T }`, we will end up adding the bounds twice, once
-    // above as it appears in a field and once again below as it's one of the
-    // type params of `A`. Type params that appear as parameters to other types,
-    // e.g. `struct A<T> { one: PhantomData<T> }` do not get double bounds.
-
-    // The reason we do this "double looping" over first generics in used in
-    // fields/variants and then generics is that a type can have a type
-    // parameter bound to a trait, e.g. `T: SomeTrait`, that is not used as-is
-    // in the fields/variants but whose associated type **is**. Something like
-    // this:
+    // The reason we do this "double looping", first over generics used in
+    // fields/variants and then the generics given in the type definition
+    // itself, is that a type can have a type parameter bound to a trait, e.g.
+    // `T: SomeTrait`, that is not used as-is in the fields/variants but whose
+    // associated type **is**. Something like this:
     // `struct A<T: SomeTrait> { one: T::SomeAssoc, }`
+    //
     // When deriving `TypeInfo` for `A`, the first loop above adds
     // `T::SomeAssoc: TypeInfo + 'static`, but we also need
     // `T: TypeInfo + 'static`.
     // Hence the second loop.
     generics.type_params().into_iter().for_each(|type_param| {
         let ident = type_param.ident.clone();
-        // Find the type parameter in the list of types that appear in the
+        // Find the type parameter in the list of types that appear in any of the
         // fields/variants and check if it is used in a `Compact` field/variant.
         // If yes, only add the `'static` bound, else add both `TypeInfo` and
         // `'static` bounds.
@@ -137,49 +105,6 @@ pub fn make_where_clause<'a>(
             bounds.push(parse_quote!('static));
         }
         where_predicates.insert(parse_quote!( #ident : #bounds));
-
-        // let mut bounds = type_param.bounds.clone();
-        // if need_compact_bounds.contains(&ident) {
-        //     bounds.push(parse_quote!('static));
-        //     where_clause
-        //         .predicates
-        //         .push(parse_quote!( #ident : #bounds));
-        // } else {
-        //     // let mut bounds = type_param.bounds.clone();
-        //     bounds.push(parse_quote!(:: #scale_info ::TypeInfo));
-        //     bounds.push(parse_quote!('static));
-        //     where_clause
-        //         .predicates
-        //         .push(parse_quote!( #ident : #bounds));
-        // }
-
-        // let is_compact = types2
-        //     .iter()
-        //     .filter(|ty| {
-        //         if let Some(i) = &ty.2 {
-        //             i == &ident
-        //         } else {
-        //             false
-        //         }
-        //     })
-        //     .any(|ty| ty.1 );
-        // if is_compact {
-        //     // println!("[DDD] ident {:?} is used for a field that is Compact; not adding TypeInfo bound", ident);
-        //     let mut bounds = type_param.bounds.clone();
-        //     bounds.push(parse_quote!('static));
-        //     where_clause
-        //         .predicates
-        //         .push(parse_quote!( #ident : #bounds));
-
-        // } else {
-        //     // println!("[DDD] ident {:?} is used for a field that is NOT Compact. Adding bounds", ident);
-        //     let mut bounds = type_param.bounds.clone();
-        //     bounds.push(parse_quote!(:: #scale_info ::TypeInfo));
-        //     bounds.push(parse_quote!('static));
-        //     where_clause
-        //         .predicates
-        //         .push(parse_quote!( #ident : #bounds));
-        // }
     });
 
     where_predicates.extend(
@@ -197,132 +122,80 @@ pub fn make_where_clause<'a>(
     Ok((where_clause, need_compact_bounds))
 }
 
-/// Visits the ast and checks if the given type contains one of the given
+/// Visits the ast for a [`syn::Type`] and checks if it contains one of the given
 /// idents.
-// TODO: what if the type contains more than one of the idents?
-// TODO: return just `Option<Ident>`?
-fn type_contains_idents(ty: &Type, idents: &[Ident]) -> (bool, Option<Ident>) {
+fn type_contains_idents(ty: &Type, idents: &[Ident]) -> Option<Ident> {
     struct ContainIdents<'a> {
-        result: (bool, Option<Ident>),
         idents: &'a [Ident],
+        result: Option<Ident>,
     }
     impl<'a, 'ast> Visit<'ast> for ContainIdents<'a> {
         fn visit_ident(&mut self, i: &'ast Ident) {
             if self.idents.iter().any(|id| id == i) {
-                self.result = (true, Some(i.clone()));
+                self.result = Some(i.clone());
             }
         }
     }
 
     let mut visitor = ContainIdents {
-        result: (false, None),
         idents,
+        result: None,
     };
     visitor.visit_type(ty);
     visitor.result
 }
 
-// Should call this on a syn:Field instead so we have access to the Attributes, that way we could collect both `Compact` and generics usage?
-// TODO: Can this be done when visiting the type in `type_contains_ident` instead?
-// Visit a `Type` and collect all generics used.
-// example: given `struct A<T> { thing: SomeType<T> }` will return `T`.
-// example: given `struct A<T> { thing: T }` will **not** return `T`.
-// TODO: can it be changed to return both `T` in both cases? I think not, proc macros work on the syntax level.
+/// Visit a `Type` and collect generic type params used.
+/// Given `struct A<T> { thing: SomeType<T> }`, will return `T`.
+/// Given `struct A<T> { thing: T }`, will **not** return `T`.
 fn collect_generic_arguments(ty: &Type) -> HashSet<Ident> {
-    use syn::GenericArgument;
-    println!("[collect_generic_arguments]  ty={:?}", ty);
-    struct Bla {
-        result: HashSet<Ident>,
+    struct GenericsVisitor {
+        found: HashSet<Ident>,
     }
-    impl<'ast> Visit<'ast> for Bla {
+    impl<'ast> Visit<'ast> for GenericsVisitor {
         fn visit_generic_argument(&mut self, g: &'ast GenericArgument) {
-            println!("collect_generic_arguments={:?}", g);
             if let GenericArgument::Type(syn::Type::Path(syn::TypePath {
                 path: t, ..
             })) = g
             {
-                println!("collect_generic_arguments, type={:?}", t.get_ident());
-
                 if let Some(ident) = t.get_ident() {
-                    self.result.insert(ident.clone());
+                    self.found.insert(ident.clone());
                 }
             }
         }
     }
-    let mut visitor = Bla {
-        result: HashSet::new(),
+    let mut visitor = GenericsVisitor {
+        found: HashSet::new(),
     };
     visitor.visit_type(ty);
-    println!(
-        "[collect_generic_arguments]  found type params={:?}",
-        visitor.result
-    );
-
-    visitor.result
+    visitor.found
 }
 
-fn visit_fields(ident: &Ident, data: &syn::Data) {
-    use syn::{
-        Attribute,
-        Field,
-        Fields,
-    };
-    struct Bla {
-        result: HashSet<Ident>,
-    }
-
-    impl<'ast> Visit<'ast> for Bla {
-        fn visit_fields(&mut self, fs: &'ast Fields) {
-            println!("visit_fields={:#?}", fs);
-            for f in fs {
-                self.visit_field(f)
-            }
-        }
-        // Nope
-        fn visit_attribute(&mut self, node: &'ast Attribute) {
-            println!("visit_attribute={:#?}", node);
-        }
-        // Nope
-        fn visit_field(&mut self, i: &'ast Field) {
-            println!("visit_field (sing)={:#?}", i);
-            for attr in &i.attrs {
-                self.visit_attribute(&attr);
-            }
-        }
-    }
-
-    let mut visitor = Bla {
-        result: HashSet::new(),
-    };
-    visitor.visit_data(data);
-}
-
-/// Returns all types that must be added to the where clause with a boolean
+/// Returns all types that must be added to the where clause, with a boolean
 /// indicating if the field is [`scale::Compact`] or not.
 fn collect_types_to_bind(
     input_ident: &Ident,
     data: &syn::Data,
     ty_params: &[Ident],
 ) -> Result<Vec<(Type, bool, Option<Ident>)>> {
-    // Experiment:
-    // visit_fields(input_ident, data);
     let types_from_fields =
         |fields: &Punctuated<syn::Field, _>| -> Vec<(Type, bool, Option<Ident>)> {
             fields
                 .iter()
+                // TODO: Rewrite this as a `fold` to remove multiple calls to `type_contains_ident`.
                 .filter(|field| {
                     // Only add a bound if the type uses a generic.
-                    type_contains_idents(&field.ty, &ty_params).0
+                    type_contains_idents(&field.ty, &ty_params).is_some()
                 &&
                 // Remove all remaining types that start/contain the input ident
                 // to not have them in the where clause.
-                !type_contains_idents(&field.ty, &[input_ident.clone()]).0
+                type_contains_idents(&field.ty, &[input_ident.clone()]).is_none()
                 })
                 .map(|f| {
                     (
                         f.ty.clone(),
                         super::is_compact(f),
-                        type_contains_idents(&f.ty, &ty_params).1,
+                        type_contains_idents(&f.ty, &ty_params),
                     )
                 })
                 .collect()

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use alloc::vec::Vec;
-use hashbrown::HashSet;
 use proc_macro2::Ident;
+use std::collections::HashSet;
 use syn::{
     parse_quote,
     punctuated::Punctuated,

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -281,7 +281,9 @@ fn scale_compact_types_work_in_enums() {
 
 #[test]
 fn scale_compact_types_complex() {
-    trait Boo { type B: TypeInfo; }
+    trait Boo {
+        type B: TypeInfo;
+    }
     impl Boo for u8 {
         type B = bool;
     }
@@ -299,11 +301,12 @@ fn scale_compact_types_complex() {
     let ty = Type::builder()
         .path(Path::new("A", "derive"))
         .type_params(tuple_meta_type![u8, u16])
-        .composite(Fields::named()
-            .field_of::<PhantomData<u8>>("one", "PhantomData<T>")
-            .field_of::<PhantomData<u16>>("two", "PhantomData<U>")
-            .compact_of::<u8>("three", "T")
-            .field_of::<bool>("four", "T::B")
+        .composite(
+            Fields::named()
+                .field_of::<PhantomData<u8>>("one", "PhantomData<T>")
+                .field_of::<PhantomData<u16>>("two", "PhantomData<U>")
+                .compact_of::<u8>("three", "T")
+                .field_of::<bool>("four", "T::B"),
         );
 
     assert_type!(A<u8, u16>, ty);

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+// #![cfg_attr(not(feature = "std"), no_std)]
 
 use pretty_assertions::assert_eq;
 use scale::Encode;
@@ -254,30 +254,119 @@ fn scale_compact_types_work_in_structs() {
     assert_type!(Dense, ty_alt);
 }
 
+// #[test]
+// fn scale_compact_types_work_in_enums() {
+//     #[allow(unused)]
+//     #[derive(Encode, TypeInfo)]
+//     enum MutilatedMultiAddress<AccountId, AccountIndex> {
+//         Id(AccountId),
+//         Index(#[codec(compact)] AccountIndex),
+//         Address32([u8; 32]),
+//     }
+
+//     let ty = Type::builder()
+//         .path(Path::new("MutilatedMultiAddress", "derive"))
+//         .type_params(tuple_meta_type!(u8, u16))
+//         .variant(
+//             Variants::with_fields()
+//                 .variant("Id", Fields::unnamed().field_of::<u8>("AccountId"))
+//                 .variant("Index", Fields::unnamed().compact_of::<u16>("AccountIndex"))
+//                 .variant(
+//                     "Address32",
+//                     Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"),
+//                 ),
+//         );
+
+//     assert_type!(MutilatedMultiAddress<u8, u16>, ty);
+// }
+
 #[test]
-fn scale_compact_types_work_in_enums() {
+fn bah() {
+    use scale::Decode;
     #[allow(unused)]
-    #[derive(Encode, TypeInfo)]
-    enum MutilatedMultiAddress<AccountId, AccountIndex> {
+    #[derive(Encode, TypeInfo, Decode, PartialEq, Clone, Hash)]
+    // #[derive(Encode, Decode, PartialEq, Clone, Hash)]
+    pub enum MultiAddress<AccountId, AccountIndex> {
+        /// It's an account ID (pubkey).
         Id(AccountId),
+        /// It's an account index.
         Index(#[codec(compact)] AccountIndex),
+        /// It's some arbitrary raw bytes.
+        Raw(Vec<u8>),
+        /// It's a 32 byte representation.
         Address32([u8; 32]),
+        /// Its a 20 byte representation.
+        Address20([u8; 20]),
     }
 
+    // use scale::HasCompact;
+    // impl<AccountId, AccountIndex> TypeInfo for MultiAddress<AccountId, AccountIndex>
+    // where
+    //     AccountId: ::scale_info::TypeInfo + 'static,
+    //     AccountIndex: ::scale::HasCompact + 'static,
+    //     <AccountIndex as ::scale::HasCompact>::Type: ::scale_info::TypeInfo + 'static,
+    // {
+    //     type Identity = Self;
+    //     fn type_info() -> ::scale_info::Type {
+    //         ::scale_info::Type::builder()
+    //             .path(::scale_info::Path::new("MultiAddress", "derive"))
+    //             .type_params(vec![
+    //                 ::scale_info::meta_type::<AccountId>(),
+    //                 ::scale_info::meta_type::<<AccountIndex as HasCompact>::Type>(),
+    //             ])
+    //             .variant(
+    //                 ::scale_info::build::Variants::with_fields()
+    //                     .variant(
+    //                         "Id",
+    //                         ::scale_info::build::Fields::unnamed()
+    //                             .field_of::<AccountId>("AccountId"),
+    //                     )
+    //                     .variant(
+    //                         "Index",
+    //                         ::scale_info::build::Fields::unnamed()
+    //                             .compact_of::<AccountIndex>("AccountIndex"),
+    //                     )
+    //                     .variant(
+    //                         "Raw",
+    //                         ::scale_info::build::Fields::unnamed()
+    //                             .field_of::<Vec<u8>>("Vec<u8>"),
+    //                     )
+    //                     .variant(
+    //                         "Address32",
+    //                         ::scale_info::build::Fields::unnamed()
+    //                             .field_of::<[u8; 32]>("[u8; 32]"),
+    //                     )
+    //                     .variant(
+    //                         "Address20",
+    //                         ::scale_info::build::Fields::unnamed()
+    //                             .field_of::<[u8; 20]>("[u8; 20]"),
+    //                     ),
+    //             )
+    //     }
+    // }
     let ty = Type::builder()
-        .path(Path::new("MutilatedMultiAddress", "derive"))
-        .type_params(tuple_meta_type!(u8, u16))
+        .path(Path::new("MultiAddress", "derive"))
+        // .type_params(tuple_meta_type!(u8, u16))
+        .type_params(vec![
+            ::scale_info::meta_type::<u8>(),
+            ::scale_info::meta_type::<<u16 as ::scale::HasCompact>::Type>(),
+        ])
         .variant(
             Variants::with_fields()
                 .variant("Id", Fields::unnamed().field_of::<u8>("AccountId"))
                 .variant("Index", Fields::unnamed().compact_of::<u16>("AccountIndex"))
+                .variant("Raw", Fields::unnamed().field_of::<Vec<u8>>("Vec<u8>"))
                 .variant(
                     "Address32",
                     Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"),
-                ),
+                )
+                .variant(
+                    "Address20",
+                    Fields::unnamed().field_of::<[u8; 20]>("[u8; 20]"),
+                )
         );
 
-    assert_type!(MutilatedMultiAddress<u8, u16>, ty);
+    assert_type!(MultiAddress<u8, u16>, ty);
 }
 
 #[test]
@@ -295,14 +384,14 @@ fn whitespace_scrubbing_works() {
     assert_type!(A, ty);
 }
 
-#[rustversion::nightly]
-#[test]
-fn ui_tests() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/fail_missing_derive.rs");
-    t.compile_fail("tests/ui/fail_unions.rs");
-    t.pass("tests/ui/pass_non_static_lifetime.rs");
-    t.pass("tests/ui/pass_self_referential.rs");
-    t.pass("tests/ui/pass_basic_generic_type.rs");
-    t.pass("tests/ui/pass_complex_generic_self_referential_type.rs");
-}
+// #[rustversion::nightly]
+// #[test]
+// fn ui_tests() {
+//     let t = trybuild::TestCases::new();
+//     t.compile_fail("tests/ui/fail_missing_derive.rs");
+//     t.compile_fail("tests/ui/fail_unions.rs");
+//     t.pass("tests/ui/pass_non_static_lifetime.rs");
+//     t.pass("tests/ui/pass_self_referential.rs");
+//     t.pass("tests/ui/pass_basic_generic_type.rs");
+//     t.pass("tests/ui/pass_complex_generic_self_referential_type.rs");
+// }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -215,6 +215,7 @@ fn associated_types_derive_without_bounds() {
         a: T::A,
         b: &'bar u64,
     }
+
     #[derive(TypeInfo)]
     enum ConcreteTypes {}
     impl Types for ConcreteTypes {

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use pretty_assertions::assert_eq;
-use scale::{Encode, HasCompact};
+use scale::Encode;
 use scale_info::{
     build::*,
-    meta_type,
     prelude::{
         boxed::Box,
         marker::PhantomData,
@@ -299,7 +298,7 @@ fn scale_compact_types_complex() {
 
     let ty = Type::builder()
         .path(Path::new("A", "derive"))
-        .type_params(vec![meta_type::<u8>(), meta_type::<u16>()])
+        .type_params(tuple_meta_type![u8, u16])
         .composite(Fields::named()
             .field_of::<PhantomData<u8>>("one", "PhantomData<T>")
             .field_of::<PhantomData<u16>>("two", "PhantomData<U>")
@@ -309,32 +308,6 @@ fn scale_compact_types_complex() {
 
     assert_type!(A<u8, u16>, ty);
 }
-
-
-// TODO: make failing trybuild test out of this so we know when https://github.com/rust-lang/rust/issues/81785 is fixed
-// #[test]
-// fn scale_compact_types_work_with_generic_types() {
-//     #[derive(TypeInfo)]
-//     struct Color<Hue>{hue: Hue}
-//     #[derive(TypeInfo)]
-//     struct Texture<Bump, Hump>{bump: Bump, hump: Hump}
-
-//     #[allow(unused)]
-//     #[derive(Encode, TypeInfo)]
-//     struct Apple<T, U> {
-//         #[codec(compact)]
-//         one: Color<U>,   // <– works with a "naked" generic, `U`, but not like this
-//         two: Texture<T, U>,
-//     }
-//     let ty = Type::builder().path(Path::new("Apple", "derive"))
-//         .type_params(tuple_meta_type!(u8, u16))
-//         .composite(
-//             Fields::named()
-//                 .compact_of::<Color<u16>>("one", "Color<U>")
-//                 .field_of::<Texture<u8, u16>>("two", "Texture<T, U>")
-//         );
-//     assert_type!(Apple<u8, u16>, ty);
-// }
 
 #[test]
 fn whitespace_scrubbing_works() {
@@ -351,18 +324,18 @@ fn whitespace_scrubbing_works() {
     assert_type!(A, ty);
 }
 
-// TODO: re-enable when warnings are fixed
-// #[rustversion::nightly]
-// #[test]
-// fn ui_tests() {
-//     let t = trybuild::TestCases::new();
-//     t.compile_fail("tests/ui/fail_missing_derive.rs");
-//     t.compile_fail("tests/ui/fail_unions.rs");
-//     t.compile_fail("tests/ui/fail_use_codec_attrs_without_deriving_encode.rs");
-//     t.compile_fail("tests/ui/fail_with_invalid_codec_attrs.rs");
-//     t.pass("tests/ui/pass_with_valid_codec_attrs.rs");
-//     t.pass("tests/ui/pass_non_static_lifetime.rs");
-//     t.pass("tests/ui/pass_self_referential.rs");
-//     t.pass("tests/ui/pass_basic_generic_type.rs");
-//     t.pass("tests/ui/pass_complex_generic_self_referential_type.rs");
-// }
+#[rustversion::nightly]
+#[test]
+fn ui_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail_missing_derive.rs");
+    t.compile_fail("tests/ui/fail_unions.rs");
+    t.compile_fail("tests/ui/fail_use_codec_attrs_without_deriving_encode.rs");
+    t.compile_fail("tests/ui/fail_with_invalid_codec_attrs.rs");
+    t.compile_fail("tests/ui/fail_infinite_recursion.rs");
+    t.pass("tests/ui/pass_with_valid_codec_attrs.rs");
+    t.pass("tests/ui/pass_non_static_lifetime.rs");
+    t.pass("tests/ui/pass_self_referential.rs");
+    t.pass("tests/ui/pass_basic_generic_type.rs");
+    t.pass("tests/ui/pass_complex_generic_self_referential_type.rs");
+}

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -246,14 +246,13 @@ fn test_struct_with_some_fields_marked_as_compact() {
 fn test_struct_with_phantom() {
     use scale_info::prelude::marker::PhantomData;
     #[derive(TypeInfo)]
-    struct SSStruct<T> {
-        // a: i32,
+    struct Struct<T> {
         a: T,
         b: PhantomData<T>,
     }
 
-    assert_json_for_type::<SSStruct<u8>>(json!({
-        "path": ["json", "SSStruct"],
+    assert_json_for_type::<Struct<u8>>(json!({
+        "path": ["json", "Struct"],
         "params": [1],
         "def": {
             "composite": {

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -246,13 +246,14 @@ fn test_struct_with_some_fields_marked_as_compact() {
 fn test_struct_with_phantom() {
     use scale_info::prelude::marker::PhantomData;
     #[derive(TypeInfo)]
-    struct Struct<T> {
-        a: i32,
+    struct SSStruct<T> {
+        // a: i32,
+        a: T,
         b: PhantomData<T>,
     }
 
-    assert_json_for_type::<Struct<u8>>(json!({
-        "path": ["json", "Struct"],
+    assert_json_for_type::<SSStruct<u8>>(json!({
+        "path": ["json", "SSStruct"],
         "params": [1],
         "def": {
             "composite": {

--- a/test_suite/tests/ui/fail_infinite_recursion.rs
+++ b/test_suite/tests/ui/fail_infinite_recursion.rs
@@ -1,0 +1,22 @@
+use scale_info::TypeInfo;
+use scale::Encode;
+
+#[derive(TypeInfo)]
+struct Color<Hue>{hue: Hue}
+#[derive(TypeInfo)]
+struct Texture<Bump, Hump>{bump: Bump, hump: Hump}
+
+#[allow(unused)]
+#[derive(Encode, TypeInfo)]
+struct Apple<T, U> {
+    #[codec(compact)]
+    one: Color<U>,   // <– works with a "naked" generic, `U`, but not like this
+    two: Texture<T, U>,
+}
+
+fn assert_type_info<T: TypeInfo + 'static>() {}
+
+fn main() {
+    // When this test fails it could mean that https://github.com/rust-lang/rust/issues/81785 is fixed
+    assert_type_info::<Apple<u8, u16>>();
+}

--- a/test_suite/tests/ui/fail_infinite_recursion.stderr
+++ b/test_suite/tests/ui/fail_infinite_recursion.stderr
@@ -1,0 +1,6 @@
+error[E0275]: overflow evaluating the requirement `_parity_scale_codec::Compact<_>: Decode`
+  |
+  = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`$CRATE`)
+  = note: required because of the requirements on the impl of `Decode` for `_parity_scale_codec::Compact<_>`
+  = note: 126 redundant requirements hidden
+  = note: required because of the requirements on the impl of `Decode` for `_parity_scale_codec::Compact<_>`


### PR DESCRIPTION
If a type param is used in a compact field, don't add `TypeInfo + 'static` bound (just `'static`)
If a type param is used in a compact field, call `meta_type::<<$ty as HasCompact>::Type>()` instead of `meta_type::<$ty>()` in the implementation of `TypeInfo`.

Avoid adding duplicate bounds.
