### PR TITLE
Add BitVec support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: test
       run: |
-        cargo test --all
+        cargo test --all --all-features
 
     - name: test no-std
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: check-features
       run: |
+        cargo check --no-default-features --features bit-vec
         cargo check --no-default-features --features serde
         cargo check --no-default-features --features serde,decode
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["no-std", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-bitvec = { version = "0.20.1", default-features = false }
+bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
 scale-info-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
@@ -24,6 +24,7 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 [features]
 default = ["std"]
 std = [
+    "bitvec/std",
     "scale/std",
 ]
 derive = [
@@ -32,6 +33,10 @@ derive = [
 # enables decoding and deserialization of portable scale-info type metadata
 decode = [
     "scale/full"
+]
+# enables type information for bitvec types, matching the name of the parity-scale-codec feature
+bit-vec = [
+    "bitvec"
 ]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["no-std", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
+bitvec = { version = "0.20.1", default-features = false }
 cfg-if = "1.0"
 scale-info-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -33,6 +33,7 @@ use crate::{
     Path,
     Type,
     TypeDefArray,
+    TypeDefBitVec,
     TypeDefCompact,
     TypeDefPhantom,
     TypeDefPrimitive,
@@ -284,5 +285,37 @@ where
     type Identity = Self;
     fn type_info() -> Type {
         TypeDefCompact::new(MetaType::new::<T>()).into()
+    }
+}
+
+impl<O, T> TypeInfo for bitvec::vec::BitVec<O, T>
+where
+    O: bitvec::order::BitOrder + TypeInfo + 'static,
+    T: bitvec::store::BitStore + TypeInfo + 'static,
+{
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        TypeDefBitVec::new::<O, T>().into()
+    }
+}
+
+impl TypeInfo for bitvec::order::Lsb0 {
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::new("Lsb0", "bitvec::order"))
+            .composite(Fields::unit())
+    }
+}
+
+impl TypeInfo for bitvec::order::Msb0 {
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::new("Msb0", "bitvec::order"))
+            .composite(Fields::unit())
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -33,7 +33,6 @@ use crate::{
     Path,
     Type,
     TypeDefArray,
-    TypeDefBitVec,
     TypeDefCompact,
     TypeDefPhantom,
     TypeDefPrimitive,
@@ -288,6 +287,7 @@ where
     }
 }
 
+#[cfg(feature = "bit-vec")]
 impl<O, T> TypeInfo for bitvec::vec::BitVec<O, T>
 where
     O: bitvec::order::BitOrder + TypeInfo + 'static,
@@ -296,10 +296,11 @@ where
     type Identity = Self;
 
     fn type_info() -> Type {
-        TypeDefBitVec::new::<O, T>().into()
+        crate::TypeDefBitVec::new::<O, T>().into()
     }
 }
 
+#[cfg(feature = "bit-vec")]
 impl TypeInfo for bitvec::order::Lsb0 {
     type Identity = Self;
 
@@ -310,6 +311,7 @@ impl TypeInfo for bitvec::order::Lsb0 {
     }
 }
 
