### PR TITLE
Add capture_docs attribute

### DIFF
--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -133,14 +133,14 @@ impl Attributes {
     pub fn never_capture_docs(&self) -> bool {
         self.capture_docs
             .as_ref()
-            .map_or(false, |attr| attr.capture_docs == false)
+            .map_or(false, |attr| !attr.capture_docs)
     }
 
     /// Returns true if the type is annotated with `#[scale_info(capture_docs = true)]`
     pub fn always_capture_docs(&self) -> bool {
         self.capture_docs
             .as_ref()
-            .map_or(false, |attr| attr.capture_docs == true)
+            .map_or(false, |attr| attr.capture_docs)
     }
 }
 

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -209,7 +209,9 @@ impl Parse for CaptureDocsAttr {
         input.parse::<keywords::capture_docs>()?;
         input.parse::<syn::Token![=]>()?;
         let capture_docs_lit = input.parse::<syn::LitBool>()?;
-        Ok(Self { capture_docs: capture_docs_lit.value() })
+        Ok(Self {
+            capture_docs: capture_docs_lit.value(),
+        })
     }
 }
 
@@ -241,7 +243,8 @@ impl Parse for ScaleInfoAttr {
             let capture_docs = input.parse()?;
             Ok(Self::CaptureDocs(capture_docs))
         } else {
-            Err(input.error("Expected one of: `bounds`, `skip_type_params` or `capture_docs"))
+            Err(input
+                .error("Expected one of: `bounds`, `skip_type_params` or `capture_docs"))
         }
     }
 }

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -129,9 +129,14 @@ impl Attributes {
         self.skip_type_params.as_ref()
     }
 
-    /// Get the `#[scale_info(capture_docs = {bool})]` attribute, if present.
-    pub fn capture_docs(&self) -> Option<&CaptureDocsAttr> {
-        self.capture_docs.as_ref()
+    /// Returns true if the type is annotated with `#[scale_info(capture_docs = false)]`
+    pub fn never_capture_docs(&self) -> bool {
+        self.capture_docs.as_ref().map_or(false, |attr| attr.capture_docs == false)
+    }
+
+    /// Returns true if the type is annotated with `#[scale_info(capture_docs = true)]`
+    pub fn always_capture_docs(&self) -> bool {
+        self.capture_docs.as_ref().map_or(false, |attr| attr.capture_docs == true)
     }
 }
 
@@ -212,14 +217,6 @@ impl Parse for CaptureDocsAttr {
         Ok(Self {
             capture_docs: capture_docs_lit.value(),
         })
-    }
-}
-
-impl CaptureDocsAttr {
-    /// Returns `true` if docs should *always* be captured for a type.
-    /// Returns `false` if docs should *never* be captured for a type.
-    pub fn capture_docs(&self) -> bool {
-        self.capture_docs
     }
 }
 

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -133,7 +133,9 @@ impl Attributes {
     ///
     /// Defaults to `CaptureDocsAttr::Default` if the attribute is not present.
     pub fn capture_docs(&self) -> &CaptureDocsAttr {
-        self.capture_docs.as_ref().unwrap_or(&CaptureDocsAttr::Default)
+        self.capture_docs
+            .as_ref()
+            .unwrap_or(&CaptureDocsAttr::Default)
     }
 }
 
@@ -218,12 +220,12 @@ impl Parse for CaptureDocsAttr {
             "default" => Ok(Self::Default),
             "always" => Ok(Self::Always),
             "never" => Ok(Self::Never),
-            _ => Err(
-                syn::Error::new_spanned(
+            _ => {
+                Err(syn::Error::new_spanned(
                     capture_docs_lit,
-                    r#"Invalid capture_docs value. Expected one of: "default", "always", "never" "#
-                )
-            )
+                    r#"Invalid capture_docs value. Expected one of: "default", "always", "never" "#,
+                ))
+            }
         }
     }
 }

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -131,12 +131,16 @@ impl Attributes {
 
     /// Returns true if the type is annotated with `#[scale_info(capture_docs = false)]`
     pub fn never_capture_docs(&self) -> bool {
-        self.capture_docs.as_ref().map_or(false, |attr| attr.capture_docs == false)
+        self.capture_docs
+            .as_ref()
+            .map_or(false, |attr| attr.capture_docs == false)
     }
 
     /// Returns true if the type is annotated with `#[scale_info(capture_docs = true)]`
     pub fn always_capture_docs(&self) -> bool {
-        self.capture_docs.as_ref().map_or(false, |attr| attr.capture_docs == true)
+        self.capture_docs
+            .as_ref()
+            .map_or(false, |attr| attr.capture_docs == true)
     }
 }
 

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -28,12 +28,14 @@ mod keywords {
     syn::custom_keyword!(scale_info);
     syn::custom_keyword!(bounds);
     syn::custom_keyword!(skip_type_params);
+    syn::custom_keyword!(capture_docs);
 }
 
 /// Parsed and validated set of `#[scale_info(...)]` attributes for an item.
 pub struct Attributes {
     bounds: Option<BoundsAttr>,
     skip_type_params: Option<SkipTypeParamsAttr>,
+    capture_docs: Option<CaptureDocsAttr>,
 }
 
 impl Attributes {
@@ -41,6 +43,7 @@ impl Attributes {
     pub fn from_ast(item: &syn::DeriveInput) -> syn::Result<Self> {
         let mut bounds = None;
         let mut skip_type_params = None;
+        let mut capture_docs = None;
 
         let attributes_parser = |input: &ParseBuffer| {
             let attrs: Punctuated<ScaleInfoAttr, Token![,]> =
@@ -75,6 +78,15 @@ impl Attributes {
                         }
                         skip_type_params = Some(parsed_skip_type_params);
                     }
+                    ScaleInfoAttr::CaptureDocs(parsed_capture_docs) => {
+                        if capture_docs.is_some() {
+                            return Err(syn::Error::new(
+                                attr.span(),
+                                "Duplicate `capture_docs` attributes",
+                            ))
+                        }
+                        capture_docs = Some(parsed_capture_docs);
+                    }
                 }
             }
         }
