### PR TITLE
Release v0.8.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0-rc.1] - 2021-06-29
+### Changed
+
+- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102)
+
 ## [0.7.0] - 2021-06-29
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.5.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "docs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.7.0"
+version = "0.8.0-rc.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
The reason for this is pre-release is to include the `codec` pre-release as part of https://github.com/paritytech/substrate/pull/9163.

### Changed

- Bump parity-scale-codec to 2.2.0-rc.2 [(#102)](https://github.com/paritytech/scale-info/pull/102)