+#[cfg(feature = "bit-vec")]
 impl TypeInfo for bitvec::order::Msb0 {
     type Identity = Self;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -296,7 +296,7 @@ where
     type Identity = Self;
 
     fn type_info() -> Type {
-        crate::TypeDefBitVec::new::<O, T>().into()
+        crate::TypeDefBitSequence::new::<O, T>().into()
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -288,36 +288,39 @@ where
 }
 
 #[cfg(feature = "bit-vec")]
-impl<O, T> TypeInfo for bitvec::vec::BitVec<O, T>
-where
-    O: bitvec::order::BitOrder + TypeInfo + 'static,
-    T: bitvec::store::BitStore + TypeInfo + 'static,
-{
-    type Identity = Self;
+mod bit_vec {
+    use super::*;
 
-    fn type_info() -> Type {
-        crate::TypeDefBitSequence::new::<O, T>().into()
+    impl<O, T> TypeInfo for bitvec::vec::BitVec<O, T>
+        where
+            O: bitvec::order::BitOrder + TypeInfo + 'static,
+            T: bitvec::store::BitStore + TypeInfo + 'static,
+    {
+        type Identity = Self;
+
+        fn type_info() -> Type {
+            crate::TypeDefBitSequence::new::<O, T>().into()
+        }
+    }
+
+    impl TypeInfo for bitvec::order::Lsb0 {
+        type Identity = Self;
+
+        fn type_info() -> Type {
+            Type::builder()
+                .path(Path::new("Lsb0", "bitvec::order"))
+                .composite(Fields::unit())
+        }
+    }
+
+    impl TypeInfo for bitvec::order::Msb0 {
+        type Identity = Self;
+
+        fn type_info() -> Type {
+            Type::builder()
+                .path(Path::new("Msb0", "bitvec::order"))
+                .composite(Fields::unit())
+        }
     }
 }
 
-#[cfg(feature = "bit-vec")]
-impl TypeInfo for bitvec::order::Lsb0 {
-    type Identity = Self;
-
-    fn type_info() -> Type {
-        Type::builder()
-            .path(Path::new("Lsb0", "bitvec::order"))
-            .composite(Fields::unit())
-    }
-}
-
-#[cfg(feature = "bit-vec")]
-impl TypeInfo for bitvec::order::Msb0 {
-    type Identity = Self;
-
-    fn type_info() -> Type {
-        Type::builder()
-            .path(Path::new("Msb0", "bitvec::order"))
-            .composite(Fields::unit())
-    }
-}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -292,9 +292,9 @@ mod bit_vec {
     use super::*;
 
     impl<O, T> TypeInfo for bitvec::vec::BitVec<O, T>
-        where
-            O: bitvec::order::BitOrder + TypeInfo + 'static,
-            T: bitvec::store::BitStore + TypeInfo + 'static,
+    where
+        O: bitvec::order::BitOrder + TypeInfo + 'static,
+        T: bitvec::store::BitStore + TypeInfo + 'static,
     {
         type Identity = Self;
 
@@ -323,4 +323,3 @@ mod bit_vec {
         }
     }
 }
-

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -124,17 +124,17 @@ fn bitvec() {
 
     assert_type!(
         BitVec<Lsb0, u8>,
-        TypeDefBitVec::new::<Lsb0, u8>()
+        TypeDefBitSequence::new::<Lsb0, u8>()
     );
 
     assert_type!(
         BitVec<Msb0, u16>,
-        TypeDefBitVec::new::<Msb0, u16>()
+        TypeDefBitSequence::new::<Msb0, u16>()
     );
 
     assert_type!(
         BitVec<Msb0, u32>,
-        TypeDefBitVec::new::<Msb0, u32>()
+        TypeDefBitSequence::new::<Msb0, u32>()
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -111,6 +111,7 @@ fn collections() {
     );
 }
 
+#[cfg(feature = "bit-vec")]
 #[test]
 fn bitvec() {
     use bitvec::{

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -112,6 +112,32 @@ fn collections() {
 }
 
 #[test]
+fn bitvec() {
+    use bitvec::{
+        order::{
+            Lsb0,
+            Msb0,
+        },
+        vec::BitVec,
+    };
+
+    assert_type!(
+        BitVec<Lsb0, u8>,
+        TypeDefBitVec::new::<Lsb0, u8>()
+    );
+
+    assert_type!(
+        BitVec<Msb0, u16>,
+        TypeDefBitVec::new::<Msb0, u16>()
+    );
+
+    assert_type!(
+        BitVec<Msb0, u32>,
+        TypeDefBitVec::new::<Msb0, u32>()
+    );
+}
+
+#[test]
 fn scale_compact_types() {
     assert_type!(Compact<i32>, TypeDefCompact::new(meta_type::<i32>()))
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -116,8 +116,14 @@ impl_from_type_def_for_type!(
     TypeDefTuple,
     TypeDefCompact,
     TypeDefPhantom,
-    TypeDefBitVec,
 );
+
+#[cfg(feature = "bit-vec")]
+impl From<crate::TypeDefBitVec> for Type {
+    fn from(item: crate::TypeDefBitVec) -> Self {
+        Self::new(Path::voldemort(), Vec::new(), item, Vec::new())
+    }
+}
 
 impl Type {
     /// Create a [`TypeBuilder`](`crate::build::TypeBuilder`) the public API for constructing a [`Type`]
@@ -198,6 +204,7 @@ pub enum TypeDef<T: Form = MetaForm> {
     Compact(TypeDefCompact<T>),
     /// A PhantomData type.
     Phantom(TypeDefPhantom<T>),
+    #[cfg(feature = "bit-vec")]
     /// A BitVec type.
     BitVec(TypeDefBitVec<T>),
 }
@@ -215,6 +222,7 @@ impl IntoPortable for TypeDef {
             TypeDef::Primitive(primitive) => primitive.into(),
             TypeDef::Compact(compact) => compact.into_portable(registry).into(),
             TypeDef::Phantom(phantom) => phantom.into_portable(registry).into(),
+            #[cfg(feature = "bit-vec")]
             TypeDef::BitVec(bitvec) => bitvec.into_portable(registry).into(),
         }
     }
@@ -491,6 +499,7 @@ where
 }
 
 /// Type describing a [`bitvec::vec::BitVec`].
+#[cfg(feature = "bit-vec")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
@@ -501,8 +510,9 @@ pub struct TypeDefBitVec<T: Form = MetaForm> {
     bit_order_type: T::Type,
 }
 
-impl IntoPortable for TypeDefBitVec {
-    type Output = TypeDefBitVec<PortableForm>;
+#[cfg(feature = "bit-vec")]
+impl IntoPortable for crate::TypeDefBitVec {
+    type Output = crate::TypeDefBitVec<PortableForm>;
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         TypeDefBitVec {
@@ -512,6 +522,7 @@ impl IntoPortable for TypeDefBitVec {
     }
 }
 
+#[cfg(feature = "bit-vec")]
 impl TypeDefBitVec {
     /// Creates a new phantom type definition.
     pub fn new<O, T>() -> Self
@@ -526,6 +537,7 @@ impl TypeDefBitVec {
     }
 }
 
+#[cfg(feature = "bit-vec")]
 impl<T> TypeDefBitVec<T>
 where
     T: Form,

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -116,14 +116,8 @@ impl_from_type_def_for_type!(
     TypeDefTuple,
     TypeDefCompact,
     TypeDefPhantom,
+    TypeDefBitSequence,
 );
-
-#[cfg(feature = "bit-vec")]
-impl From<crate::TypeDefBitSequence> for Type {
-    fn from(item: crate::TypeDefBitSequence) -> Self {
-        Self::new(Path::voldemort(), Vec::new(), item, Vec::new())
-    }
-}
 
 impl Type {
     /// Create a [`TypeBuilder`](`crate::build::TypeBuilder`) the public API for constructing a [`Type`]


### PR DESCRIPTION
Required for `polkadot`, some types use `BitVec` e.g. https://github.com/paritytech/polkadot/blob/master/primitives/src/v1/mod.rs#L468.

Rationale is that `parity-scale-codec` has support for bitvec: https://github.com/paritytech/parity-scale-codec/blob/master/src/bit_vec.rs, by enabling the `bit-vec` feature, so this library should too.

**EDIT**

I've modified this so that the `TypeDefBitSequence` struct and variant is still included even without `bit-vec` enabled, in order for compatible encoding/decoding between the crate with or without the feature enabled. Enabling the feature will simply add the `bitvec` dependency and the relevant`TypeInfo` impls.