### PR TITLE
Fix trait bounds for associated types

### DIFF
--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -18,10 +18,11 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    visit::Visit,
+    visit::{self, Visit},
     Generics,
     Result,
     Type,
+    TypePath,
     WhereClause,
 };
 
@@ -112,6 +113,34 @@ fn type_contains_idents(ty: &Type, idents: &[Ident]) -> bool {
     visitor.result
 }
 
+/// Checks if the given type or any containing type path starts with the given ident.
+fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
+    // Visits the ast and checks if the a type path starts with the given ident.
+    struct TypePathStartsWithIdent<'a> {
+        result: bool,
+        ident: &'a Ident
+    }
+
+    impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
+        fn visit_type_path(&mut self, i: &'ast TypePath) {
+            if i.qself.is_none() {
+                if let Some(segment) = i.path.segments.first() {
+                    if &segment.ident == self.ident {
+                        self.result = true;
+                        return;
+                    }
+                }
+            }
+            visit::visit_type_path(self, i);
+        }
+    }
+
+	let mut visitor = TypePathStartsWithIdent { result: false, ident };
+	visitor.visit_type(ty);
+	visitor.result
+}
+
+
 /// Returns all types that must be added to the where clause with a boolean
 /// indicating if the field is [`scale::Compact`] or not.
 fn collect_types_to_bind(
@@ -128,7 +157,7 @@ fn collect_types_to_bind(
                 &&
                 // Remove all remaining types that start/contain the input ident
                 // to not have them in the where clause.
-                !type_contains_idents(&field.ty, &[input_ident.clone()])
+                !type_or_sub_type_path_starts_with_ident(&field.ty, &input_ident)
             })
             .map(|f| (f.ty.clone(), super::is_compact(f)))
             .collect()

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -18,7 +18,10 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    visit::{self, Visit},
+    visit::{
+        self,
+        Visit,
+    },
     Generics,
     Result,
     Type,
@@ -118,7 +121,7 @@ fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
     // Visits the ast and checks if the a type path starts with the given ident.
     struct TypePathStartsWithIdent<'a> {
         result: bool,
-        ident: &'a Ident
+        ident: &'a Ident,
     }
 
     impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
@@ -127,7 +130,7 @@ fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
                 if let Some(segment) = i.path.segments.first() {
                     if &segment.ident == self.ident {
                         self.result = true;
-                        return;
+                        return
                     }
                 }
             }
@@ -135,11 +138,13 @@ fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
         }
     }
 
-	let mut visitor = TypePathStartsWithIdent { result: false, ident };
-	visitor.visit_type(ty);
-	visitor.result
+    let mut visitor = TypePathStartsWithIdent {
+        result: false,
+        ident,
+    };
+    visitor.visit_type(ty);
+    visitor.result
 }
-
 
 /// Returns all types that must be added to the where clause with a boolean
 /// indicating if the field is [`scale::Compact`] or not.

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -21,6 +21,7 @@ use scale_info::{
     prelude::{
         boxed::Box,
         marker::PhantomData,
+        vec::Vec,
     },
     tuple_meta_type,
     Path,
@@ -229,6 +230,40 @@ fn associated_types_derive_without_bounds() {
             Fields::named()
                 .field_of::<bool>("a", "T::A")
                 .field_of::<u64>("b", "&'static u64"),
+        );
+
+    assert_type!(Assoc<ConcreteTypes>, struct_type);
+}
+
+#[test]
+fn associated_types_named_like_the_derived_type_works() {
+    trait Types {
+        type Assoc;
+    }
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Assoc<T: Types> {
+        a: Vec<T::Assoc>,
+        b: Vec<<T>::Assoc>,
+        c: T::Assoc,
+        d: <T>::Assoc,
+    }
+
+    #[derive(TypeInfo)]
+    enum ConcreteTypes {}
+    impl Types for ConcreteTypes {
+        type Assoc = bool;
+    }
+
+    let struct_type = Type::builder()
+        .path(Path::new("Assoc", "derive"))
+        .type_params(tuple_meta_type!(ConcreteTypes))
+        .composite(
+            Fields::named()
+                .field_of::<Vec<bool>>("a", "Vec<T::Assoc>")
+                .field_of::<Vec<bool>>("b", "Vec<<T>::Assoc>")
+                .field_of::<bool>("c", "T::Assoc")
+                .field_of::<bool>("d", "<T>::Assoc")
         );
 
     assert_type!(Assoc<ConcreteTypes>, struct_type);

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -263,7 +263,7 @@ fn associated_types_named_like_the_derived_type_works() {
                 .field_of::<Vec<bool>>("a", "Vec<T::Assoc>")
                 .field_of::<Vec<bool>>("b", "Vec<<T>::Assoc>")
                 .field_of::<bool>("c", "T::Assoc")
-                .field_of::<bool>("d", "<T>::Assoc")
+                .field_of::<bool>("d", "<T>::Assoc"),
         );
 
     assert_type!(Assoc<ConcreteTypes>, struct_type);


### PR DESCRIPTION
When a type has a type parameter that is bound to a trait with an associated type and that associated type has the same name as the type we're deriving TypeInfo for, the trait bounds are wrong.

See #73 for more gory details.

Thanks to @thiolliere for [the fix](https://github.com/paritytech/parity-scale-codec/issues/257).

Closes #73
