### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-06-30
+### Changed
+
+- Reverted parity-scale-codec prerelease requirement
+
+### Added
+
+- Add `skip_type_params` attribute [(#96)](https://github.com/paritytech/scale-info/pull/96)
+
 ## [0.8.0-rc.1] - 2021-06-29
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - 2021-06-30
 ### Changed
 
-- Reverted parity-scale-codec prerelease requirement
+- Reverted parity-scale-codec prerelease requirement from [0.8.0-rc.1]
+- Reexport parity-scale-codec for derive [(#106)](https://github.com/paritytech/scale-info/pull/106)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.8.0-rc.1"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "0.5.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "0.6.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 scale-info-derive = { version = "0.6.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "docs"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2.2.0-rc.2", features = ["full"] }
+scale = { package = "parity-scale-codec", version = "2", features = ["full"] }
 
 libc = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
The main motivation for this release is for #96, which I failed to include in `0.7.0`. I've skipped straight to `0.9.0` because of the interim `0.8.0-rc.1` release. There won't be a `0.8.0` release now.

### Changed

- Reverted parity-scale-codec prerelease requirement from `0.8.0-rc.1`
- Reexport parity-scale-codec for derive [(#106)](https://github.com/paritytech/scale-info/pull/106)

### Added

- Add `skip_type_params` attribute [(#96)](https://github.com/paritytech/scale-info/pull/96)