### PR TITLE
Implement `TypeInfo` for up to 20 element tuples

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -110,6 +110,10 @@ impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
 
 impl<T> TypeInfo for Vec<T>
 where


### PR DESCRIPTION
Required for key tuples with up to 18 elements: https://github.com/paritytech/substrate/blob/66c85aeb29fbf4786e76be328cf73241f72c2f18/frame/support/src/storage/types/key.rs#L102. Added a couple of extra impls for up to 20 just in case.

Required for the metadata of the keys for StorageNMap support introduced in https://github.com/paritytech/substrate/pull/8635/.