### PR TITLE
Replace NonZeroU32 type lookup ids with u32

### DIFF
--- a/src/interner.rs
+++ b/src/interner.rs
@@ -51,7 +51,18 @@ pub struct UntrackedSymbol<T> {
     marker: PhantomData<fn() -> T>,
 }
 
+impl<T> From<u32> for UntrackedSymbol<T> {
+    fn from(id: u32) -> Self {
+        Self::new(id)
+    }
+}
+
 impl<T> UntrackedSymbol<T> {
+    /// Construct a new [`UntrackedSymbol`].
+    pub fn new(id: u32) -> Self {
+        Self { id, marker: PhantomData }
+    }
+
     /// Returns the index to the symbol in the interner table.
     pub fn id(&self) -> u32 {
         self.id
@@ -87,10 +98,7 @@ impl<T> Symbol<'_, T> {
     /// considered to be safe since untracked symbols can no longer be
     /// used to resolve their associated instance from the interner.
     pub fn into_untracked(self) -> UntrackedSymbol<T> {
-        UntrackedSymbol {
-            id: self.id,
-            marker: PhantomData,
-        }
+        UntrackedSymbol::new(self.id)
     }
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -170,7 +170,7 @@ where
 
     /// Returns the symbol of the given element or `None` if it hasn't been
     /// interned already.
-    pub fn get(&self, s: &T) -> Option<Symbol<T>> {
+    pub fn get(&self, sym: &T) -> Option<Symbol<T>> {
         self.map.get(s).map(|&id| {
             Symbol {
                 id: id as u32,

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -171,7 +171,7 @@ where
     /// Returns the symbol of the given element or `None` if it hasn't been
     /// interned already.
     pub fn get(&self, sym: &T) -> Option<Symbol<T>> {
-        self.map.get(s).map(|&id| {
+        self.map.get(sym).map(|&id| {
             Symbol {
                 id: id as u32,
                 marker: PhantomData,

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -41,7 +41,9 @@ use serde::{
 ///
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, scale::Encode, scale::Decode)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, scale::Encode, scale::Decode,
+)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct UntrackedSymbol<T> {
@@ -60,7 +62,10 @@ impl<T> From<u32> for UntrackedSymbol<T> {
 impl<T> UntrackedSymbol<T> {
     /// Construct a new [`UntrackedSymbol`].
     pub fn new(id: u32) -> Self {
-        Self { id, marker: PhantomData }
+        Self {
+            id,
+            marker: PhantomData,
+        }
     }
 
     /// Returns the index to the symbol in the interner table.

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -53,21 +53,7 @@ pub struct UntrackedSymbol<T> {
     marker: PhantomData<fn() -> T>,
 }
 
-impl<T> From<u32> for UntrackedSymbol<T> {
-    fn from(id: u32) -> Self {
-        Self::new(id)
-    }
-}
-
 impl<T> UntrackedSymbol<T> {
-    /// Construct a new [`UntrackedSymbol`].
-    pub fn new(id: u32) -> Self {
-        Self {
-            id,
-            marker: PhantomData,
-        }
-    }
-
     /// Returns the index to the symbol in the interner table.
     pub fn id(&self) -> u32 {
         self.id
@@ -103,7 +89,10 @@ impl<T> Symbol<'_, T> {
     /// considered to be safe since untracked symbols can no longer be
     /// used to resolve their associated instance from the interner.
     pub fn into_untracked(self) -> UntrackedSymbol<T> {
-        UntrackedSymbol::new(self.id)
+        UntrackedSymbol {
+            id: self.id,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -27,7 +27,6 @@ use crate::prelude::{
     any::TypeId,
     collections::BTreeMap,
     fmt::Debug,
-    num::NonZeroU32,
     vec::Vec,
 };
 
@@ -178,14 +177,14 @@ impl From<Registry> for PortableRegistry {
 
 impl PortableRegistry {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
-    pub fn resolve(&self, id: NonZeroU32) -> Option<&Type<PortableForm>> {
-        self.types.get((id.get() - 1) as usize)
+    pub fn resolve(&self, id: u32) -> Option<&Type<PortableForm>> {
+        self.types.get(id as usize)
     }
 
-    /// Returns an iterator for all types paired with their associated NonZeroU32 identifier.
-    pub fn enumerate(&self) -> impl Iterator<Item = (NonZeroU32, &Type<PortableForm>)> {
+    /// Returns an iterator for all types paired with their associated u32 identifier.
+    pub fn enumerate(&self) -> impl Iterator<Item = (u32, &Type<PortableForm>)> {
         self.types.iter().enumerate().map(|(i, ty)| {
-            let id = NonZeroU32::new(i as u32 + 1).expect("i + 1 > 0; qed");
+            let id = i as u32;
             (id, ty)
         })
     }
@@ -213,9 +212,9 @@ mod tests {
 
         assert_eq!(4, readonly.enumerate().count());
 
-        let mut expected = 1;
+        let mut expected = 0;
         for (i, _) in readonly.enumerate() {
-            assert_eq!(NonZeroU32::new(expected).unwrap(), i);
+            assert_eq!(expected, i);
             expected += 1;
         }
     }

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -64,7 +64,7 @@ fn scale_encode_then_decode_to_readonly() {
 
     let readonly_decoded = PortableRegistry::decode(&mut &encoded[..]).unwrap();
     assert!(readonly_decoded
-        .resolve(NonZeroU32::new(1).unwrap())
+        .resolve(0)
         .is_some());
     let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
 
@@ -82,7 +82,7 @@ fn json_serialize_then_deserialize_to_readonly() {
     let readonly_deserialized: PortableRegistry =
         serde_json::from_value(original_serialized.clone()).unwrap();
     assert!(readonly_deserialized
-        .resolve(NonZeroU32::new(1).unwrap())
+        .resolve(0)
         .is_some());
     let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
 

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -63,9 +63,7 @@ fn scale_encode_then_decode_to_readonly() {
     let original_serialized = serde_json::to_value(registry).unwrap();
 
     let readonly_decoded = PortableRegistry::decode(&mut &encoded[..]).unwrap();
-    assert!(readonly_decoded
-        .resolve(0)
-        .is_some());
+    assert!(readonly_decoded.resolve(0).is_some());
     let decoded_serialized = serde_json::to_value(readonly_decoded).unwrap();
 
     assert_eq!(decoded_serialized, original_serialized);
@@ -81,9 +79,7 @@ fn json_serialize_then_deserialize_to_readonly() {
     // assert_eq!(original_serialized, serde_json::Value::Null);
     let readonly_deserialized: PortableRegistry =
         serde_json::from_value(original_serialized.clone()).unwrap();
-    assert!(readonly_deserialized
-        .resolve(0)
-        .is_some());
+    assert!(readonly_deserialized.resolve(0).is_some());
     let readonly_serialized = serde_json::to_value(readonly_deserialized).unwrap();
 
     assert_eq!(readonly_serialized, original_serialized);

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -69,32 +69,32 @@ fn test_primitives() {
 fn test_builtins() {
     // arrays
     assert_json_for_type::<[u8; 2]>(
-        json!({ "def": { "array": { "len": 2, "type": 1 } } }),
+        json!({ "def": { "array": { "len": 2, "type": 0 } } }),
     );
     assert_json_for_type::<[bool; 4]>(
-        json!({ "def": { "array": { "len": 4, "type": 1 } } }),
+        json!({ "def": { "array": { "len": 4, "type": 0 } } }),
     );
     assert_json_for_type::<[char; 8]>(
-        json!({ "def": { "array": { "len": 8, "type": 1 } } }),
+        json!({ "def": { "array": { "len": 8, "type": 0 } } }),
     );
     // tuples
-    assert_json_for_type::<(u8, bool)>(json!({ "def": { "tuple": [ 1, 2 ] } }));
+    assert_json_for_type::<(u8, bool)>(json!({ "def": { "tuple": [ 0, 1 ] } }));
     assert_json_for_type::<(u8, bool, char, u128)>(
-        json!({ "def": { "tuple": [ 1, 2, 3, 4 ] } }),
+        json!({ "def": { "tuple": [ 0, 1, 2, 3 ] } }),
     );
     assert_json_for_type::<(u8, bool, char, u128, i32, u32)>(json!({
         "def": {
-            "tuple": [ 1, 2, 3, 4, 5, 6 ]
+            "tuple": [ 0, 1, 2, 3, 4, 5 ]
         }
     }));
     // sequences
-    assert_json_for_type::<[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
-    assert_json_for_type::<&[bool]>(json!({ "def": { "sequence": { "type": 1 } } }));
-    assert_json_for_type::<Vec<bool>>(json!({ "def": { "sequence": { "type": 1 } } }));
+    assert_json_for_type::<[bool]>(json!({ "def": { "sequence": { "type": 0 } } }));
+    assert_json_for_type::<&[bool]>(json!({ "def": { "sequence": { "type": 0 } } }));
+    assert_json_for_type::<Vec<bool>>(json!({ "def": { "sequence": { "type": 0 } } }));
     // complex types
     assert_json_for_type::<Option<&str>>(json!({
         "path": ["Option"],
-        "params": [1],
+        "params": [0],
         "def": {
             "variant": {
                 "variants": [
@@ -103,7 +103,7 @@ fn test_builtins() {
                     },
                     {
                         "name": "Some",
-                        "fields": [ { "type": 1, "typeName": "T" } ]
+                        "fields": [ { "type": 0, "typeName": "T" } ]
                     },
                 ]
             }
@@ -111,17 +111,17 @@ fn test_builtins() {
     }));
     assert_json_for_type::<Result<u32, u64>>(json!({
         "path": ["Result"],
-        "params": [1, 2],
+        "params": [0, 1],
         "def": {
             "variant": {
                 "variants": [
                     {
                         "name": "Ok",
-                        "fields": [ { "type": 1, "typeName": "T" } ]
+                        "fields": [ { "type": 0, "typeName": "T" } ]
                     },
                     {
                         "name": "Err",
-                        "fields": [ { "type": 2, "typeName": "E" } ]
+                        "fields": [ { "type": 1, "typeName": "E" } ]
                     }
                 ]
             }
@@ -136,7 +136,7 @@ fn test_builtins() {
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
     // PhantomData
     assert_json_for_type::<PhantomData<bool>>(
-        json!({ "def": { "phantom": { "type": 1 } }, }),
+        json!({ "def": { "phantom": { "type": 0 } }, }),
     )
 }
 
@@ -163,9 +163,9 @@ fn test_tuplestruct() {
         "def": {
             "composite": {
                 "fields": [
-                    { "type": 1, "typeName": "i32" },
-                    { "type": 2, "typeName": "[u8; 32]" },
-                    { "type": 4, "typeName": "bool" },
+                    { "type": 0, "typeName": "i32" },
+                    { "type": 1, "typeName": "[u8; 32]" },
+                    { "type": 3, "typeName": "bool" },
                 ],
             },
         }
@@ -186,9 +186,9 @@ fn test_struct() {
         "def": {
             "composite": {
                 "fields": [
-                    { "name": "a", "type": 1, "typeName": "i32" },
-                    { "name": "b", "type": 2, "typeName": "[u8; 32]" },
-                    { "name": "c", "type": 4, "typeName": "bool" },
+                    { "name": "a", "type": 0, "typeName": "i32" },
+                    { "name": "b", "type": 1, "typeName": "[u8; 32]" },
+                    { "name": "c", "type": 3, "typeName": "bool" },
                 ],
             },
         }
@@ -233,10 +233,10 @@ fn test_struct_with_some_fields_marked_as_compact() {
         "def": {
             "composite": {
                 "fields": [
-                    { "name": "a", "type": 1, "typeName": "u128" },
-                    { "name": "a_not_compact", "type": 2, "typeName": "u128" },
-                    { "name": "b", "type": 3, "typeName": "[u8; 32]" },
-                    { "name": "c", "type": 5, "typeName": "u64" },
+                    { "name": "a", "type": 0, "typeName": "u128" },
+                    { "name": "a_not_compact", "type": 1, "typeName": "u128" },
+                    { "name": "b", "type": 2, "typeName": "[u8; 32]" },
+                    { "name": "c", "type": 4, "typeName": "u64" },
                 ],
             },
         }
@@ -254,13 +254,13 @@ fn test_struct_with_phantom() {
 
     assert_json_for_type::<Struct<u8>>(json!({
         "path": ["json", "Struct"],
-        "params": [1],
+        "params": [0],
         "def": {
             "composite": {
                 "fields": [
-                    { "name": "a", "type": 2, "typeName": "i32" },
+                    { "name": "a", "type": 1, "typeName": "i32" },
                     // type 1 is the `u8` in the `PhantomData`
-                    { "name": "b", "type": 3, "typeName": "PhantomData<T>" },
+                    { "name": "b", "type": 2, "typeName": "PhantomData<T>" },
                 ],
             },
         }
@@ -308,16 +308,16 @@ fn test_enum() {
                     {
                         "name": "TupleStructVariant",
                         "fields": [
-                            { "type": 1, "typeName": "u32" },
-                            { "type": 2, "typeName": "bool" },
+                            { "type": 0, "typeName": "u32" },
+                            { "type": 1, "typeName": "bool" },
                         ],
                     },
                     {
                         "name": "StructVariant",
                         "fields": [
-                            { "name": "a", "type": 1, "typeName": "u32" },
-                            { "name": "b", "type": 3, "typeName": "[u8; 32]" },
-                            { "name": "c", "type": 5, "typeName": "char" },
+                            { "name": "a", "type": 0, "typeName": "u32" },
+                            { "name": "b", "type": 2, "typeName": "[u8; 32]" },
+                            { "name": "c", "type": 4, "typeName": "char" },
                         ],
                     }
                 ],
@@ -347,14 +347,14 @@ fn test_recursive_type_with_box() {
                             {
                                 "name": "Leaf",
                                 "fields": [
-                                    { "name": "value", "type": 2, "typeName": "i32" },
+                                    { "name": "value", "type": 1, "typeName": "i32" },
                                 ],
                             },
                             {
                                 "name": "Node",
                                 "fields": [
-                                    { "name": "right", "type": 1, "typeName": "Box<Tree>" },
-                                    { "name": "left", "type": 1, "typeName": "Box<Tree>" },
+                                    { "name": "right", "type": 0, "typeName": "Box<Tree>" },
+                                    { "name": "left", "type": 0, "typeName": "Box<Tree>" },
                                 ],
                             }
                         ],
@@ -393,28 +393,28 @@ fn registry_knows_about_compact_types() {
                 "def": {
                     "composite": {
                         "fields": [
-                            { "name": "a", "type": 2, "typeName": "u128" },
-                            { "name": "a_not_compact", "type": 3, "typeName": "u128" },
-                            { "name": "b", "type": 4, "typeName": "[u8; 32]" },
-                            { "name": "c", "type": 6, "typeName": "u64" }
+                            { "name": "a", "type": 1, "typeName": "u128" },
+                            { "name": "a_not_compact", "type": 2, "typeName": "u128" },
+                            { "name": "b", "type": 3, "typeName": "[u8; 32]" },
+                            { "name": "c", "type": 5, "typeName": "u64" }
                         ]
                     }
                 }
             },
             { // type 2, the `Compact<u128>` of field `a`.
-                "def": { "compact": { "type": 3 } },
+                "def": { "compact": { "type": 2 } },
             },
             { // type 3, the `u128` used by type 2 and field `a_not_compact`.
                 "def": { "primitive": "u128" }
             },
             { // type 4, the `[u8; 32]` of field `b`.
-                "def": { "array": { "len": 32, "type": 5 }}
+                "def": { "array": { "len": 32, "type": 4 }}
             },
             { // type 5, the `u8` in `[u8; 32]`
                 "def": { "primitive": "u8" }
             },
             { // type 6, the `Compact<u64>` of field `c`
-                "def": { "compact": { "type": 7 } },
+                "def": { "compact": { "type": 6 } },
             },
             { // type 7, the `u64` in `Compact<u64>` of field `c`
                 "def": { "primitive": "u64" }
@@ -466,7 +466,7 @@ fn test_registry() {
 
     let expected_json = json!({
         "types": [
-            { // type 1
+            { // type 0
                 "path": [
                     "json",
                     "UnitStruct",
@@ -475,7 +475,7 @@ fn test_registry() {
                     "composite": {},
                 }
             },
-            { // type 2
+            { // type 1
                 "path": [
                     "json",
                     "TupleStruct",
@@ -483,19 +483,19 @@ fn test_registry() {
                 "def": {
                     "composite": {
                         "fields": [
-                            { "type": 3, "typeName": "u8" },
-                            { "type": 4, "typeName": "u32" },
+                            { "type": 2, "typeName": "u8" },
+                            { "type": 3, "typeName": "u32" },
                         ],
                     },
                 }
             },
-            { // type 3
+            { // type 2
                 "def": { "primitive": "u8" },
             },
-            { // type 4
+            { // type 3
                 "def": { "primitive": "u32" },
             },
-            { // type 5
+            { // type 4
                 "path": [
                     "json",
                     "Struct",
@@ -505,32 +505,32 @@ fn test_registry() {
                         "fields": [
                             {
                                 "name": "a",
-                                "type": 3,
+                                "type": 2,
                                 "typeName": "u8"
                             },
                             {
                                 "name": "b",
-                                "type": 4,
+                                "type": 3,
                                 "typeName": "u32"
                             },
                             {
                                 "name": "c",
-                                "type": 6,
+                                "type": 5,
                                 "typeName": "[u8; 32]"
                             }
                         ]
                     },
                 }
             },
-            { // type 6
+            { // type 5
                 "def": {
                     "array": {
                         "len": 32,
-                        "type": 3, // u8
+                        "type": 2, // u8
                     },
                 }
             },
-            { // type 7
+            { // type 6
                 "path": [
                     "json",
                     "RecursiveStruct",
@@ -540,21 +540,21 @@ fn test_registry() {
                         "fields": [
                             {
                                 "name": "rec",
-                                "type": 8,
+                                "type": 7,
                                 "typeName": "Vec<RecursiveStruct>"
                             }
                         ]
                     },
                 }
             },
-            { // type 8
+            { // type 7
                 "def": {
                     "sequence": {
-                        "type": 7, // RecursiveStruct
+                        "type": 6, // RecursiveStruct
                     },
                 }
             },
-            { // type 9
+            { // type 8
                 "path": [
                     "json",
                     "ClikeEnum",
@@ -578,7 +578,7 @@ fn test_registry() {
                     }
                 }
             },
-            { // type 10
+            { // type 9
                 "path": [
                     "json",
                     "RustEnum"
@@ -592,8 +592,8 @@ fn test_registry() {
                             {
                                 "name": "B",
                                 "fields": [
-                                    { "type": 3, "typeName": "u8" }, // u8
-                                    { "type": 4, "typeName": "u32" }, // u32
+                                    { "type": 2, "typeName": "u8" }, // u8
+                                    { "type": 3, "typeName": "u32" }, // u32
                                 ]
                             },
                             {
@@ -601,17 +601,17 @@ fn test_registry() {
                                 "fields": [
                                     {
                                         "name": "a",
-                                        "type": 3, // u8
+                                        "type": 2, // u8
                                         "typeName": "u8"
                                     },
                                     {
                                         "name": "b",
-                                        "type": 4, // u32
+                                        "type": 3, // u32
                                         "typeName": "u32"
                                     },
                                     {
                                         "name": "c",
-                                        "type": 6,
+                                        "type": 5,
                                         "typeName": "[u8; 32]"
                                     }
                                 ]


### PR DESCRIPTION
@Robbepop says that this was an unnecessary premature optimization. This simplifies downstream consumers of `scale-info` because now type lookups into the array are `0` based.