### PR TITLE
Fix `PhantomData` filtering

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -264,19 +264,8 @@ impl<T> FieldsBuilder<T> {
     pub fn finalize(self) -> Vec<Field<MetaForm>> {
         self.fields
     }
-}
 
-impl FieldsBuilder<NamedFields> {
-    /// Add a named field constructed using the builder.
-    pub fn field<F>(mut self, builder: F) -> Self
-    where
-        F: Fn(
-            FieldBuilder,
-        )
-            -> FieldBuilder<field_state::NameAssigned, field_state::TypeAssigned>,
-    {
-        let builder = builder(FieldBuilder::new());
-        let field = builder.finalize();
+    fn push_field(mut self, field: Field) -> Self {
         // filter out fields of PhantomData
         if !field.ty().is_phantom() {
             self.fields.push(field);
@@ -285,9 +274,23 @@ impl FieldsBuilder<NamedFields> {
     }
 }
 
+impl FieldsBuilder<NamedFields> {
+    /// Add a named field constructed using the builder.
+    pub fn field<F>(self, builder: F) -> Self
+    where
+        F: Fn(
+            FieldBuilder,
+        )
+            -> FieldBuilder<field_state::NameAssigned, field_state::TypeAssigned>,
+    {
+        let builder = builder(FieldBuilder::new());
+        self.push_field(builder.finalize())
+    }
+}
+
 impl FieldsBuilder<UnnamedFields> {
     /// Add an unnamed field constructed using the builder.
-    pub fn field<F>(mut self, builder: F) -> Self
+    pub fn field<F>(self, builder: F) -> Self
     where
         F: Fn(
             FieldBuilder,
@@ -295,8 +298,7 @@ impl FieldsBuilder<UnnamedFields> {
             -> FieldBuilder<field_state::NameNotAssigned, field_state::TypeAssigned>,
     {
         let builder = builder(FieldBuilder::new());
-        self.fields.push(builder.finalize());
-        self
+        self.push_field(builder.finalize())
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -329,7 +329,11 @@ impl<T> TypeInfo for PhantomData<T> {
     type Identity = PhantomIdentity;
 
     fn type_info() -> Type {
-        panic!("PhantomData type instances should be filtered out.")
+        // Fields of this type should be filtered out and never appear in the type graph.
+        Type::builder()
+            .path(Path::prelude("PhantomData"))
+            .docs(&["PhantomData placeholder, this type should be filtered out"])
+            .composite(Fields::unit())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -106,9 +106,14 @@ fn prelude_items() {
 }
 
 #[test]
-#[should_panic]
 fn phantom_data() {
-    PhantomData::<i32>::type_info();
+    assert_type!(
+        PhantomData<i32>,
+        Type::builder()
+            .path(Path::prelude("PhantomData"))
+            .docs(&["PhantomData placeholder, this type should be filtered out"])
+            .composite(Fields::unit())
+    )
 }
 
 #[test]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -108,10 +108,7 @@ fn phantom_data_field_is_erased() {
     let ty = Type::builder()
         .path(Path::new("P", "derive"))
         .type_params(named_type_params!((T, bool)))
-        .composite(
-            Fields::named()
-                .field(|f| f.ty::<u8>().name("a").type_name("u8"))
-        );
+        .composite(Fields::named().field(|f| f.ty::<u8>().name("a").type_name("u8")));
 
     assert_type!(P<bool>, ty);
 }
@@ -125,10 +122,7 @@ fn phantom_data_tuple_struct_field_is_erased() {
     let ty = Type::builder()
         .path(Path::new("P", "derive"))
         .type_params(named_type_params!((T, bool)))
-        .composite(
-            Fields::unnamed()
-                .field(|f| f.ty::<u8>().type_name("u8"))
-        );
+        .composite(Fields::unnamed().field(|f| f.ty::<u8>().type_name("u8")));
 
     assert_type!(P<bool>, ty);
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -133,9 +133,7 @@ fn phantom_data_tuple_struct_field_is_erased() {
         .composite(
             Fields::unnamed()
                 .field(|f| f.ty::<u8>().type_name("u8"))
-                .field(|f| {
-                    f.ty::<PhantomData<bool>>().type_name("PhantomData<T>")
-                }),
+                .field(|f| f.ty::<PhantomData<bool>>().type_name("PhantomData<T>")),
         );
 
     assert_type!(P<bool>, ty);

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -122,6 +122,26 @@ fn phantom_data_field_is_erased() {
 }
 
 #[test]
+fn phantom_data_tuple_struct_field_is_erased() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct P<T>(u8, PhantomData<T>);
+
+    let ty = Type::builder()
+        .path(Path::new("P", "derive"))
+        .type_params(named_type_params!((T, bool)))
+        .composite(
+            Fields::unnamed()
+                .field(|f| f.ty::<u8>().type_name("u8"))
+                .field(|f| {
+                    f.ty::<PhantomData<bool>>().type_name("PhantomData<T>")
+                }),
+        );
+
+    assert_type!(P<bool>, ty);
+}
+
+#[test]
 fn tuple_struct_derive() {
     #[allow(unused)]
     #[derive(TypeInfo)]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -111,11 +111,6 @@ fn phantom_data_field_is_erased() {
         .composite(
             Fields::named()
                 .field(|f| f.ty::<u8>().name("a").type_name("u8"))
-                .field(|f| {
-                    f.ty::<PhantomData<bool>>()
-                        .name("m")
-                        .type_name("PhantomData<T>")
-                }),
         );
 
     assert_type!(P<bool>, ty);
@@ -133,7 +128,6 @@ fn phantom_data_tuple_struct_field_is_erased() {
         .composite(
             Fields::unnamed()
                 .field(|f| f.ty::<u8>().type_name("u8"))
-                .field(|f| f.ty::<PhantomData<bool>>().type_name("PhantomData<T>")),
         );
 
     assert_type!(P<bool>, ty);


### PR DESCRIPTION
Following up on #111, which failed to filter out `PhantomData` for tuple structs, causing a panic. I've removed said panic, replaced with a placeholder type def which can be searched for in case one sneaks through.