### PR TITLE
Remove HasCompact::Type bounds

### DIFF
--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -71,9 +71,6 @@ pub fn make_where_clause<'a>(
             where_clause
                 .predicates
                 .push(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
-            where_clause
-                .predicates
-                .push(parse_quote!(<#ty as :: #parity_scale_codec ::HasCompact>::Type : :: #scale_info ::TypeInfo + 'static));
         } else {
             where_clause
                 .predicates

--- a/src/build.rs
+++ b/src/build.rs
@@ -263,8 +263,7 @@ impl FieldsBuilder<NamedFields> {
     /// Add a named, [`Compact`] field of type `T`.
     pub fn compact_of<T>(mut self, name: &'static str, type_name: &'static str) -> Self
     where
-        T: scale::HasCompact,
-        <T as scale::HasCompact>::Type: TypeInfo + 'static,
+        T: scale::HasCompact + TypeInfo + 'static,
     {
         self.fields
             .push(Field::compact_of::<T>(Some(name), type_name));
@@ -285,8 +284,7 @@ impl FieldsBuilder<UnnamedFields> {
     /// Add an unnamed, [`Compact`] field of type `T`.
     pub fn compact_of<T>(mut self, type_name: &'static str) -> Self
     where
-        T: scale::HasCompact,
-        <T as scale::HasCompact>::Type: TypeInfo + 'static,
+        T: scale::HasCompact + TypeInfo + 'static,
     {
         self.fields.push(Field::compact_of::<T>(None, type_name));
         self

--- a/src/build.rs
+++ b/src/build.rs
@@ -363,11 +363,11 @@ impl<N> FieldBuilder<N, field_state::TypeNotAssigned> {
     /// Initializes the type of the field as a compact type.
     pub fn compact<TY>(self) -> FieldBuilder<N, field_state::TypeAssigned>
     where
-        T: scale::HasCompact + TypeInfo + 'static,
+        TY: scale::HasCompact + TypeInfo + 'static,
     {
         FieldBuilder {
             name: self.name,
-            ty: Some(MetaType::new::<<TY as scale::HasCompact>::Type>()),
+            ty: Some(MetaType::new::<scale::Compact<TY>>()),
             type_name: self.type_name,
             docs: self.docs,
             marker: PhantomData,

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -134,10 +134,9 @@ impl Field {
     /// Creates a new [`Compact`] field.
     pub fn compact_of<T>(name: Option<&'static str>, type_name: &'static str) -> Field
     where
-        T: HasCompact,
-        <T as HasCompact>::Type: TypeInfo + 'static,
+        T: HasCompact + TypeInfo + 'static,
     {
-        Self::new(name, MetaType::new::<<T as HasCompact>::Type>(), type_name)
+        Self::new(name, MetaType::new::<scale::Compact<T>>(), type_name)
     }
 }
 


### PR DESCRIPTION
Removes the requirement for `HasCompact::Type: TypeInfo` bounds I had to add to some impls in substrate, see them removed in this commit https://github.com/paritytech/substrate/commit/7da3bb82351b2f45f12a06b5be64c87f256a9cc8. 

It does this by just registering `T` for a compact field in a `Compact<T>`. This relies on the fact that the [blanket impl](https://github.com/paritytech/parity-scale-codec/blob/master/src/compact.rs#L222) always has `Type = Compact<T>`.  

@dvdplm maybe you already tried this as part of https://github.com/paritytech/scale-info/pull/53 and decided against it.