### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2021-08-31
+## [1.0.0] - 2021-09-01
 ### Changed
 - Replace Range variant with built-in composite definitions [(#130)](https://github.com/paritytech/scale-info/pull/130)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-08-31
+
 ## [0.12.0] - 2021-08-25
 ### Changed
 - Add range getters, combine start and end types [(#126)](https://github.com/paritytech/scale-info/pull/126)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0] - 2021-08-31
+### Changed
+- Replace Range variant with built-in composite definitions [(#130)](https://github.com/paritytech/scale-info/pull/130)
 
 ## [0.12.0] - 2021-08-25
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "0.11.0"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "0.7.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "1.0.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "0.7.0"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 


### PR DESCRIPTION
Closes #89 

### Changed
- Replace Range variant with built-in composite definitions [(#130)](https://github.com/paritytech/scale-info/pull/130)

For upcoming integration into [substrate](https://github.com/paritytech/substrate/pull/8615) and polkadot, now that things are stabilized.