### PR TITLE
Remove type parameter defaults

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 extern crate proc_macro;

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -42,7 +42,9 @@ pub fn make_where_clause<'a>(
         }
     });
     for lifetime in generics.lifetimes() {
-        where_clause.predicates.push(parse_quote!(#lifetime: 'static))
+        where_clause
+            .predicates
+            .push(parse_quote!(#lifetime: 'static))
     }
 
     let type_params = generics.type_params();

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -41,6 +41,9 @@ pub fn make_where_clause<'a>(
             predicates: Punctuated::new(),
         }
     });
+    for lifetime in generics.lifetimes() {
+        where_clause.predicates.push(parse_quote!(#lifetime: 'static))
+    }
 
     let type_params = generics.type_params();
     let ty_params_ids = type_params

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -301,6 +301,7 @@ fn type_parameters_with_default_bound_works() {
         .path(Path::new("Bat", "derive"))
         .type_params(tuple_meta_type!(MetaFormy))
         .composite(Fields::named().field_of::<MetaFormy>("one", "TTT"));
+
     assert_type!(Bat<MetaFormy>, ty);
 }
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -281,6 +281,30 @@ fn scale_compact_types_work_in_enums() {
 }
 
 #[test]
+fn type_parameters_with_default_bound_works() {
+    trait Formy {
+        type Tip;
+    }
+    #[derive(TypeInfo)]
+    pub enum MetaFormy {}
+    impl Formy for MetaFormy { type Tip = u8; }
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Bat<TTT: Formy = MetaFormy> {
+        one: TTT
+    }
+
+    let ty = Type::builder()
+        .path(Path::new("Bat", "derive"))
+        .type_params(tuple_meta_type!(MetaFormy))
+        .composite(
+            Fields::named().field_of::<MetaFormy>("one", "TTT")
+        );
+    assert_type!(Bat<MetaFormy>, ty);
+}
+
+#[test]
 fn whitespace_scrubbing_works() {
     #[allow(unused)]
     #[derive(TypeInfo)]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -287,20 +287,20 @@ fn type_parameters_with_default_bound_works() {
     }
     #[derive(TypeInfo)]
     pub enum MetaFormy {}
-    impl Formy for MetaFormy { type Tip = u8; }
+    impl Formy for MetaFormy {
+        type Tip = u8;
+    }
 
     #[allow(unused)]
     #[derive(TypeInfo)]
     struct Bat<TTT: Formy = MetaFormy> {
-        one: TTT
+        one: TTT,
     }
 
     let ty = Type::builder()
         .path(Path::new("Bat", "derive"))
         .type_params(tuple_meta_type!(MetaFormy))
-        .composite(
-            Fields::named().field_of::<MetaFormy>("one", "TTT")
-        );
+        .composite(Fields::named().field_of::<MetaFormy>("one", "TTT"));
     assert_type!(Bat<MetaFormy>, ty);
 }
 


### PR DESCRIPTION
Defaults for type parameter bounds are only allowed in structs, enums, type and trait definitions, not in impl blocks, so when deriving the `TypeInfo` impl we have to remove them.

See https://github.com/rust-lang/rust/issues/36887 for details.﻿
