### PR TITLE
Bump parity-scale-codec to 2.2.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "docs"]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2.0", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
Part of paritytech/substrate#9163.

Needed to bump `parity-scale-codec` version used by the [`primitive-types`](https://github.com/paritytech/parity-common/blob/7c2a9b28e266d0b0adbad4869e2559500fad4859/primitive-types/Cargo.toml#L18-L20) crate, which in turn needs a new version in order to implement a new `codec::MaxEncodedLen` trait as part of the paritytech/substrate#9163 migration.