### PR TITLE
Add support for Range and RangeInclusive

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -26,6 +26,7 @@ use crate::prelude::{
     marker::PhantomData,
     string::String,
     vec::Vec,
+    ops::Range,
 };
 
 use crate::{
@@ -38,6 +39,8 @@ use crate::{
     TypeDefPrimitive,
     TypeDefSequence,
     TypeDefTuple,
+    TypeDefRange,
+    TypeDefRangeInclusive,
     TypeInfo,
 };
 use core::num::{
@@ -52,6 +55,7 @@ use core::num::{
     NonZeroU64,
     NonZeroU8,
 };
+use std::ops::RangeInclusive;
 
 macro_rules! impl_metadata_for_primitives {
     ( $( $t:ty => $ident_kind:expr, )* ) => { $(
@@ -344,6 +348,26 @@ where
     type Identity = Self;
     fn type_info() -> Type {
         TypeDefCompact::new(MetaType::new::<T>()).into()
+    }
+}
+
+impl<Idx> TypeInfo for Range<Idx>
+where
+    Idx: TypeInfo + 'static + PartialOrd + core::fmt::Debug,
+{
+    type Identity = Self;
+    fn type_info() -> Type {
+        TypeDefRange::new::<Idx>().into()
+    }
+}
+
+impl<Idx> TypeInfo for RangeInclusive<Idx>
+where
+    Idx: TypeInfo + 'static + PartialOrd + core::fmt::Debug,
+{
+    type Identity = Self;
+    fn type_info() -> Type {
+        TypeDefRangeInclusive::new::<Idx>().into()
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -23,6 +23,7 @@ use crate::prelude::{
         BTreeSet,
         VecDeque,
     },
+    fmt,
     marker::PhantomData,
     ops::{
         Range,
@@ -354,7 +355,7 @@ where
 
 impl<Idx> TypeInfo for Range<Idx>
 where
-    Idx: TypeInfo + 'static + PartialOrd + core::fmt::Debug,
+    Idx: TypeInfo + 'static + PartialOrd + fmt::Debug,
 {
     type Identity = Self;
     fn type_info() -> Type {
@@ -364,7 +365,7 @@ where
 
 impl<Idx> TypeInfo for RangeInclusive<Idx>
 where
-    Idx: TypeInfo + 'static + PartialOrd + core::fmt::Debug,
+    Idx: TypeInfo + 'static + PartialOrd + fmt::Debug,
 {
     type Identity = Self;
     fn type_info() -> Type {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -24,9 +24,12 @@ use crate::prelude::{
         VecDeque,
     },
     marker::PhantomData,
+    ops::{
+        Range,
+        RangeInclusive,
+    },
     string::String,
     vec::Vec,
-    ops::Range,
 };
 
 use crate::{
@@ -37,10 +40,10 @@ use crate::{
     TypeDefArray,
     TypeDefCompact,
     TypeDefPrimitive,
-    TypeDefSequence,
-    TypeDefTuple,
     TypeDefRange,
     TypeDefRangeInclusive,
+    TypeDefSequence,
+    TypeDefTuple,
     TypeInfo,
 };
 use core::num::{
@@ -55,7 +58,6 @@ use core::num::{
     NonZeroU64,
     NonZeroU8,
 };
-use std::ops::RangeInclusive;
 
 macro_rules! impl_metadata_for_primitives {
     ( $( $t:ty => $ident_kind:expr, )* ) => { $(

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -41,7 +41,6 @@ use crate::{
     TypeDefCompact,
     TypeDefPrimitive,
     TypeDefRange,
-    TypeDefRangeInclusive,
     TypeDefSequence,
     TypeDefTuple,
     TypeInfo,
@@ -359,7 +358,7 @@ where
 {
     type Identity = Self;
     fn type_info() -> Type {
-        TypeDefRange::new::<Idx>().into()
+        TypeDefRange::new::<Idx>(false).into()
     }
 }
 
@@ -369,7 +368,7 @@ where
 {
     type Identity = Self;
     fn type_info() -> Type {
-        TypeDefRangeInclusive::new::<Idx>().into()
+        TypeDefRange::new::<Idx>(true).into()
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -35,6 +35,7 @@ cfg_if! {
             marker,
             mem,
             num,
+            ops,
             string,
             vec,
         };
@@ -56,6 +57,7 @@ cfg_if! {
             marker,
             mem,
             num,
+            ops,
         };
     }
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::prelude::{
+    fmt,
     vec,
     vec::Vec,
 };
@@ -434,10 +435,10 @@ pub struct TypeDefRange<T: Form = MetaForm> {
 
 impl TypeDefRange {
     /// Creates a new [`TypeDefRange`] for the supplied index type. Use the `inclusive` parameter to
-    /// distinguish between [`Range`] and [`RangeInclusive`] range types.
+    /// distinguish between [`core::ops::Range`] and [`core::ops::RangeInclusive`] range types.
     pub fn new<Idx>(inclusive: bool) -> Self
     where
-        Idx: PartialOrd + core::fmt::Debug + TypeInfo + 'static,
+        Idx: PartialOrd + fmt::Debug + TypeInfo + 'static,
     {
         Self {
             start: MetaType::new::<Idx>(),

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -14,6 +14,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::ops::{Range, RangeInclusive};
+
 use pretty_assertions::assert_eq;
 use scale::Encode;
 use scale_info::{
@@ -837,6 +839,25 @@ fn docs_attr() {
         .composite(Fields::unit());
 
     assert_type!(S, ty);
+}
+
+#[test]
+fn ranges() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Rangey {
+        open: Range<u8>,
+        closed: RangeInclusive<u16>,
+    }
+
+    let ty = Type::builder()
+        .path(Path::new("Rangey", "derive"))
+        .composite(Fields::named()
+            .field(|f| f.ty::<Range<u8>>().name("open").type_name("Range<u8>"))
+            .field(|f| f.ty::<RangeInclusive<u16>>().name("closed").type_name("RangeInclusive<u16>"))
+        );
+
+    assert_type!(Rangey, ty);
 }
 
 #[rustversion::nightly]

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -14,7 +14,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::ops::{Range, RangeInclusive};
+use core::ops::{
+    Range,
+    RangeInclusive,
+};
 
 use pretty_assertions::assert_eq;
 use scale::Encode;
@@ -852,9 +855,14 @@ fn ranges() {
 
     let ty = Type::builder()
         .path(Path::new("Rangey", "derive"))
-        .composite(Fields::named()
-            .field(|f| f.ty::<Range<u8>>().name("open").type_name("Range<u8>"))
-            .field(|f| f.ty::<RangeInclusive<u16>>().name("closed").type_name("RangeInclusive<u16>"))
+        .composite(
+            Fields::named()
+                .field(|f| f.ty::<Range<u8>>().name("open").type_name("Range<u8>"))
+                .field(|f| {
+                    f.ty::<RangeInclusive<u16>>()
+                        .name("closed")
+                        .type_name("RangeInclusive<u16>")
+                }),
         );
 
     assert_type!(Rangey, ty);

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -420,8 +420,6 @@ fn test_ranges() {
 
     let registry: PortableRegistry = registry.into();
     assert_eq!(serde_json::to_value(registry).unwrap(), expected);
-
-    // assert_json_for_type::<TypeWithRanges>();
 }
 
 #[test]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -372,17 +372,56 @@ fn test_ranges() {
         closed_range: RangeInclusive<u64>,
     }
 
-    assert_json_for_type::<TypeWithRanges>(json!({
-        "path": ["json", "TypeWithRanges"],
-        "def": {
-            "composite": {
-                "fields": [
-                    { "name": "open_range", "type": 0, "typeName": "Range<u8>" },
-                    { "name": "closed_range", "type": 2, "typeName": "RangeInclusive<u64>" },
-                ],
+    let mut registry = Registry::new();
+    registry.register_type(&meta_type::<TypeWithRanges>());
+
+    let expected = json!({
+        "types": [
+            {
+                "id": 0,
+                "type": {
+                    "path": ["json", "TypeWithRanges"],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                { "name": "open_range", "type": 1, "typeName": "Range<u8>" },
+                                { "name": "closed_range", "type": 3, "typeName": "RangeInclusive<u64>" },
+                            ],
+                        },
+                    }
+                }
             },
-        }
-    }));
+            {
+                "id": 1,
+                "type": {
+                    "def": { "range": { "start": 2, "end": 2, "inclusive": false} },
+                }
+            },
+            {
+                "id": 2,
+                "type": {
+                    "def": { "primitive": "u8" },
+                }
+            },
+            {
+                "id": 3,
+                "type": {
+                    "def": { "range": { "start": 4, "end": 4, "inclusive": true} },
+                }
+            },
+            {
+                "id": 4,
+                "type": {
+                    "def": { "primitive": "u64" },
+                }
+            }
+        ],
+    });
+
+    let registry: PortableRegistry = registry.into();
+    assert_eq!(serde_json::to_value(registry).unwrap(), expected);
+
+    // assert_json_for_type::<TypeWithRanges>();
 }
 
 #[test]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -20,6 +20,10 @@ use scale_info::prelude::{
     boxed::Box,
     collections::VecDeque,
     marker::PhantomData,
+    ops::{
+        Range,
+        RangeInclusive,
+    },
     string::String,
     vec,
     vec::Vec,
@@ -354,6 +358,27 @@ fn test_enum() {
                             { "name": "c", "type": 4, "typeName": "char" },
                         ],
                     }
+                ],
+            },
+        }
+    }));
+}
+
+#[test]
+fn test_ranges() {
+    #[derive(TypeInfo)]
+    struct TypeWithRanges {
+        open_range: Range<u8>,
+        closed_range: RangeInclusive<u64>,
+    }
+
+    assert_json_for_type::<TypeWithRanges>(json!({
+        "path": ["json", "TypeWithRanges"],
+        "def": {
+            "composite": {
+                "fields": [
+                    { "name": "open_range", "type": 0, "typeName": "Range<u8>" },
+                    { "name": "closed_range", "type": 2, "typeName": "RangeInclusive<u64>" },
                 ],
             },
         }


### PR DESCRIPTION
Adding support for `Range` and `RangeInclusive` (added in https://github.com/paritytech/parity-scale-codec/pull/269 to `parity-scale-codec` and to polkadot.js in https://github.com/polkadot-js/api/pull/3791).

Closes https://github.com/paritytech/scale-info/issues/123