@@ -103,6 +115,7 @@ impl Attributes {
         Ok(Self {
             bounds,
             skip_type_params,
+            capture_docs,
         })
     }
 
@@ -114,6 +127,11 @@ impl Attributes {
     /// Get the `#[scale_info(skip_type_params(...))]` attribute, if present.
     pub fn skip_type_params(&self) -> Option<&SkipTypeParamsAttr> {
         self.skip_type_params.as_ref()
+    }
+
+    /// Get the `#[scale_info(capture_docs = {bool})]` attribute, if present.
+    pub fn capture_docs(&self) -> Option<&CaptureDocsAttr> {
+        self.capture_docs.as_ref()
     }
 }
 
@@ -180,10 +198,34 @@ impl SkipTypeParamsAttr {
     }
 }
 
+/// Parsed representation of the `#[scale_info(capture_docs = {bool})]` attribute.
+#[derive(Clone)]
+pub struct CaptureDocsAttr {
+    capture_docs: bool,
+}
+
+impl Parse for CaptureDocsAttr {
+    fn parse(input: &ParseBuffer) -> syn::Result<Self> {
+        input.parse::<keywords::capture_docs>()?;
+        input.parse::<syn::Token![=]>()?;
+        let capture_docs_lit = input.parse::<syn::LitBool>()?;
+        Ok(Self { capture_docs: capture_docs_lit.value() })
+    }
+}
+
+impl CaptureDocsAttr {
+    /// Returns `true` if docs should *always* be captured for a type.
+    /// Returns `false` if docs should *never* be captured for a type.
+    pub fn capture_docs(&self) -> bool {
+        self.capture_docs
+    }
+}
+
 /// Parsed representation of one of the `#[scale_info(..)]` attributes.
 pub enum ScaleInfoAttr {
     Bounds(BoundsAttr),
     SkipTypeParams(SkipTypeParamsAttr),
+    CaptureDocs(CaptureDocsAttr),
 }
 
 impl Parse for ScaleInfoAttr {
@@ -195,8 +237,11 @@ impl Parse for ScaleInfoAttr {
         } else if lookahead.peek(keywords::skip_type_params) {
             let skip_type_params = input.parse()?;
             Ok(Self::SkipTypeParams(skip_type_params))
+        } else if lookahead.peek(keywords::capture_docs) {
+            let capture_docs = input.parse()?;
+            Ok(Self::CaptureDocs(capture_docs))
         } else {
-            Err(input.error("Expected either `bounds` or `skip_type_params`"))
+            Err(input.error("Expected one of: `bounds`, `skip_type_params` or `capture_docs"))
         }
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -250,6 +250,10 @@ impl TypeInfoImpl {
     }
 
     fn generate_docs(&self, attrs: &[syn::Attribute]) -> Option<TokenStream2> {
+        if self.attrs.never_capture_docs() {
+            return None;
+        }
+
         let docs = attrs
             .iter()
             .filter_map(|attr| {
@@ -273,8 +277,14 @@ impl TypeInfoImpl {
             })
             .collect::<Vec<_>>();
 
+        let docs_builder_fn = if self.attrs.always_capture_docs() {
+            quote!( docs )
+        } else {
+            quote!( docs_always )
+        };
+
         Some(quote! {
-            .docs(&[ #( #docs ),* ])
+            .#docs_builder_fn(&[ #( #docs ),* ])
         })
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -72,7 +72,7 @@ struct TypeInfoImpl {
 
 impl TypeInfoImpl {
     fn parse(input: TokenStream2) -> Result<Self> {
-        let ast: DeriveInput = syn::parse2(input.clone())?;
+        let ast: DeriveInput = syn::parse2(input)?;
         let scale_info = crate_name_ident("scale-info")?;
         let attrs = attr::Attributes::from_ast(&ast)?;
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -278,9 +278,9 @@ impl TypeInfoImpl {
             .collect::<Vec<_>>();
 
         let docs_builder_fn = if self.attrs.always_capture_docs() {
-            quote!(docs)
-        } else {
             quote!(docs_always)
+        } else {
+            quote!(docs)
         };
 
         Some(quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -42,8 +42,8 @@ use syn::{
     Fields,
     Ident,
     Lifetime,
-    Variant,
 };
+use crate::attr::Attributes;
 
 #[proc_macro_derive(TypeInfo, attributes(scale_info, codec))]
 pub fn type_info(input: TokenStream) -> TokenStream {
@@ -54,68 +54,218 @@ pub fn type_info(input: TokenStream) -> TokenStream {
 }
 
 fn generate(input: TokenStream2) -> Result<TokenStream2> {
-    let mut tokens = quote! {};
-    tokens.extend(generate_type(input)?);
-    Ok(tokens)
-}
-
-fn generate_type(input: TokenStream2) -> Result<TokenStream2> {
-    let ast: DeriveInput = syn::parse2(input.clone())?;
-
-    let attrs = attr::Attributes::from_ast(&ast)?;
-
-    let scale_info = crate_name_ident("scale-info")?;
-
-    let ident = &ast.ident;
-
-    let where_clause = trait_bounds::make_where_clause(
-        &attrs,
-        ident,
-        &ast.generics,
-        &ast.data,
-        &scale_info,
-    )?;
-
-    let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
-
-    let type_params = ast.generics.type_params().map(|tp| {
-        let ty_ident = &tp.ident;
-        let ty = if attrs.skip_type_params().map_or(true, |skip| !skip.skip(tp)) {
-            quote! { ::core::option::Option::Some(:: #scale_info ::meta_type::<#ty_ident>()) }
-        } else {
-            quote! { ::core::option::Option::None }
-        };
-        quote! {
-            :: #scale_info ::TypeParameter::new(::core::stringify!(#ty_ident), #ty)
-        }
-    });
-
-    let build_type = match &ast.data {
-        Data::Struct(ref s) => generate_composite_type(s, &scale_info),
-        Data::Enum(ref e) => generate_variant_type(e, &scale_info),
-        Data::Union(_) => return Err(Error::new_spanned(input, "Unions not supported")),
-    };
-    let docs = generate_docs(&ast.attrs);
-
-    let type_info_impl = quote! {
-        impl #impl_generics :: #scale_info ::TypeInfo for #ident #ty_generics #where_clause {
-            type Identity = Self;
-            fn type_info() -> :: #scale_info ::Type {
-                :: #scale_info ::Type::builder()
-                    .path(:: #scale_info ::Path::new(::core::stringify!(#ident), ::core::module_path!()))
-                    .type_params(:: #scale_info ::prelude::vec![ #( #type_params ),* ])
-                    #docs
-                    .#build_type
-            }
-        }
-    };
-
+    let type_info_impl = TypeInfoImpl::parse(input)?;
+    let type_info_impl_toks = type_info_impl.expand()?;
     Ok(quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
         const _: () = {
-            #type_info_impl;
+            #type_info_impl_toks;
         };
     })
+}
+
+struct TypeInfoImpl {
+    ast: DeriveInput,
+    scale_info: Ident,
+    attrs: Attributes,
+}
+
+impl TypeInfoImpl {
+    fn parse(input: TokenStream2) -> Result<Self> {
+        let ast: DeriveInput = syn::parse2(input.clone())?;
+        let scale_info = crate_name_ident("scale-info")?;
+        let attrs = attr::Attributes::from_ast(&ast)?;
+
+        Ok(Self { ast, scale_info, attrs })
+    }
+
+    fn expand(&self) -> Result<TokenStream2> {
+        let ident = &self.ast.ident;
+        let scale_info = &self.scale_info;
+
+        let where_clause = trait_bounds::make_where_clause(
+            &self.attrs,
+            ident,
+            &self.ast.generics,
+            &self.ast.data,
+            &self.scale_info,
+        )?;
+
+        let (impl_generics, ty_generics, _) = self.ast.generics.split_for_impl();
+
+        let type_params = self.ast.generics.type_params().map(|tp| {
+            let ty_ident = &tp.ident;
+            let ty = if self.attrs.skip_type_params().map_or(true, |skip| !skip.skip(tp)) {
+                quote! { ::core::option::Option::Some(:: #scale_info ::meta_type::<#ty_ident>()) }
+            } else {
+                quote! { ::core::option::Option::None }
+            };
+            quote! {
+                :: #scale_info ::TypeParameter::new(::core::stringify!(#ty_ident), #ty)
+            }
+        });
+
+        let build_type = match &self.ast.data {
+            Data::Struct(ref s) => self.generate_composite_type(s),
+            Data::Enum(ref e) => self.generate_variant_type(e, &scale_info),
+            Data::Union(_) => return Err(Error::new_spanned(&self.ast, "Unions not supported")),
+        };
+        let docs = self.generate_docs(&self.ast.attrs);
+
+        Ok(quote! {
+            impl #impl_generics :: #scale_info ::TypeInfo for #ident #ty_generics #where_clause {
+                type Identity = Self;
+                fn type_info() -> :: #scale_info ::Type {
+                    :: #scale_info ::Type::builder()
+                        .path(:: #scale_info ::Path::new(::core::stringify!(#ident), ::core::module_path!()))
+                        .type_params(:: #scale_info ::prelude::vec![ #( #type_params ),* ])
+                        #docs
+                        .#build_type
+                }
+            }
+        })
+    }
+
+    fn generate_composite_type(&self, data_struct: &DataStruct) -> TokenStream2 {
+        let fields = match data_struct.fields {
+            Fields::Named(ref fs) => {
+                let fields = self.generate_fields(&fs.named);
+                quote! { named()#( #fields )* }
+            }
+            Fields::Unnamed(ref fs) => {
+                let fields = self.generate_fields(&fs.unnamed);
+                quote! { unnamed()#( #fields )* }
+            }
+            Fields::Unit => {
+                quote! {
+                    unit()
+                }
+            }
+        };
+        let scale_info = &self.scale_info;
+        quote! {
+            composite(:: #scale_info ::build::Fields::#fields)
+        }
+    }
+
+    fn generate_fields(&self, fields: &Punctuated<Field, Comma>) -> Vec<TokenStream2> {
+        fields
+            .iter()
+            .filter(|f| !utils::should_skip(&f.attrs))
+            .map(|f| {
+                let (ty, ident) = (&f.ty, &f.ident);
+                // Replace any field lifetime params with `static to prevent "unnecessary lifetime parameter"
+                // warning. Any lifetime parameters are specified as 'static in the type of the impl.
+                struct StaticLifetimesReplace;
+                impl VisitMut for StaticLifetimesReplace {
+                    fn visit_lifetime_mut(&mut self, lifetime: &mut Lifetime) {
+                        *lifetime = parse_quote!('static)
+                    }
+                }
+                let mut ty = ty.clone();
+                StaticLifetimesReplace.visit_type_mut(&mut ty);
+
+                let type_name = clean_type_string(&quote!(#ty).to_string());
+                let docs = self.generate_docs(&f.attrs);
+                let type_of_method = if utils::is_compact(f) {
+                    quote!(compact)
+                } else {
+                    quote!(ty)
+                };
+                let name = if let Some(ident) = ident {
+                    quote!(.name(::core::stringify!(#ident)))
+                } else {
+                    quote!()
+                };
+                quote!(
+                    .field(|f| f
+                        .#type_of_method::<#ty>()
+                        #name
+                        .type_name(#type_name)
+                        #docs
+                    )
+                )
+            })
+            .collect()
+    }
+
+    fn generate_variant_type(&self, data_enum: &DataEnum, scale_info: &Ident) -> TokenStream2 {
+        let variants = &data_enum.variants;
+
+        let variants = variants
+            .into_iter()
+            .filter(|v| !utils::should_skip(&v.attrs))
+            .enumerate()
+            .map(|(i, v)| {
+                let ident = &v.ident;
+                let v_name = quote! {::core::stringify!(#ident) };
+                let docs = self.generate_docs(&v.attrs);
+                let index = utils::variant_index(v, i);
+
+                let fields = match v.fields {
+                    Fields::Named(ref fs) => {
+                        let fields = self.generate_fields(&fs.named);
+                        Some(quote! {
+                            .fields(:: #scale_info::build::Fields::named()
+                                #( #fields )*
+                            )
+                        })
+                    }
+                    Fields::Unnamed(ref fs) => {
+                        let fields = self.generate_fields(&fs.unnamed);
+                        Some(quote! {
+                            .fields(:: #scale_info::build::Fields::unnamed()
+                                #( #fields )*
+                            )
+                        })
+                    }
+                    Fields::Unit => None
+                };
+
+                quote! {
+                    .variant(#v_name, |v|
+                        v
+                            .index(#index as ::core::primitive::u8)
+                            #fields
+                            #docs
+                    )
+                }
+            });
+        quote! {
+            variant(
+                :: #scale_info ::build::Variants::new()
+                    #( #variants )*
+            )
+        }
+    }
+
+    fn generate_docs(&self, attrs: &[syn::Attribute]) -> Option<TokenStream2> {
+        let docs = attrs
+            .iter()
+            .filter_map(|attr| {
+                if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
+                    if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
+                        if let syn::Lit::Str(lit) = &meta.lit {
+                            let lit_value = lit.value();
+                            let stripped = lit_value.strip_prefix(' ').unwrap_or(&lit_value);
+                            let lit: syn::Lit = parse_quote!(#stripped);
+                            Some(lit)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Some(quote! {
+            .docs(&[ #( #docs ),* ])
+        })
+    }
 }
 
 /// Get the name of a crate, to be robust against renamed dependencies.
@@ -129,49 +279,6 @@ fn crate_name_ident(name: &str) -> Result<Ident> {
             }
         })
         .map_err(|e| syn::Error::new(Span::call_site(), &e))
-}
-
-type FieldsList = Punctuated<Field, Comma>;
-
-fn generate_fields(fields: &FieldsList) -> Vec<TokenStream2> {
-    fields
-        .iter()
-        .filter(|f| !utils::should_skip(&f.attrs))
-        .map(|f| {
-            let (ty, ident) = (&f.ty, &f.ident);
-            // Replace any field lifetime params with `static to prevent "unnecessary lifetime parameter"
-            // warning. Any lifetime parameters are specified as 'static in the type of the impl.
-            struct StaticLifetimesReplace;
-            impl VisitMut for StaticLifetimesReplace {
-                fn visit_lifetime_mut(&mut self, lifetime: &mut Lifetime) {
-                    *lifetime = parse_quote!('static)
-                }
-            }
-            let mut ty = ty.clone();
-            StaticLifetimesReplace.visit_type_mut(&mut ty);
-
-            let type_name = clean_type_string(&quote!(#ty).to_string());
-            let docs = generate_docs(&f.attrs);
-            let type_of_method = if utils::is_compact(f) {
-                quote!(compact)
-            } else {
-                quote!(ty)
-            };
-            let name = if let Some(ident) = ident {
-                quote!(.name(::core::stringify!(#ident)))
-            } else {
-                quote!()
-            };
-            quote!(
-                .field(|f| f
-                    .#type_of_method::<#ty>()
-                    #name
-                    .type_name(#type_name)
-                    #docs
-                )
-            )
-        })
-        .collect()
 }
 
 fn clean_type_string(input: &str) -> String {
@@ -193,143 +300,4 @@ fn clean_type_string(input: &str) -> String {
         .replace(" >", ">")
         .replace("& \'", "&'")
         .replace("&\'", "&'")
-}
-
-fn generate_composite_type(data_struct: &DataStruct, scale_info: &Ident) -> TokenStream2 {
-    let fields = match data_struct.fields {
-        Fields::Named(ref fs) => {
-            let fields = generate_fields(&fs.named);
-            quote! { named()#( #fields )* }
-        }
-        Fields::Unnamed(ref fs) => {
-            let fields = generate_fields(&fs.unnamed);
-            quote! { unnamed()#( #fields )* }
-        }
-        Fields::Unit => {
-            quote! {
-                unit()
-            }
-        }
-    };
-    quote! {
-        composite(:: #scale_info ::build::Fields::#fields)
-    }
-}
-
-type VariantList = Punctuated<Variant, Comma>;
-
-fn generate_c_like_enum_def(variants: &VariantList, scale_info: &Ident) -> TokenStream2 {
-    let variants = variants
-        .into_iter()
-        .filter(|v| !utils::should_skip(&v.attrs))
-        .enumerate()
-        .map(|(i, v)| {
-            let name = &v.ident;
-            let index = utils::variant_index(v, i);
-            let docs = generate_docs(&v.attrs);
-            quote! {
-                .variant(::core::stringify!(#name), |v|
-                    v
-                        .index(#index as ::core::primitive::u8)
-                        #docs
-                )
-            }
-        });
-    quote! {
-        variant(
-            :: #scale_info ::build::Variants::new()
-                #( #variants )*
-        )
-    }
-}
-
-fn is_c_like_enum(variants: &VariantList) -> bool {
-    // One of the variants has an explicit discriminant, or…
-    variants.iter().any(|v| v.discriminant.is_some()) ||
-        // …all variants are unit
-        variants.iter().all(|v| matches!(v.fields, Fields::Unit))
-}
-
-fn generate_variant_type(data_enum: &DataEnum, scale_info: &Ident) -> TokenStream2 {
-    let variants = &data_enum.variants;
-
-    if is_c_like_enum(variants) {
-        return generate_c_like_enum_def(variants, scale_info)
-    }
-
-    let variants = variants
-        .into_iter()
-        .filter(|v| !utils::should_skip(&v.attrs))
-        .enumerate()
-        .map(|(i, v)| {
-            let ident = &v.ident;
-            let v_name = quote! {::core::stringify!(#ident) };
-            let docs = generate_docs(&v.attrs);
-            let index = utils::variant_index(v, i);
-
-            let fields = match v.fields {
-                Fields::Named(ref fs) => {
-                    let fields = generate_fields(&fs.named);
-                    quote! {
-                        :: #scale_info::build::Fields::named()
-                            #( #fields )*
-                    }
-                }
-                Fields::Unnamed(ref fs) => {
-                    let fields = generate_fields(&fs.unnamed);
-                    quote! {
-                        :: #scale_info::build::Fields::unnamed()
-                            #( #fields )*
-                    }
-                }
-                Fields::Unit => {
-                    quote! {
-                        :: #scale_info::build::Fields::unit()
-                    }
-                }
-            };
-
-            quote! {
-                .variant(#v_name, |v|
-                    v
-                        .index(#index as ::core::primitive::u8)
-                        .fields(#fields)
-                        #docs
-                )
-            }
-        });
-    quote! {
-        variant(
-            :: #scale_info ::build::Variants::new()
-                #( #variants )*
-        )
-    }
-}
-
-fn generate_docs(attrs: &[syn::Attribute]) -> Option<TokenStream2> {
-    let docs = attrs
-        .iter()
-        .filter_map(|attr| {
-            if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
-                if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
-                    if let syn::Lit::Str(lit) = &meta.lit {
-                        let lit_value = lit.value();
-                        let stripped = lit_value.strip_prefix(' ').unwrap_or(&lit_value);
-                        let lit: syn::Lit = parse_quote!(#stripped);
-                        Some(lit)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-
-    Some(quote! {
-        .docs(&[ #( #docs ),* ])
-    })
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -111,7 +111,7 @@ impl TypeInfoImpl {
 
         let build_type = match &self.ast.data {
             Data::Struct(ref s) => self.generate_composite_type(s),
-            Data::Enum(ref e) => self.generate_variant_type(e, &scale_info),
+            Data::Enum(ref e) => self.generate_variant_type(e, scale_info),
             Data::Union(_) => {
                 return Err(Error::new_spanned(&self.ast, "Unions not supported"))
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -251,7 +251,7 @@ impl TypeInfoImpl {
 
     fn generate_docs(&self, attrs: &[syn::Attribute]) -> Option<TokenStream2> {
         if self.attrs.never_capture_docs() {
-            return None;
+            return None
         }
 
         let docs = attrs
@@ -278,9 +278,9 @@ impl TypeInfoImpl {
             .collect::<Vec<_>>();
 
         let docs_builder_fn = if self.attrs.always_capture_docs() {
-            quote!( docs )
+            quote!(docs)
         } else {
-            quote!( docs_always )
+            quote!(docs_always)
         };
 
         Some(quote! {

--- a/src/build.rs
+++ b/src/build.rs
@@ -223,6 +223,12 @@ impl<S> TypeBuilder<S> {
     pub fn docs(self, _docs: &'static [&'static str]) -> Self {
         self
     }
+
+    /// Set the type documentation, always captured even if the "docs" feature is not enabled.
+    pub fn docs_always(mut self, docs: &[&'static str]) -> Self {
+        self.docs = docs.to_vec();
+        self
+    }
 }
 
 /// A fields builder has no fields (e.g. a unit struct)
@@ -426,6 +432,18 @@ impl<N, T> FieldBuilder<N, T> {
     pub fn docs(self, _docs: &'static [&'static str]) -> FieldBuilder<N, T> {
         self
     }
+
+    /// Initialize the documentation of a field, always captured even if the "docs" feature is not
+    /// enabled.
+    pub fn docs_always(self, docs: &'static[&'static str]) -> Self {
+        FieldBuilder {
+            name: self.name,
+            ty: self.ty,
+            type_name: self.type_name,
+            docs,
+            marker: PhantomData,
+        }
+    }
 }
 
 impl<N> FieldBuilder<N, field_state::TypeAssigned> {
@@ -545,6 +563,13 @@ impl<S> VariantBuilder<S> {
     #[inline]
     /// Doc capture is not enabled via the "docs" feature so this is a no-op.
     pub fn docs(self, _docs: &[&'static str]) -> Self {
+        self
+    }
+
+    /// Initialize the variant's documentation, always captured even if the "docs" feature is not
+    /// enabled.
+    pub fn docs_always(mut self, docs: &[&'static str]) -> Self {
+        self.docs = docs.to_vec();
         self
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -435,7 +435,7 @@ impl<N, T> FieldBuilder<N, T> {
 
     /// Initialize the documentation of a field, always captured even if the "docs" feature is not
     /// enabled.
-    pub fn docs_always(self, docs: &'static[&'static str]) -> Self {
+    pub fn docs_always(self, docs: &'static [&'static str]) -> Self {
         FieldBuilder {
             name: self.name,
             ty: self.ty,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,21 @@
 //! **Note:** When using `bounds` without `skip_type_params`, it is therefore required to manually
 //! add a `TypeInfo` bound for any non skipped type parameters. The compiler will let you know.
 //!
+//! #### `#[scale_info(capture_docs = {bool})]`
+//!
+//! Docs for types, fields and variants can all be captured by the `docs` feature being enabled.
+//! This can be overridden using the `capture_docs` attribute:
+//!
+//! `#[scale_info(capture_docs = false)]` will *not* capture docs for the annotated type even if
+//! the `docs` is enabled.
+//!
+//! `#[scale_info(capture_docs = true)]` will capture docs for the annotated type even if the
+//! `docs` feature is *not* enabled.
+//!
+//! This is useful e.g. when compiling metadata into a Wasm blob, and it is desirable to keep the
+//! binary size as small as possible, so the `docs` feature would be disabled. In case the docs for
+//! some types is necessary they could be enabled on a per-type basis with the above attribute.
+//!
 //! # Forms
 //!
 //! To bridge between compile-time type information and runtime the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,16 +190,19 @@
 //! **Note:** When using `bounds` without `skip_type_params`, it is therefore required to manually
 //! add a `TypeInfo` bound for any non skipped type parameters. The compiler will let you know.
 //!
-//! #### `#[scale_info(capture_docs = {bool})]`
+//! #### `#[scale_info(capture_docs = "default|always|never")]`
 //!
 //! Docs for types, fields and variants can all be captured by the `docs` feature being enabled.
 //! This can be overridden using the `capture_docs` attribute:
 //!
-//! `#[scale_info(capture_docs = false)]` will *not* capture docs for the annotated type even if
-//! the `docs` is enabled.
+//! `#[scale_info(capture_docs = "default")]` will capture docs iff the `docs` feature is enabled.
+//! This is the default if `capture_docs` is not specified.
 //!
-//! `#[scale_info(capture_docs = true)]` will capture docs for the annotated type even if the
+//! `#[scale_info(capture_docs = "always")]` will capture docs for the annotated type even if the
 //! `docs` feature is *not* enabled.
+//!
+//! `#[scale_info(capture_docs = "never")]` will *not* capture docs for the annotated type even if
+//! the `docs` is enabled.
 //!
 //! This is useful e.g. when compiling metadata into a Wasm blob, and it is desirable to keep the
 //! binary size as small as possible, so the `docs` feature would be disabled. In case the docs for

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scale-info = { path = "..", features = ["derive", "serde", "decode", "docs"] }
+scale-info = { path = "..", features = ["derive", "serde", "decode"] }
 
 scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 serde = "1.0"

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scale-info = { path = "..", features = ["derive", "serde", "decode"] }
+scale-info = { path = "..", features = ["derive", "serde", "decode", "docs"] }
 
 scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 serde = "1.0"

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -684,26 +684,26 @@ fn always_capture_docs() {
 
     let enum_ty = Type::builder()
         .path(Path::new("E", "derive"))
-        .docs(&["Type docs"])
+        .docs_always(&["Type docs"])
         .variant(Variants::new().variant("A", |v| {
             v.index(0)
                 .fields(Fields::named().field(|f| {
                     f.ty::<u32>()
                         .name("a")
                         .type_name("u32")
-                        .docs(&["field docs"])
+                        .docs_always(&["field docs"])
                 }))
-                .docs(&["Variant docs"])
+                .docs_always(&["Variant docs"])
         }));
 
     let struct_ty = Type::builder()
         .path(Path::new("S", "derive"))
-        .docs(&["Type docs"])
+        .docs_always(&["Type docs"])
         .composite(Fields::named().field(|f| {
             f.ty::<bool>()
                 .name("a")
                 .type_name("bool")
-                .docs(&["field docs"])
+                .docs_always(&["field docs"])
         }));
 
     assert_type!(E, enum_ty);

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -620,6 +620,104 @@ fn doc_capture_works() {
 }
 
 #[test]
+fn never_capture_docs() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[scale_info(capture_docs = false)]
+    /// Type docs
+    enum E {
+        /// Variant docs
+        A {
+            /// field docs
+            a: u32
+        }
+    }
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[scale_info(capture_docs = false)]
+    /// Type docs
+    struct S {
+        /// field docs
+        a: bool
+    }
+
+    let enum_ty = Type::builder().path(Path::new("E", "derive")).variant(
+        Variants::new()
+            .variant("A", |v| {
+                v.index(0).fields(
+                    Fields::named().field(|f| f.ty::<u32>().name("a").type_name("u32")),
+                )
+            })
+    );
+
+    let struct_ty = Type::builder().path(Path::new("S", "derive"))
+        .composite(
+        Fields::named()
+            .field(|f| {
+                f.ty::<bool>()
+                    .name("a")
+                    .type_name("bool")
+            })
+    );
+
+    assert_type!(E, enum_ty);
+    assert_type!(S, struct_ty);
+}
+
+#[test]
+fn always_capture_docs() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[scale_info(capture_docs = true)]
+    /// Type docs
+    enum E {
+        /// Variant docs
+        A {
+            /// field docs
+            a: u32
+        }
+    }
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[scale_info(capture_docs = true)]
+    /// Type docs
+    struct S {
+        /// field docs
+        a: bool
+    }
+
+    let enum_ty = Type::builder()
+        .path(Path::new("E", "derive"))
+        .docs(&["Type docs"])
+        .variant(
+            Variants::new()
+                .variant("A", |v| {
+                    v.index(0).fields(
+                        Fields::named().field(|f|
+                            f.ty::<u32>().name("a").type_name("u32").docs(&["field docs"])),
+                    ).docs(&["Variant docs"])
+                })
+        );
+
+    let struct_ty = Type::builder().path(Path::new("S", "derive"))
+        .docs(&["Type docs"])
+        .composite(
+            Fields::named()
+                .field(|f| {
+                    f.ty::<bool>()
+                        .name("a")
+                        .type_name("bool")
+                        .docs(&["field docs"])
+                })
+        );
+
+    assert_type!(E, enum_ty);
+    assert_type!(S, struct_ty);
+}
+
+#[test]
 fn skip_type_params_nested() {
     #[allow(unused)]
     #[derive(TypeInfo)]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -629,8 +629,8 @@ fn never_capture_docs() {
         /// Variant docs
         A {
             /// field docs
-            a: u32
-        }
+            a: u32,
+        },
     }
 
     #[allow(unused)]
@@ -639,27 +639,21 @@ fn never_capture_docs() {
     /// Type docs
     struct S {
         /// field docs
-        a: bool
+        a: bool,
     }
 
-    let enum_ty = Type::builder().path(Path::new("E", "derive")).variant(
-        Variants::new()
-            .variant("A", |v| {
+    let enum_ty =
+        Type::builder()
+            .path(Path::new("E", "derive"))
+            .variant(Variants::new().variant("A", |v| {
                 v.index(0).fields(
                     Fields::named().field(|f| f.ty::<u32>().name("a").type_name("u32")),
                 )
-            })
-    );
+            }));
 
-    let struct_ty = Type::builder().path(Path::new("S", "derive"))
-        .composite(
-        Fields::named()
-            .field(|f| {
-                f.ty::<bool>()
-                    .name("a")
-                    .type_name("bool")
-            })
-    );
+    let struct_ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .composite(Fields::named().field(|f| f.ty::<bool>().name("a").type_name("bool")));
 
     assert_type!(E, enum_ty);
     assert_type!(S, struct_ty);
@@ -675,8 +669,8 @@ fn always_capture_docs() {
         /// Variant docs
         A {
             /// field docs
-            a: u32
-        }
+            a: u32,
+        },
     }
 
     #[allow(unused)]
@@ -685,33 +679,32 @@ fn always_capture_docs() {
     /// Type docs
     struct S {
         /// field docs
-        a: bool
+        a: bool,
     }
 
     let enum_ty = Type::builder()
         .path(Path::new("E", "derive"))
         .docs(&["Type docs"])
-        .variant(
-            Variants::new()
-                .variant("A", |v| {
-                    v.index(0).fields(
-                        Fields::named().field(|f|
-                            f.ty::<u32>().name("a").type_name("u32").docs(&["field docs"])),
-                    ).docs(&["Variant docs"])
-                })
-        );
-
-    let struct_ty = Type::builder().path(Path::new("S", "derive"))
-        .docs(&["Type docs"])
-        .composite(
-            Fields::named()
-                .field(|f| {
-                    f.ty::<bool>()
+        .variant(Variants::new().variant("A", |v| {
+            v.index(0)
+                .fields(Fields::named().field(|f| {
+                    f.ty::<u32>()
                         .name("a")
-                        .type_name("bool")
+                        .type_name("u32")
                         .docs(&["field docs"])
-                })
-        );
+                }))
+                .docs(&["Variant docs"])
+        }));
+
+    let struct_ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .docs(&["Type docs"])
+        .composite(Fields::named().field(|f| {
+            f.ty::<bool>()
+                .name("a")
+                .type_name("bool")
+                .docs(&["field docs"])
+        }));
 
     assert_type!(E, enum_ty);
     assert_type!(S, struct_ty);

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -623,7 +623,7 @@ fn doc_capture_works() {
 fn never_capture_docs() {
     #[allow(unused)]
     #[derive(TypeInfo)]
-    #[scale_info(capture_docs = false)]
+    #[scale_info(capture_docs = "never")]
     /// Type docs
     enum E {
         /// Variant docs
@@ -635,7 +635,7 @@ fn never_capture_docs() {
 
     #[allow(unused)]
     #[derive(TypeInfo)]
-    #[scale_info(capture_docs = false)]
+    #[scale_info(capture_docs = "never")]
     /// Type docs
     struct S {
         /// field docs
@@ -663,7 +663,7 @@ fn never_capture_docs() {
 fn always_capture_docs() {
     #[allow(unused)]
     #[derive(TypeInfo)]
-    #[scale_info(capture_docs = true)]
+    #[scale_info(capture_docs = "always")]
     /// Type docs
     enum E {
         /// Variant docs
@@ -675,7 +675,7 @@ fn always_capture_docs() {
 
     #[allow(unused)]
     #[derive(TypeInfo)]
-    #[scale_info(capture_docs = true)]
+    #[scale_info(capture_docs = "always")]
     /// Type docs
     struct S {
         /// field docs

--- a/test_suite/tests/ui/fail_with_invalid_capture_docs_attr.rs
+++ b/test_suite/tests/ui/fail_with_invalid_capture_docs_attr.rs
@@ -1,0 +1,12 @@
+use scale_info::TypeInfo;
+use scale::Encode;
+
+#[derive(TypeInfo, Encode)]
+#[scale_info(capture_docs = "invalid")]
+/// Docs
+struct InvalidDocsCapture {
+    /// Docs
+    a: u8,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/fail_with_invalid_capture_docs_attr.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_capture_docs_attr.stderr
@@ -1,0 +1,5 @@
+error: Invalid capture_docs value. Expected one of: "default", "always", "never"
+ --> $DIR/fail_with_invalid_capture_docs_attr.rs:5:29
+  |
+5 | #[scale_info(capture_docs = "invalid")]
+  |                             ^^^^^^^^^


### PR DESCRIPTION
Annotating a type with `#[scale_info(capture_docs = "always|never|default")]` will override the default docs capturing enabled by the `docs` feature.

 ### `#[scale_info(capture_docs = "never")]`
Never capture docs for a specific type even if the `docs` feature is enabled.

 ### `#[scale_info(capture_docs = "always")]`
Always capture docs for a specific type even if the `docs` feature is not enabled.

 ### `#[scale_info(capture_docs = "default")]`
Captures docs *iff* the `docs` feature is enabled, which is the default if this attribute is not present

This will allow e.g. including required docs for enums such as `Call`, `Error` etc in substrate pallets without adding docs for every single other type, thus bloating the runtime size.

### Derive refactoring

Much of the changes in the diff are because of the `TypeInfoImpl` type I have introduced into the derive implementation, which allows sharing of the attributes and other state to avoid it having to be passed around through all the methods. We could do some further refactoring here but this is a good first step.