### PR TITLE
Add `docs` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
     - name: check-features
       run: |
         cargo check --no-default-features --features bit-vec
+        cargo check --no-default-features --features docs
         cargo check --no-default-features --features serde
         cargo check --no-default-features --features serde,decode
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ std = [
 derive = [
     "scale-info-derive"
 ]
-# Include code docs in type metadata.
+# Include rustdoc strings in the type metadata.
 docs = [
     "scale-info-derive/docs"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "0.99.1", default-features = false, features = ["from"
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 
 [features]
-default = ["std"]
+default = ["std", "docs"]
 std = [
     "bitvec/std",
     "scale/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ std = [
 derive = [
     "scale-info-derive"
 ]
+# Include code docs in type metadata.
+docs = [
+    "scale-info-derive/docs"
+]
 # enables decoding and deserialization of portable scale-info type metadata
 decode = [
     "scale/full"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,3 +19,8 @@ quote = "1.0"
 syn = { version = "1.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
 proc-macro2 = "1.0"
 proc-macro-crate = "1"
+
+[features]
+default = []
+# Include code docs in type metadata.
+docs = []

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -21,6 +21,6 @@ proc-macro2 = "1.0"
 proc-macro-crate = "1"
 
 [features]
-default = []
+default = ["docs"]
 # Include code docs in type metadata.
 docs = []

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -104,7 +104,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
         Data::Enum(ref e) => generate_variant_type(e, &scale_info),
         Data::Union(_) => return Err(Error::new_spanned(input, "Unions not supported")),
     };
-    let docs = utils::get_doc_literals(&ast.attrs);
+    let docs = generate_docs(&ast.attrs);
 
     let type_info_impl = quote! {
         impl #impl_generics :: #scale_info ::TypeInfo for #ident #ty_generics #where_clause {
@@ -113,7 +113,7 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
                 :: #scale_info ::Type::builder()
                     .path(:: #scale_info ::Path::new(::core::stringify!(#ident), ::core::module_path!()))
                     .type_params(:: #scale_info ::prelude::vec![ #( #generic_type_ids ),* ])
-                    .docs(&[ #( #docs ),* ])
+                    #docs
                     .#build_type
             }
         }
@@ -160,7 +160,7 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
             StaticLifetimesReplace.visit_type_mut(&mut ty);
 
             let type_name = clean_type_string(&quote!(#ty).to_string());
-            let docs = utils::get_doc_literals(&f.attrs);
+            let docs = generate_docs(&f.attrs);
             let type_of_method = if utils::is_compact(f) {
                 quote!(compact)
             } else {
@@ -176,7 +176,7 @@ fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
                     .#type_of_method::<#ty>()
                     #name
                     .type_name(#type_name)
-                    .docs(&[ #( #docs ),* ])
+                    #docs
                 )
             )
         })
@@ -235,12 +235,12 @@ fn generate_c_like_enum_def(variants: &VariantList, scale_info: &Ident) -> Token
         .map(|(i, v)| {
             let name = &v.ident;
             let discriminant = utils::variant_index(v, i);
-            let docs = utils::get_doc_literals(&v.attrs);
+            let docs = generate_docs(&v.attrs);
             quote! {
                 .variant(::core::stringify!(#name), |v|
                     v
                         .discriminant(#discriminant as ::core::primitive::u64)
-                        .docs(&[ #( #docs ),* ])
+                        #docs
                 )
             }
         });
@@ -272,7 +272,7 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
         .map(|v| {
             let ident = &v.ident;
             let v_name = quote! {::core::stringify!(#ident) };
-            let docs = utils::get_doc_literals(&v.attrs);
+            let docs = generate_docs(&v.attrs);
             let index = utils::maybe_index(v).map(|i| quote!(.index(#i)));
 
             let fields = match v.fields {
@@ -301,7 +301,7 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
                 .variant(#v_name, |v|
                     v
                         .fields(#fields)
-                        .docs(&[ #( #docs ),* ])
+                        #docs
                         #index
                 )
             }
@@ -312,4 +312,19 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
                 #( #variants )*
         )
     }
+}
+
+// #[cfg(feature = "docs")]
+#[cfg(not(feature = "docs"))]
+fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
+    let docs = utils::get_doc_literals(attrs);
+    Some(quote! {
+        .docs(&[ #( #docs ),* ])
+    })
+}
+
+// #[cfg(not(feature = "docs"))]
+#[cfg(feature = "docs")]
+fn generate_docs(_: &[syn::Attribute]) -> Option<TokenStream2> {
+    None
 }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -16,15 +16,10 @@
 //!
 //! NOTE: The code here is copied verbatim from `parity-scale-codec-derive`.
 
-use alloc::{
-    string::ToString,
-    vec::Vec,
-};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     parse::Parse,
-    parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
     token,
@@ -36,28 +31,6 @@ use syn::{
     NestedMeta,
     Variant,
 };
-
-/// Return all doc attributes literals found.
-pub fn get_doc_literals(attrs: &[syn::Attribute]) -> Vec<syn::Lit> {
-    attrs
-        .iter()
-        .filter_map(|attr| {
-            if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
-                if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
-                    let lit = &meta.lit;
-                    let doc_lit = quote!(#lit).to_string();
-                    let trimmed_doc_lit =
-                        doc_lit.trim_start_matches(r#"" "#).trim_end_matches('"');
-                    Some(parse_quote!(#trimmed_doc_lit))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .collect()
-}
 
 /// Trait bounds.
 pub type TraitBounds = Punctuated<syn::WherePredicate, token::Comma>;


### PR DESCRIPTION
Docs will not be generated by the proc macro unless the `docs` feature is enabled. 

This allows reducing the size of the metadata code, useful for substrate runtimes: https://github.com/paritytech/substrate/discussions/8370#discussioncomment-909365