### PR TITLE
Implement TypeInfo for VecDeque

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -21,6 +21,7 @@ use crate::prelude::{
     collections::{
         BTreeMap,
         BTreeSet,
+        VecDeque,
     },
     marker::PhantomData,
     string::String,
@@ -120,6 +121,17 @@ where
     T: TypeInfo + 'static,
 {
     type Identity = [T];
+
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
+}
+
+impl<T> TypeInfo for VecDeque<T>
+where
+    T: TypeInfo + 'static,
+{
+    type Identity = Vec<T>;
 
     fn type_info() -> Type {
         Self::Identity::type_info()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -109,6 +109,11 @@ fn collections() {
             .type_params(tuple_meta_type![String])
             .composite(Fields::unnamed().field(|f| f.ty::<[String]>()))
     );
+
+    assert_type!(
+        std::collections::VecDeque<String>,
+        TypeDefSequence::new(meta_type::<String>())
+    );
 }
 
 #[test]


### PR DESCRIPTION
Is encoded like a `Vec`: https://github.com/paritytech/parity-scale-codec/blob/master/src/codec.rs#L970