### PR TITLE
Don't count skipped variants for inferred indices

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -221,8 +221,8 @@ type VariantList = Punctuated<Variant, Comma>;
 fn generate_c_like_enum_def(variants: &VariantList, scale_info: &Ident) -> TokenStream2 {
     let variants = variants
         .into_iter()
+        .filter(|v| !utils::should_skip(&v.attrs))
         .enumerate()
-        .filter(|(_, v)| !utils::should_skip(&v.attrs))
         .map(|(i, v)| {
             let name = &v.ident;
             let index = utils::variant_index(v, i);
@@ -259,8 +259,8 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
 
     let variants = variants
         .into_iter()
+        .filter(|v| !utils::should_skip(&v.attrs))
         .enumerate()
-        .filter(|(_, v)| !utils::should_skip(&v.attrs))
         .map(|(i, v)| {
             let ident = &v.ident;
             let v_name = quote! {::core::stringify!(#ident) };

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -496,7 +496,7 @@ fn enum_variants_marked_scale_skip_are_skipped() {
     let ty = Type::builder().path(Path::new("Skippy", "derive")).variant(
         Variants::new()
             .variant("A", |v| v.index(0))
-            .variant("C", |v| v.index(2)),
+            .variant("C", |v| v.index(1)),
     );
     assert_type!(Skippy, ty);
 }
@@ -519,12 +519,12 @@ fn enum_variants_with_fields_marked_scale_skip_are_skipped() {
     let ty = Type::builder().path(Path::new("Skippy", "derive")).variant(
         Variants::new()
             .variant("Bajs", |v| {
-                v.index(1).fields(
+                v.index(0).fields(
                     Fields::named().field(|f| f.ty::<bool>().name("b").type_name("bool")),
                 )
             })
             .variant("Coo", |v| {
-                v.index(2)
+                v.index(1)
                     .fields(Fields::unnamed().field(|f| f.ty::<bool>().type_name("bool")))
             }),
     );


### PR DESCRIPTION
Fix bug introduced in #112. See https://github.com/paritytech/parity-scale-codec/blob/2ce46f444b1615b064c7d084f817ebe032e9aa7b/tests/variant_number.rs#L18