### PR TITLE
Implement `TypeInfo` for `Cow`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 use crate::prelude::{
+    borrow::{
+        Cow,
+        ToOwned,
+    },
     boxed::Box,
-    borrow::{Cow, ToOwned},
     collections::BTreeMap,
     marker::PhantomData,
     string::String,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -14,6 +14,7 @@
 
 use crate::prelude::{
     boxed::Box,
+    borrow::{Cow, ToOwned},
     collections::BTreeMap,
     marker::PhantomData,
     string::String,
@@ -149,6 +150,20 @@ where
                     .variant("Ok", Fields::unnamed().field_of::<T>("T"))
                     .variant("Err", Fields::unnamed().field_of::<E>("E")),
             )
+    }
+}
+
+impl<T> TypeInfo for Cow<'static, T>
+where
+    T: ToOwned + TypeInfo + ?Sized + 'static,
+{
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::prelude("Cow"))
+            .type_params(tuple_meta_type!(T))
+            .composite(Fields::unnamed().field_of::<T>("T"))
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,6 +25,7 @@ cfg_if! {
     if #[cfg(feature = "std")] {
         pub use std::{
             any,
+            borrow,
             boxed,
             cmp,
             collections,
@@ -39,6 +40,7 @@ cfg_if! {
         };
     } else {
         pub use alloc::{
+            borrow,
             boxed,
             collections,
             format,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,17 +14,16 @@
 
 use crate::{
     build::*,
+    prelude::{
+        borrow::Cow,
+        boxed::Box,
+        string::String,
+        vec,
+    },
     *,
 };
 use core::marker::PhantomData;
 use scale::Compact;
-
-#[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::String,
-    vec,
-};
 
 fn assert_type<T, E>(expected: E)
 where
@@ -76,6 +75,15 @@ fn prelude_items() {
             )
     );
     assert_type!(PhantomData<i32>, TypeDefPhantom::new(meta_type::<i32>()));
+    assert_type!(
+        Cow<u128>,
+        Type::builder()
+            .path(Path::prelude("Cow"))
+            .type_params(tuple_meta_type!(u128))
+            .composite(
+                Fields::unnamed().field_of::<u128>("T")
+            )
+    );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -80,9 +80,7 @@ fn prelude_items() {
         Type::builder()
             .path(Path::prelude("Cow"))
             .type_params(tuple_meta_type!(u128))
-            .composite(
-                Fields::unnamed().field_of::<u128>("T")
-            )
+            .composite(Fields::unnamed().field_of::<u128>("T"))
     );
 }
 

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
@@ -10,6 +10,12 @@ error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` an
 13 |     Thing(#[codec(index = 3)] u32),
    |                   ^^^^^^^^^
 
+error: expected literal
+  --> $DIR/fail_with_invalid_codec_attrs.rs:18:21
+   |
+18 |     #[codec(index = a)]
+   |                     ^
+
 error: proc-macro derive panicked
   --> $DIR/fail_with_invalid_codec_attrs.rs:16:18
    |
@@ -19,10 +25,10 @@ error: proc-macro derive panicked
    = help: message: scale-info: Bad index in `#[codec(index = …)]`, see `parity-scale-codec` error: Error("expected literal")
 
 error: expected literal
-  --> $DIR/fail_with_invalid_codec_attrs.rs:18:21
+  --> $DIR/fail_with_invalid_codec_attrs.rs:24:25
    |
-18 |     #[codec(index = a)]
-   |                     ^
+24 |     #[codec(encode_as = u8, compact)]
+   |                         ^^
 
 error: proc-macro derive panicked
   --> $DIR/fail_with_invalid_codec_attrs.rs:22:18
@@ -31,9 +37,3 @@ error: proc-macro derive panicked
    |                  ^^^^^^^^
    |
    = help: message: scale-info: Bad index in `#[codec(index = …)]`, see `parity-scale-codec` error: Error("expected literal")
-
-error: expected literal
-  --> $DIR/fail_with_invalid_codec_attrs.rs:24:25
-   |
-24 |     #[codec(encode_as = u8, compact)]
-   |                         ^^


### PR DESCRIPTION
Required for substrate integration. `Cow` is just encoded as the `T` and as such is just considered a `WrapperType`. 