### PR TITLE
Include type id in serialized type registry

### DIFF
--- a/src/interner.rs
+++ b/src/interner.rs
@@ -48,6 +48,7 @@ use serde::{
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
+    #[codec(compact)]
     id: u32,
     #[cfg_attr(feature = "serde", serde(skip))]
     marker: PhantomData<fn() -> T>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -201,6 +201,7 @@ impl PortableRegistry {
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableType {
+    #[codec(compact)]
     id: u32,
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
     ty: Type<PortableForm>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -170,7 +170,16 @@ pub struct PortableRegistry {
 impl From<Registry> for PortableRegistry {
     fn from(registry: Registry) -> Self {
         PortableRegistry {
-            types: registry.types.iter().map(|(k, v)| PortableType { id: k.id(), ty: v.clone() }).collect::<Vec<_>>(),
+            types: registry
+                .types
+                .iter()
+                .map(|(k, v)| {
+                    PortableType {
+                        id: k.id(),
+                        ty: v.clone(),
+                    }
+                })
+                .collect::<Vec<_>>(),
         }
     }
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -612,20 +612,20 @@ fn test_registry() {
                                 { "type": 2, "typeName": "u8" },
                                 { "type": 3, "typeName": "u32" },
                             ],
-                        },
+                        }
                     }
                 }
             },
             {
                 "id": 2,
-                "type" {
-                    "def": { "primitive": "u8" },
+                "type": {
+                    "def": { "primitive": "u8" }
                 }
             },
             {
                 "id": 3,
-                "type" {
-                    "def": { "primitive": "u32" },
+                "type": {
+                    "def": { "primitive": "u32" }
                 }
             },
             {
@@ -654,7 +654,7 @@ fn test_registry() {
                                     "typeName": "[u8; 32]"
                                 }
                             ]
-                        },
+                        }
                     }
                 }
             },
@@ -665,7 +665,7 @@ fn test_registry() {
                         "array": {
                             "len": 32,
                             "type": 2, // u8
-                        },
+                        }
                     }
                 }
             },
@@ -685,7 +685,7 @@ fn test_registry() {
                                     "typeName": "Vec<RecursiveStruct>"
                                 }
                             ]
-                        },
+                        }
                     }
                 }
             },
@@ -770,10 +770,10 @@ fn test_registry() {
                                     ]
                                 }
                             ]
-                        },
+                        }
                     }
                 }
