### PR TITLE
Update expected output for recent compilers

### DIFF
--- a/test_suite/tests/ui/fail_missing_derive.stderr
+++ b/test_suite/tests/ui/fail_missing_derive.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `PawType<u16>: TypeInfo` is not satisfied
   --> $DIR/fail_missing_derive.rs:17:5
    |
-14 | fn assert_type_info<T: TypeInfo + 'static>() {}
-   |                        -------- required by this bound in `assert_type_info`
-...
 17 |     assert_type_info::<Cat<bool, u8, u16>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypeInfo` is not implemented for `PawType<u16>`
    |
@@ -14,4 +11,9 @@ note: required because of the requirements on the impl of `TypeInfo` for `Cat<bo
    |          ^^^^^^^^
 8  | struct Cat<Tail, Ear, Paw> {
    |        ^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `assert_type_info`
+  --> $DIR/fail_missing_derive.rs:14:24
+   |
+14 | fn assert_type_info<T: TypeInfo + 'static>() {}
+   |                        ^^^^^^^^ required by this bound in `assert_type_info`
    = note: this error originates in the derive macro `TypeInfo` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test_suite/tests/ui/fail_unions.stderr
+++ b/test_suite/tests/ui/fail_unions.stderr
@@ -11,8 +11,11 @@ error: Unions not supported
 error[E0277]: the trait bound `Commonwealth: TypeInfo` is not satisfied
   --> $DIR/fail_unions.rs:13:24
    |
-10 | fn assert_type_info<T: TypeInfo + 'static>() {}
-   |                        -------- required by this bound in `assert_type_info`
-...
 13 |     assert_type_info::<Commonwealth>();
    |                        ^^^^^^^^^^^^ the trait `TypeInfo` is not implemented for `Commonwealth`
+   |
+note: required by a bound in `assert_type_info`
+  --> $DIR/fail_unions.rs:10:24
+   |
+10 | fn assert_type_info<T: TypeInfo + 'static>() {}
+   |                        ^^^^^^^^ required by this bound in `assert_type_info`


### PR DESCRIPTION
Looks like recent compilers made changes to the error output in a couple of cases.﻿
