### PR TITLE
Erase PhantomData fields

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -272,7 +272,7 @@ impl FieldsBuilder<NamedFields> {
         let builder = builder(FieldBuilder::new());
         let field = builder.finalize();
         // filter out fields of PhantomData
-        if field.ty() != &MetaType::new::<crate::impls::PhantomIdentity>() {
+        if !field.ty().is_phantom() {
             self.fields.push(field);
         }
         self

--- a/src/build.rs
+++ b/src/build.rs
@@ -270,7 +270,11 @@ impl FieldsBuilder<NamedFields> {
             -> FieldBuilder<field_state::NameAssigned, field_state::TypeAssigned>,
     {
         let builder = builder(FieldBuilder::new());
-        self.fields.push(builder.finalize());
+        let field = builder.finalize();
+        // filter out fields of PhantomData
+        if field.ty() != &MetaType::new::<crate::impls::PhantomIdentity>() {
+            self.fields.push(field);
+        }
         self
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -35,7 +35,6 @@ use crate::{
     Type,
     TypeDefArray,
     TypeDefCompact,
-    TypeDefPhantom,
     TypeDefPrimitive,
     TypeDefSequence,
     TypeDefTuple,
@@ -324,7 +323,7 @@ impl<T> TypeInfo for PhantomData<T> {
     type Identity = PhantomIdentity;
 
     fn type_info() -> Type {
-        TypeDefPhantom.into()
+        panic!("PhantomData types should be filtered out by the FieldsBuilder")
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -318,8 +318,10 @@ impl TypeInfo for String {
     }
 }
 
+pub(crate) type PhantomIdentity = PhantomData<()>;
+
 impl<T> TypeInfo for PhantomData<T> {
-    type Identity = PhantomData<()>;
+    type Identity = PhantomIdentity;
 
     fn type_info() -> Type {
         TypeDefPhantom.into()

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -323,7 +323,7 @@ impl<T> TypeInfo for PhantomData<T> {
     type Identity = PhantomIdentity;
 
     fn type_info() -> Type {
-        panic!("PhantomData types should be filtered out by the FieldsBuilder")
+        panic!("PhantomData type instances should be filtered out.")
     }
 }
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -105,4 +105,9 @@ impl MetaType {
     pub fn type_id(&self) -> TypeId {
         self.type_id
     }
+
+    /// Returns true if this represents a type of [`core::marker::PhantomData`].
+    pub(crate) fn is_phantom(&self) -> bool {
+        self == &MetaType::new::<crate::impls::PhantomIdentity>()
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,6 +183,15 @@ fn tuple_primitives() {
 }
 
 #[test]
+fn tuple_phantom_data_erased() {
+    // nested tuple
+    assert_type!(
+        (u64, PhantomData<u8>),
+        TypeDefTuple::new(vec![meta_type::<u64>(),])
+    );
+}
+
+#[test]
 fn array_primitives() {
     // array
     assert_type!([bool; 3], TypeDefArray::new(3, meta_type::<bool>()));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,7 +83,6 @@ fn prelude_items() {
                     )
             )
     );
-    assert_type!(PhantomData<i32>, TypeDefPhantom);
     assert_type!(
         Cow<u128>,
         Type::builder()
@@ -98,6 +97,12 @@ fn prelude_items() {
             .path(Path::prelude("NonZeroU32"))
             .composite(Fields::unnamed().field(|f| f.ty::<NonZeroU32>()))
     )
+}
+
+#[test]
+#[should_panic]
+fn phantom_data() {
+    PhantomData::<i32>::type_info();
 }
 
 #[test]

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -89,9 +89,9 @@ impl IntoPortable for TypeDefComposite {
     }
 }
 
-impl TypeDefComposite {
+impl TypeDefComposit0e {
     /// Creates a new struct definition with named fields.
-    pub fn new<I>(fields: I) -> Self
+    pub(crate) fn new<I>(fields: I) -> Self
     where
         I: IntoIterator<Item = Field>,
     {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -89,7 +89,7 @@ impl IntoPortable for TypeDefComposite {
     }
 }
 
-impl TypeDefComposit0e {
+impl TypeDefComposite {
     /// Creates a new struct definition with named fields.
     pub(crate) fn new<I>(fields: I) -> Self
     where

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -115,7 +115,6 @@ impl_from_type_def_for_type!(
     TypeDefSequence,
     TypeDefTuple,
     TypeDefCompact,
-    TypeDefPhantom,
     TypeDefBitSequence,
 );
 
@@ -238,8 +237,6 @@ pub enum TypeDef<T: Form = MetaForm> {
     Primitive(TypeDefPrimitive),
     /// A type using the [`Compact`] encoding
     Compact(TypeDefCompact<T>),
-    /// A PhantomData type.
-    Phantom(TypeDefPhantom),
     /// A type representing a sequence of bits.
     BitSequence(TypeDefBitSequence<T>),
 }
@@ -256,7 +253,6 @@ impl IntoPortable for TypeDef {
             TypeDef::Tuple(tuple) => tuple.into_portable(registry).into(),
             TypeDef::Primitive(primitive) => primitive.into(),
             TypeDef::Compact(compact) => compact.into_portable(registry).into(),
-            TypeDef::Phantom(phantom) => phantom.into(),
             TypeDef::BitSequence(bitseq) => bitseq.into_portable(registry).into(),
         }
     }
@@ -485,21 +481,6 @@ where
         &self.type_param
     }
 }
-
-/// A type describing a `PhantomData<T>` type.
-///
-/// In the context of SCALE encoded types, including `PhantomData<T>` types in
-/// the type info  might seem surprising. The reason to include this information
-/// is that there could be situations where it's useful and because removing
-/// `PhantomData` items from the derive input quickly becomes a messy
-/// syntax-level hack (see PR https://github.com/paritytech/scale-info/pull/31).
-/// Instead we take the same approach as `parity-scale-codec` where users are
-/// required to explicitly skip fields that cannot be represented in SCALE
-/// encoding, using the `#[codec(skip)]` attribute.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
-pub struct TypeDefPhantom;
 
 /// Type describing a [`bitvec::vec::BitVec`].
 ///

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -376,7 +376,10 @@ impl TypeDefTuple {
         T: IntoIterator<Item = MetaType>,
     {
         Self {
-            fields: type_params.into_iter().collect(),
+            fields: type_params
+                .into_iter()
+                .filter(|ty| !ty.is_phantom())
+                .collect(),
         }
     }
 

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -97,7 +97,7 @@ fn struct_derive() {
 }
 
 #[test]
-fn phantom_data_is_part_of_the_type_info() {
+fn phantom_data_field_is_erased() {
     #[allow(unused)]
     #[derive(TypeInfo)]
     struct P<T> {
@@ -667,19 +667,7 @@ fn skip_all_type_params() {
             TypeParameter::new("T", None),
             TypeParameter::new("U", None),
         ])
-        .composite(
-            Fields::named()
-                .field(|f| {
-                    f.ty::<PhantomData<NoScaleInfoImpl>>()
-                        .name("a")
-                        .type_name("PhantomData<T>")
-                })
-                .field(|f| {
-                    f.ty::<PhantomData<NoScaleInfoImpl>>()
-                        .name("b")
-                        .type_name("PhantomData<U>")
-                }),
-        );
+        .composite(Fields::named());
 
     assert_type!(SkipAllTypeParams<NoScaleInfoImpl, NoScaleInfoImpl>, ty);
 }
@@ -712,11 +700,6 @@ fn skip_type_params_with_associated_types() {
         .type_params(vec![TypeParameter::new("T", None)])
         .composite(
             Fields::named()
-                .field(|f| {
-                    f.ty::<PhantomData<NoScaleInfoImpl>>()
-                        .name("a")
-                        .type_name("PhantomData<T>")
-                })
                 .field(|f| f.ty::<u32>().name("b").type_name("T::A")),
         );
 
@@ -741,19 +724,7 @@ fn skip_type_params_with_defaults() {
             TypeParameter::new("T", None),
             TypeParameter::new("U", None),
         ])
-        .composite(
-            Fields::named()
-                .field(|f| {
-                    f.ty::<PhantomData<NoScaleInfoImpl>>()
-                        .name("a")
-                        .type_name("PhantomData<T>")
-                })
-                .field(|f| {
-                    f.ty::<PhantomData<NoScaleInfoImpl>>()
-                        .name("b")
-                        .type_name("PhantomData<U>")
-                }),
-        );
+        .composite(Fields::named());
 
     assert_type!(SkipAllTypeParamsWithDefaults<NoScaleInfoImpl, NoScaleInfoImpl>, ty);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -698,10 +698,7 @@ fn skip_type_params_with_associated_types() {
     let ty = Type::builder()
         .path(Path::new("SkipTypeParamsForTraitImpl", "derive"))
         .type_params(vec![TypeParameter::new("T", None)])
-        .composite(
-            Fields::named()
-                .field(|f| f.ty::<u32>().name("b").type_name("T::A")),
-        );
+        .composite(Fields::named().field(|f| f.ty::<u32>().name("b").type_name("T::A")));
 
     assert_type!(SkipTypeParamsForTraitImpl<NoScaleInfoImpl>, ty);
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -163,8 +163,6 @@ fn test_builtins() {
     // strings
     assert_json_for_type::<String>(json!({ "def": { "primitive": "str" } }));
     assert_json_for_type::<str>(json!({ "def": { "primitive": "str" } }));
-    // PhantomData
-    assert_json_for_type::<PhantomData<bool>>(json!({ "def": { "phantom": null }, }))
 }
 
 #[test]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -271,7 +271,7 @@ fn test_struct_with_some_fields_marked_as_compact() {
 }
 
 #[test]
-fn test_struct_with_phantom() {
+fn test_struct_with_phantom_field_erased() {
     use scale_info::prelude::marker::PhantomData;
     #[derive(TypeInfo)]
     struct Struct<T> {
@@ -288,8 +288,6 @@ fn test_struct_with_phantom() {
             "composite": {
                 "fields": [
                     { "name": "a", "type": 1, "typeName": "i32" },
-                    // type 1 is the `u8` in the `PhantomData`
-                    { "name": "b", "type": 2, "typeName": "PhantomData<T>" },
                 ],
             },
         }


### PR DESCRIPTION
Feedback from @jacogr while working on https://github.com/polkadot-js/api/pull/3759.

He rightly points out that `PhantomData` fields are redundant from a scale encoding perspective, since nothing is actually encoded. So all type generators for different langs would have to implement a filter for them or have a bunch of useless fields. This is a `Rust` implementation detail leaking out into the metadata definition. This PR removes that burden and filters out fields of `PhantomData` at source.

I know there has been much discussion of this in the past, but I think this solution avoids the main problem we had in the past by avoiding the macro having to syntactically identify `PhantomData` types.

Let me know what you think @Robbepop @dvdplm 