-            },
+            }
         ]
     });
 

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -426,31 +426,37 @@ fn test_recursive_type_with_box() {
     let expected_json = json!({
         "types": [
             {
-                "path": ["json", "Tree"],
-                "def": {
-                    "variant": {
-                        "variants": [
-                            {
-                                "name": "Leaf",
-                                "index": 0,
-                                "fields": [
-                                    { "name": "value", "type": 1, "typeName": "i32" },
-                                ],
-                            },
-                            {
-                                "name": "Node",
-                                "index": 1,
-                                "fields": [
-                                    { "name": "right", "type": 0, "typeName": "Box<Tree>" },
-                                    { "name": "left", "type": 0, "typeName": "Box<Tree>" },
-                                ],
-                            }
-                        ],
-                    },
+                "id": 0,
+                "type": {
+                    "path": ["json", "Tree"],
+                    "def": {
+                        "variant": {
+                            "variants": [
+                                {
+                                    "name": "Leaf",
+                                    "index": 0,
+                                    "fields": [
+                                        { "name": "value", "type": 1, "typeName": "i32" },
+                                    ],
+                                },
+                                {
+                                    "name": "Node",
+                                    "index": 1,
+                                    "fields": [
+                                        { "name": "right", "type": 0, "typeName": "Box<Tree>" },
+                                        { "name": "left", "type": 0, "typeName": "Box<Tree>" },
+                                    ],
+                                }
+                            ],
+                        },
+                    }
                 }
             },
             {
-                "def": { "primitive": "i32" },
+                "id": 1,
+                "type": {
+                    "def": { "primitive": "i32" },
+                }
             },
         ]
     });
@@ -476,37 +482,64 @@ fn registry_knows_about_compact_types() {
 
     let expected_json = json!({
         "types": [
-            { // type 1
-                "path": ["json", "Dense"],
-                "def": {
-                    "composite": {
-                        "fields": [
-                            { "name": "a", "type": 1, "typeName": "u128" },
-                            { "name": "a_not_compact", "type": 2, "typeName": "u128" },
-                            { "name": "b", "type": 3, "typeName": "[u8; 32]" },
-                            { "name": "c", "type": 5, "typeName": "u64" }
-                        ]
+            {
+                "id": 0,
+                "type": {
+                    "path": ["json", "Dense"],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                { "name": "a", "type": 1, "typeName": "u128" },
+                                { "name": "a_not_compact", "type": 2, "typeName": "u128" },
+                                { "name": "b", "type": 3, "typeName": "[u8; 32]" },
+                                { "name": "c", "type": 5, "typeName": "u64" }
+                            ]
+                        }
                     }
                 }
             },
-            { // type 2, the `Compact<u128>` of field `a`.
-                "def": { "compact": { "type": 2 } },
+            {
+                "id": 1,
+                "type": {
+                    // type 1, the `Compact<u128>` of field `a`.
+                    "def": { "compact": { "type": 2 } },
+                }
             },
-            { // type 3, the `u128` used by type 2 and field `a_not_compact`.
-                "def": { "primitive": "u128" }
+            {
+                "id": 2,
+                "type": {
+                    // type 2, the `u128` used by type 2 and field `a_not_compact`.
+                    "def": { "primitive": "u128" }
+                }
             },
-            { // type 4, the `[u8; 32]` of field `b`.
-                "def": { "array": { "len": 32, "type": 4 }}
+            {
+                "id": 3,
+                "type": {
+                    // type 3, the `[u8; 32]` of field `b`.
+                    "def": { "array": { "len": 32, "type": 4 }}
+                }
             },
-            { // type 5, the `u8` in `[u8; 32]`
-                "def": { "primitive": "u8" }
+            {
+                "id": 4,
+                "type": {
+                    // type 4, the `u8` in `[u8; 32]`
+                    "def": { "primitive": "u8" }
+                }
             },
-            { // type 6, the `Compact<u64>` of field `c`
-                "def": { "compact": { "type": 6 } },
+            {
+                "id": 5,
+                "type": {
+                    // type 5, the `Compact<u64>` of field `c`
+                    "def": { "compact": { "type": 6 } },
+                }
             },
-            { // type 7, the `u64` in `Compact<u64>` of field `c`
-                "def": { "primitive": "u64" }
-            },
+            {
+                "id": 6,
+                "type": {
+                    // type 6, the `u64` in `Compact<u64>` of field `c`
+                    "def": { "primitive": "u64" }
+                }
+            }
         ]
     });
 
@@ -554,161 +587,191 @@ fn test_registry() {
 
     let expected_json = json!({
         "types": [
-            { // type 0
-                "path": [
-                    "json",
-                    "UnitStruct",
-                ],
-                "def": {
-                    "composite": {},
-                }
-            },
-            { // type 1
-                "path": [
-                    "json",
-                    "TupleStruct",
-                ],
-                "def": {
-                    "composite": {
-                        "fields": [
-                            { "type": 2, "typeName": "u8" },
-                            { "type": 3, "typeName": "u32" },
-                        ],
-                    },
-                }
-            },
-            { // type 2
-                "def": { "primitive": "u8" },
-            },
-            { // type 3
-                "def": { "primitive": "u32" },
-            },
-            { // type 4
-                "path": [
-                    "json",
-                    "Struct",
-                ],
-                "def": {
-                    "composite": {
-                        "fields": [
-                            {
-                                "name": "a",
-                                "type": 2,
-                                "typeName": "u8"
-                            },
-                            {
-                                "name": "b",
-                                "type": 3,
-                                "typeName": "u32"
-                            },
-                            {
-                                "name": "c",
-                                "type": 5,
-                                "typeName": "[u8; 32]"
-                            }
-                        ]
-                    },
-                }
-            },
-            { // type 5
-                "def": {
-                    "array": {
-                        "len": 32,
-                        "type": 2, // u8
-                    },
-                }
-            },
-            { // type 6
-                "path": [
-                    "json",
-                    "RecursiveStruct",
-                ],
-                "def": {
-                    "composite": {
-                        "fields": [
-                            {
-                                "name": "rec",
-                                "type": 7,
-                                "typeName": "Vec<RecursiveStruct>"
-                            }
-                        ]
-                    },
-                }
-            },
-            { // type 7
-                "def": {
-                    "sequence": {
-                        "type": 6, // RecursiveStruct
-                    },
-                }
-            },
-            { // type 8
-                "path": [
-                    "json",
-                    "ClikeEnum",
-                ],
-                "def": {
-                    "variant": {
-                        "variants": [
-                            {
-                                "name": "A",
-                                "index": 0,
-                            },
-                            {
-                                "name": "B",
-                                "index": 1,
-                            },
-                            {
-                                "name": "C",
-                                "index": 2,
-                            },
-                        ]
+            {
+                "id": 0,
+                "type": {
+                    "path": [
+                        "json",
+                        "UnitStruct",
+                    ],
+                    "def": {
+                        "composite": {},
                     }
                 }
             },
-            { // type 9
-                "path": [
-                    "json",
-                    "RustEnum"
-                ],
-                "def": {
-                    "variant": {
-                        "variants": [
-                            {
-                                "name": "A",
-                                "index": 0,
-                            },
-                            {
-                                "name": "B",
-                                "index": 1,
-                                "fields": [
-                                    { "type": 2, "typeName": "u8" }, // u8
-                                    { "type": 3, "typeName": "u32" }, // u32
-                                ]
-                            },
-                            {
-                                "name": "C",
-                                "index": 2,
-                                "fields": [
-                                    {
-                                        "name": "a",
-                                        "type": 2, // u8
-                                        "typeName": "u8"
-                                    },
-                                    {
-                                        "name": "b",
-                                        "type": 3, // u32
-                                        "typeName": "u32"
-                                    },
-                                    {
-                                        "name": "c",
-                                        "type": 5,
-                                        "typeName": "[u8; 32]"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
+            {
+                "id": 1,
+                "type": {
+                    "path": [
+                        "json",
+                        "TupleStruct",
+                    ],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                { "type": 2, "typeName": "u8" },
+                                { "type": 3, "typeName": "u32" },
+                            ],
+                        },
+                    }
+                }
+            },
+            {
+                "id": 2,
+                "type" {
+                    "def": { "primitive": "u8" },
+                }
+            },
+            {
+                "id": 3,
+                "type" {
+                    "def": { "primitive": "u32" },
+                }
+            },
+            {
+                "id": 4,
+                "type": {
+                    "path": [
+                        "json",
+                        "Struct",
+                    ],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                {
+                                    "name": "a",
+                                    "type": 2,
+                                    "typeName": "u8"
+                                },
+                                {
+                                    "name": "b",
+                                    "type": 3,
+                                    "typeName": "u32"
+                                },
+                                {
+                                    "name": "c",
+                                    "type": 5,
+                                    "typeName": "[u8; 32]"
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+            {
+                "id": 5,
+                "type": {
+                    "def": {
+                        "array": {
+                            "len": 32,
+                            "type": 2, // u8
+                        },
+                    }
+                }
+            },
+            {
+                "id": 6,
+                "type": {
+                     "path": [
+                        "json",
+                        "RecursiveStruct",
+                    ],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                {
+                                    "name": "rec",
+                                    "type": 7,
+                                    "typeName": "Vec<RecursiveStruct>"
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+            {
+                "id": 7,
+                "type": {
+                    "def": {
+                        "sequence": {
+                            "type": 6, // RecursiveStruct
+                        },
+                    }
+                }
+            },
+            {
+                "id": 8,
+                "type": {
+                    "path": [
+                        "json",
+                        "ClikeEnum",
+                    ],
+                    "def": {
+                        "variant": {
+                            "variants": [
+                                {
+                                    "name": "A",
+                                    "index": 0,
+                                },
+                                {
+                                    "name": "B",
+                                    "index": 1,
+                                },
+                                {
+                                    "name": "C",
+                                    "index": 2,
+                                },
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "id": 9,
+                "type": {
+                    "path": [
+                        "json",
+                        "RustEnum"
+                    ],
+                    "def": {
+                        "variant": {
+                            "variants": [
+                                {
+                                    "name": "A",
+                                    "index": 0,
+                                },
+                                {
+                                    "name": "B",
+                                    "index": 1,
+                                    "fields": [
+                                        { "type": 2, "typeName": "u8" }, // u8
+                                        { "type": 3, "typeName": "u32" }, // u32
+                                    ]
+                                },
+                                {
+                                    "name": "C",
+                                    "index": 2,
+                                    "fields": [
+                                        {
+                                            "name": "a",
+                                            "type": 2, // u8
+                                            "typeName": "u8"
+                                        },
+                                        {
+                                            "name": "b",
+                                            "type": 3, // u32
+                                            "typeName": "u32"
+                                        },
+                                        {
+                                            "name": "c",
+                                            "type": 5,
+                                            "typeName": "[u8; 32]"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                    }
                 }
             },
         ]


### PR DESCRIPTION
Currently the position of a type in the list of types corresponds with its lookup id. This is fine for computers but makes human readability of the serialized json a bit more difficult.

Adding the id of the type to the serialized type registry makes developing and debugging with the type registry much easier, since you can manually lookup a type with a text search in the json metadata.

Encoded size increase should be negligible, just an extra u32 per type.

Hat tip to @jacogr for the idea.