### PR TITLE
Reexport `parity-scale-codec` for derive 

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -65,7 +65,6 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
     let attrs = attr::Attributes::from_ast(&ast)?;
 
     let scale_info = crate_name_ident("scale-info")?;
-    let parity_scale_codec = crate_name_ident("parity-scale-codec")?;
 
     let ident = &ast.ident;
 
@@ -75,7 +74,6 @@ fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
         &ast.generics,
         &ast.data,
         &scale_info,
-        &parity_scale_codec,
     )?;
 
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -53,7 +53,6 @@ pub fn make_where_clause<'a>(
     generics: &'a Generics,
     data: &'a syn::Data,
     scale_info: &Ident,
-    parity_scale_codec: &Ident,
 ) -> Result<WhereClause> {
     let mut where_clause = generics.where_clause.clone().unwrap_or_else(|| {
         WhereClause {
@@ -97,7 +96,7 @@ pub fn make_where_clause<'a>(
         if is_compact {
             where_clause
                 .predicates
-                .push(parse_quote!(#ty : :: #parity_scale_codec ::HasCompact));
+                .push(parse_quote!(#ty : :: #scale_info :: scale::HasCompact));
         } else {
             where_clause
                 .predicates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ mod utils;
 mod tests;
 
 #[doc(hidden)]
-pub use codec;
+pub use scale;
 
 pub use self::{
     meta_type::MetaType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,9 @@ mod utils;
 #[cfg(test)]
 mod tests;
 
+#[doc(hidden)]
+pub use codec;
+
 pub use self::{
     meta_type::MetaType,
     registry::{


### PR DESCRIPTION
Fixes #68.

Rexports `parity-scale-codec` as `scale` for use in the derive macro.

@Robbepop's main issue with this was https://github.com/paritytech/scale-info/pull/61#discussion_r568764168:

> the scale-info crate works with multiple parity-scale-codec versions. So re-exporting one of the supported versions would case a lock-in and potentially a duplication of dependencies in case the scale-info user does not also use the same version.

However I believe we avoid this issue by having a suitably relaxed major version constraint on the `parity-scale-codec` dependency as per https://crates.io/crates/scale-info/0.7.0/dependencies.

![image](https://user-images.githubusercontent.com/75586/123826031-4f117d00-d8f7-11eb-8677-a9b8c35c9d30.png)

Note that currently in the master branch we have restricted to a `codec` pre-release, but will likely loosen that back to major versions once `2.2.0` is released.