### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0-rc.0] - 2021-06-25 // todo: [AJ] update for day of release
+## [0.7.0] - 2021-06-25 // todo: [AJ] update for day of release
 ### Added
 
 - Handle more SCALE attributes: skip, index [(#44)](https://github.com/paritytech/scale-info/pull/44)
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace NonZeroU32 type lookup ids with u32 [(#90)](https://github.com/paritytech/scale-info/pull/90)
 - Remove HasCompact::Type bounds [(#83)](https://github.com/paritytech/scale-info/pull/83)
 - Unify sequence types [(#100)](https://github.com/paritytech/scale-info/pull/100)
-- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102)
+- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102) // todo: [AJ] remove this for 0.7.0 and make a 0.8.0-rc.0 release with it?
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -5,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.0-rc.0] - 2021-06-25 // todo: [AJ] update for day of release
+### Added
+
+- Handle more SCALE attributes: skip, index [(#44)](https://github.com/paritytech/scale-info/pull/44)
+- Implement `TypeInfo` for `BTreeSet` [(#85)](https://github.com/paritytech/scale-info/pull/85)
+- Implement `TypeInfo` for `Cow` [(#84)](https://github.com/paritytech/scale-info/pull/84)
+- Implement `TypeInfo` for up to 20 element tuples [(#92)](https://github.com/paritytech/scale-info/pull/92)
+- Add `StaticTypeInfo` convenience trait [(#91)](https://github.com/paritytech/scale-info/pull/91)
+- Capture doc comments, add variant and field builders [(#87)](https://github.com/paritytech/scale-info/pull/87)
+- Handle `#[codec(index = …)]` in regular enums [(#80)](https://github.com/paritytech/scale-info/pull/80)
+- Add new top-level attribute `scale_info(bounds(T: SomeTrait + OtherTrait))` [(#88)](https://github.com/paritytech/scale-info/pull/88)
+- (aj-vecdeque) Implement TypeInfo for VecDeque [(#99)](https://github.com/paritytech/scale-info/pull/99)
+- Add BitVec support [(#98)](https://github.com/paritytech/scale-info/pull/98)
+- Add `docs` feature [(#101)](https://github.com/paritytech/scale-info/pull/101)
+
+### Changed
+
+- Upgrade proc-macro-crate to v1 [(#77)](https://github.com/paritytech/scale-info/pull/77)
+- Use const generics for array TypeInfo impls [(#54)](https://github.com/paritytech/scale-info/pull/54)
+- Replace NonZeroU32 type lookup ids with u32 [(#90)](https://github.com/paritytech/scale-info/pull/90)
+- Remove HasCompact::Type bounds [(#83)](https://github.com/paritytech/scale-info/pull/83)
+- Unify sequence types [(#100)](https://github.com/paritytech/scale-info/pull/100)
+
+### Fixed
+
+- Fix serde and decode features without default features [(#74)](https://github.com/paritytech/scale-info/pull/74)
+- Remove type parameter defaults [(#71)](https://github.com/paritytech/scale-info/pull/71)
+- Fix trait bounds for associated types [(#76)](https://github.com/paritytech/scale-info/pull/76)
 
 ## [0.6.0] - 2021-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2021-06-25 // todo: [AJ] update for day of release
+## [0.7.0] - 2021-06-29
 ### Added
 
 - Handle more SCALE attributes: skip, index [(#44)](https://github.com/paritytech/scale-info/pull/44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace NonZeroU32 type lookup ids with u32 [(#90)](https://github.com/paritytech/scale-info/pull/90)
 - Remove HasCompact::Type bounds [(#83)](https://github.com/paritytech/scale-info/pull/83)
 - Unify sequence types [(#100)](https://github.com/paritytech/scale-info/pull/100)
-- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102) // todo: [AJ] remove this for 0.7.0 and make a 0.8.0-rc.0 release with it?
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace NonZeroU32 type lookup ids with u32 [(#90)](https://github.com/paritytech/scale-info/pull/90)
 - Remove HasCompact::Type bounds [(#83)](https://github.com/paritytech/scale-info/pull/83)
 - Unify sequence types [(#100)](https://github.com/paritytech/scale-info/pull/100)
+- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.5.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "docs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "0.4.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "0.5.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.5.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "docs"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2.0", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2.0", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
This PR reverts #102 for this release, which will be restored in a follow up `0.8.0-rc.0` release.

### Added

- Handle more SCALE attributes: skip, index [(#44)](https://github.com/paritytech/scale-info/pull/44)
- Implement `TypeInfo` for `BTreeSet` [(#85)](https://github.com/paritytech/scale-info/pull/85)
- Implement `TypeInfo` for `Cow` [(#84)](https://github.com/paritytech/scale-info/pull/84)
- Implement `TypeInfo` for up to 20 element tuples [(#92)](https://github.com/paritytech/scale-info/pull/92)
- Add `StaticTypeInfo` convenience trait [(#91)](https://github.com/paritytech/scale-info/pull/91)
- Capture doc comments, add variant and field builders [(#87)](https://github.com/paritytech/scale-info/pull/87)
- Handle `#[codec(index = …)]` in regular enums [(#80)](https://github.com/paritytech/scale-info/pull/80)
- Add new top-level attribute `scale_info(bounds(T: SomeTrait + OtherTrait))` [(#88)](https://github.com/paritytech/scale-info/pull/88)
- (aj-vecdeque) Implement TypeInfo for VecDeque [(#99)](https://github.com/paritytech/scale-info/pull/99)
- Add BitVec support [(#98)](https://github.com/paritytech/scale-info/pull/98)
- Add `docs` feature [(#101)](https://github.com/paritytech/scale-info/pull/101)

### Changed

- Upgrade proc-macro-crate to v1 [(#77)](https://github.com/paritytech/scale-info/pull/77)
- Use const generics for array TypeInfo impls [(#54)](https://github.com/paritytech/scale-info/pull/54)
- Replace NonZeroU32 type lookup ids with u32 [(#90)](https://github.com/paritytech/scale-info/pull/90)
- Remove HasCompact::Type bounds [(#83)](https://github.com/paritytech/scale-info/pull/83)
- Unify sequence types [(#100)](https://github.com/paritytech/scale-info/pull/100)

### Fixed

- Fix serde and decode features without default features [(#74)](https://github.com/paritytech/scale-info/pull/74)
- Remove type parameter defaults [(#71)](https://github.com/paritytech/scale-info/pull/71)
- Fix trait bounds for associated types [(#76)](https://github.com/paritytech/scale-info/pull/76)