### PR TITLE
Improve docs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "0.99.1", default-features = false, features = ["from"
 scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 
 [features]
-default = ["std", "docs"]
+default = ["std"]
 std = [
     "bitvec/std",
     "scale/std",

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -314,9 +314,7 @@ fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
                 if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
                     if let syn::Lit::Str(lit) = &meta.lit {
                         let lit_value = lit.value();
-                        let stripped = lit_value
-                            .strip_prefix(' ')
-                            .unwrap_or(&lit_value);
+                        let stripped = lit_value.strip_prefix(' ').unwrap_or(&lit_value);
                         let lit: syn::Lit = parse_quote!(#stripped);
                         Some(lit)
                     } else {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -313,12 +313,14 @@ fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
         .filter_map(|attr| {
             if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
                 if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
-                    let lit = &meta.lit;
-                    let doc_lit = quote!(#lit).to_string();
-                    let trimmed_doc_lit =
-                        doc_lit.trim_start_matches(r#"" "#).trim_end_matches('"');
-                    let lit: syn::Lit = parse_quote!(#trimmed_doc_lit);
-                    Some(lit)
+                    if let syn::Lit::Str(lit) = &meta.lit {
+                        let lit_value = lit.value();
+                        let stripped = lit_value.strip_prefix(' ');
+                        let lit: syn::LitStr = parse_quote!(#stripped);
+                        Some(lit)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -306,7 +306,6 @@ fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStrea
     }
 }
 
-#[cfg(feature = "docs")]
 fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
     let docs = attrs
         .iter()
@@ -335,9 +334,4 @@ fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
     Some(quote! {
         .docs(&[ #( #docs ),* ])
     })
-}
-
-#[cfg(not(feature = "docs"))]
-fn generate_docs(_: &[syn::Attribute]) -> Option<TokenStream2> {
-    None
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -315,7 +315,9 @@ fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
                 if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
                     if let syn::Lit::Str(lit) = &meta.lit {
                         let lit_value = lit.value();
-                        let stripped = lit_value.strip_prefix(' ');
+                        let stripped = lit_value
+                            .strip_prefix(' ')
+                            .unwrap_or(&lit_value);
                         let lit: syn::Lit = parse_quote!(#stripped);
                         Some(lit)
                     } else {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -316,7 +316,7 @@ fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
                     if let syn::Lit::Str(lit) = &meta.lit {
                         let lit_value = lit.value();
                         let stripped = lit_value.strip_prefix(' ');
-                        let lit: syn::LitStr = parse_quote!(#stripped);
+                        let lit: syn::Lit = parse_quote!(#stripped);
                         Some(lit)
                     } else {
                         None

--- a/src/build.rs
+++ b/src/build.rs
@@ -218,8 +218,8 @@ impl<S> TypeBuilder<S> {
     }
 
     #[cfg(not(feature = "docs"))]
-    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     #[inline]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     pub fn docs(self, _docs: &'static [&'static str]) -> Self {
         self
     }
@@ -421,8 +421,8 @@ impl<N, T> FieldBuilder<N, T> {
     }
 
     #[cfg(not(feature = "docs"))]
-    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     #[inline]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
         self
     }
@@ -542,8 +542,8 @@ impl<S> VariantBuilder<S> {
     }
 
     #[cfg(not(feature = "docs"))]
-    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     #[inline]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     pub fn docs(self, _docs: &[&'static str]) -> Self {
         self
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -219,7 +219,7 @@ impl<S> TypeBuilder<S> {
 
     #[cfg(not(feature = "docs"))]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
-    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
+    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> Self {
         self
     }
 }
@@ -540,7 +540,7 @@ impl<S> VariantBuilder<S> {
 
     #[cfg(not(feature = "docs"))]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
-    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> Self {
+    #[inline] pub fn docs(self, _docs: &[&'static str]) -> Self {
         self
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -219,7 +219,8 @@ impl<S> TypeBuilder<S> {
 
     #[cfg(not(feature = "docs"))]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
-    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> Self {
+    #[inline]
+    pub fn docs(self, _docs: &'static [&'static str]) -> Self {
         self
     }
 }
@@ -421,7 +422,8 @@ impl<N, T> FieldBuilder<N, T> {
 
     #[cfg(not(feature = "docs"))]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
-    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
+    #[inline]
+    pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
         self
     }
 }
@@ -541,7 +543,8 @@ impl<S> VariantBuilder<S> {
 
     #[cfg(not(feature = "docs"))]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
-    #[inline] pub fn docs(self, _docs: &[&'static str]) -> Self {
+    #[inline]
+    pub fn docs(self, _docs: &[&'static str]) -> Self {
         self
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -532,6 +532,7 @@ impl<S> VariantBuilder<S> {
         self
     }
 
+    #[cfg(feature = "docs")]
     /// Initialize the variant's documentation.
     pub fn docs(mut self, docs: &[&'static str]) -> Self {
         self.docs = docs.to_vec();

--- a/src/build.rs
+++ b/src/build.rs
@@ -210,9 +210,16 @@ impl<S> TypeBuilder<S> {
         self
     }
 
+    #[cfg(feature = "docs")]
     /// Set the type documentation
     pub fn docs(mut self, docs: &[&'static str]) -> Self {
         self.docs = docs.to_vec();
+        self
+    }
+
+    #[cfg(not(feature = "docs"))]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
+    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
         self
     }
 }
@@ -400,6 +407,7 @@ impl<N, T> FieldBuilder<N, T> {
         }
     }
 
+    #[cfg(feature = "docs")]
     /// Initialize the documentation of a field (optional).
     pub fn docs(self, docs: &'static [&'static str]) -> FieldBuilder<N, T> {
         FieldBuilder {
@@ -409,6 +417,12 @@ impl<N, T> FieldBuilder<N, T> {
             docs,
             marker: PhantomData,
         }
+    }
+
+    #[cfg(not(feature = "docs"))]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
+    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
+        self
     }
 }
 
@@ -521,6 +535,12 @@ impl<S> VariantBuilder<S> {
     /// Initialize the variant's documentation.
     pub fn docs(mut self, docs: &[&'static str]) -> Self {
         self.docs = docs.to_vec();
+        self
+    }
+
+    #[cfg(not(feature = "docs"))]
+    /// Doc capture is not enabled via the "docs" feature so this is a no-op.
+    #[inline] pub fn docs(self, _docs: &'static [&'static str]) -> Self {
         self
     }
 }

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -733,6 +733,21 @@ fn skip_type_params_with_defaults() {
     assert_type!(SkipAllTypeParamsWithDefaults<NoScaleInfoImpl, NoScaleInfoImpl>, ty);
 }
 
+#[test]
+fn docs_attr() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[doc = "Docs attr"]
+    pub struct S;
+
+    let ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .docs(&["Docs attr"])
+        .composite(Fields::unit());
+
+    assert_type!(S, ty);
+}
+
 #[rustversion::nightly]
 #[test]
 fn ui_tests() {

--- a/test_suite/tests/ui/fail_missing_derive.stderr
+++ b/test_suite/tests/ui/fail_missing_derive.stderr
@@ -7,4 +7,11 @@ error[E0277]: the trait bound `PawType<u16>: TypeInfo` is not satisfied
 17 |     assert_type_info::<Cat<bool, u8, u16>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypeInfo` is not implemented for `PawType<u16>`
    |
-   = note: required because of the requirements on the impl of `TypeInfo` for `Cat<bool, u8, u16>`
+note: required because of the requirements on the impl of `TypeInfo` for `Cat<bool, u8, u16>`
+  --> $DIR/fail_missing_derive.rs:7:10
+   |
+7  | #[derive(TypeInfo)]
+   |          ^^^^^^^^
+8  | struct Cat<Tail, Ear, Paw> {
+   |        ^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `TypeInfo` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Closes https://github.com/paritytech/scale-info/issues/109

1. Clean up `doc` attribute literal parsing.
2. Use `builder` with `#[inline]` no-ops to prevent doc capture, the compiler should optimize away the static strings.
3. `docs` is now an opt-in (non default) feature

/cc @jacogr 