### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2021-08-25
+### Added
+- Add type parameter getters [(#122)](https://github.com/paritytech/scale-info/pull/122)
+- Add support for Range and RangeInclusive [(#124)](https://github.com/paritytech/scale-info/pull/124), [(#126)](https://github.com/paritytech/scale-info/pull/126)
+
 ## [0.10.0] - 2021-07-29
 ### Added
 - Add capture_docs attribute [(#118)](https://github.com/paritytech/scale-info/pull/118)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add type parameter getters [(#122)](https://github.com/paritytech/scale-info/pull/122)
 - Add support for Range and RangeInclusive [(#124)](https://github.com/paritytech/scale-info/pull/124), [(#126)](https://github.com/paritytech/scale-info/pull/126)
+- Explicit codec indices for `TypeDef` and `TypeDefPrimitive` enums [(#127)](https://github.com/paritytech/scale-info/pull/127)
 
 ## [0.10.0] - 2021-07-29
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -247,14 +247,14 @@ pub enum TypeDef<T: Form = MetaForm> {
     Array(TypeDefArray<T>),
     /// A tuple type.
     Tuple(TypeDefTuple<T>),
-    /// A Range type.
-    Range(TypeDefRange<T>),
     /// A Rust primitive type.
     Primitive(TypeDefPrimitive),
     /// A type using the [`Compact`] encoding
     Compact(TypeDefCompact<T>),
     /// A type representing a sequence of bits.
     BitSequence(TypeDefBitSequence<T>),
+    /// A Range type.
+    Range(TypeDefRange<T>),
 }
 
 impl IntoPortable for TypeDef {
@@ -267,10 +267,10 @@ impl IntoPortable for TypeDef {
             TypeDef::Sequence(sequence) => sequence.into_portable(registry).into(),
             TypeDef::Array(array) => array.into_portable(registry).into(),
             TypeDef::Tuple(tuple) => tuple.into_portable(registry).into(),
-            TypeDef::Range(range) => range.into_portable(registry).into(),
             TypeDef::Primitive(primitive) => primitive.into(),
             TypeDef::Compact(compact) => compact.into_portable(registry).into(),
             TypeDef::BitSequence(bitseq) => bitseq.into_portable(registry).into(),
+            TypeDef::Range(range) => range.into_portable(registry).into(),
         }
     }
 }

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -225,6 +225,16 @@ where
 }
 
 /// The possible types a SCALE encodable Rust value could have.
+///
+/// # Note
+///
+/// In order to preserve backwards compatibility, variant indices are explicitly specified instead
+/// of depending on the default implicit ordering.
+///
+/// When adding a new variant, it must be added at the end with an incremented index.
+///
+/// When removing an existing variant, the rest of variant indices remain the same, and the removed
+/// index should not be reused.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -238,22 +248,31 @@ where
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
+    #[codec(index = 0)]
     Composite(TypeDefComposite<T>),
     /// A variant type (e.g. an enum)
+    #[codec(index = 1)]
     Variant(TypeDefVariant<T>),
     /// A sequence type with runtime known length.
+    #[codec(index = 2)]
     Sequence(TypeDefSequence<T>),
     /// An array type with compile-time known length.
+    #[codec(index = 3)]
     Array(TypeDefArray<T>),
     /// A tuple type.
+    #[codec(index = 4)]
     Tuple(TypeDefTuple<T>),
     /// A Rust primitive type.
+    #[codec(index = 5)]
     Primitive(TypeDefPrimitive),
     /// A type using the [`Compact`] encoding
+    #[codec(index = 6)]
     Compact(TypeDefCompact<T>),
     /// A type representing a sequence of bits.
+    #[codec(index = 7)]
     BitSequence(TypeDefBitSequence<T>),
     /// A Range type.
+    #[codec(index = 8)]
     Range(TypeDefRange<T>),
 }
 
@@ -276,40 +295,59 @@ impl IntoPortable for TypeDef {
 }
 
 /// A primitive Rust type.
+///
+/// # Note
+///
+/// Explicit codec indices specified to ensure backwards compatibility. See [`TypeDef`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
+    #[codec(index = 0)]
     Bool,
     /// `char` type
+    #[codec(index = 1)]
     Char,
     /// `str` type
+    #[codec(index = 2)]
     Str,
     /// `u8`
+    #[codec(index = 3)]
     U8,
     /// `u16`
+    #[codec(index = 4)]
     U16,
     /// `u32`
+    #[codec(index = 5)]
     U32,
     /// `u64`
+    #[codec(index = 6)]
     U64,
     /// `u128`
+    #[codec(index = 7)]
     U128,
     /// 256 bits unsigned int (no rust equivalent)
+    #[codec(index = 8)]
     U256,
     /// `i8`
+    #[codec(index = 9)]
     I8,
     /// `i16`
+    #[codec(index = 10)]
     I16,
     /// `i32`
+    #[codec(index = 11)]
     I32,
     /// `i64`
+    #[codec(index = 12)]
     I64,
     /// `i128`
+    #[codec(index = 13)]
     I128,
     /// 256 bits signed int (no rust equivalent)
+    #[codec(index = 14)]
     I256,
 }
 


### PR DESCRIPTION
### Added
- Add type parameter getters [(#122)](https://github.com/paritytech/scale-info/pull/122)
- Add support for Range and RangeInclusive [(#124)](https://github.com/paritytech/scale-info/pull/124), [(#126)](https://github.com/paritytech/scale-info/pull/126)
- Explicit codec indices for `TypeDef` and `TypeDefPrimitive` enums [(#127)](https://github.com/paritytech/scale-info/pull/127)

Also this moves the `Range` variant to the end, for backwards compatibility. /cc @jacogr 