### PR TITLE
Fix serde and decode features without default features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,17 @@ jobs:
         cargo clippy --version
         cargo clippy --all -- -D warnings
 
+    - name: check-all-features
+      run: |
+        cargo generate-lockfile --verbose && cargo update -p funty --precise "1.1.0" --verbose
+        cargo check --all --all-features
+
+    - name: check-features
+      run: |
+        cargo generate-lockfile --verbose && cargo update -p funty --precise "1.1.0" --verbose
+        cargo check --no-default-features --features serde
+        cargo check --no-default-features --features serde,decode
+
     - name: build
       run: |
         cargo generate-lockfile --verbose && cargo update -p funty --precise "1.1.0" --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ derive = [
     "scale-info-derive"
 ]
 # enables decoding and deserialization of portable scale-info type metadata
-decode = []
+decode = [
+    "scale/full"
+]
 
 [workspace]
 members = [

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -44,11 +44,6 @@ use crate::{
     Type,
 };
 use scale::Encode;
-#[cfg(feature = "serde")]
-use serde::{
-    Deserialize,
-    Serialize,
-};
 
 /// Convert the type definition into the portable form using a registry.
 pub trait IntoPortable {
@@ -165,7 +160,8 @@ impl Registry {
 }
 
 /// A read-only registry containing types in their portable form for serialization.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scale-info = { path = "..", features = ["derive", "serde"] }
+scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"


### PR DESCRIPTION
Previously the following feature combinations caused compilation errors: 

`cargo check --no-default-features --features serde` caused ```implementation of `Deserialize` is not general enough```: because by default `PortableForm::String = &'static str`

`cargo check --no-default-features --features decode` failed because `parity-scale-codec` needs the `full` feature to support `String` decoding.

The reason we have these features is to support constructing `PortableForm` types for encoding in the substrate runtime, which does not support `String` encoding. See https://github.com/paritytech/scale-info/pull/59 and https://github.com/paritytech/scale-info/pull/35 for more.