### PR TITLE
Replace Range variant with built-in composite definitions

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -41,7 +41,6 @@ use crate::{
     TypeDefArray,
     TypeDefCompact,
     TypeDefPrimitive,
-    TypeDefRange,
     TypeDefSequence,
     TypeDefTuple,
     TypeInfo,
@@ -359,7 +358,13 @@ where
 {
     type Identity = Self;
     fn type_info() -> Type {
-        TypeDefRange::new::<Idx>(false).into()
+        Type::builder()
+            .path(Path::prelude("Range"))
+            .type_params(type_params![Idx])
+            .composite(Fields::named()
+                .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
+                .field(|f| f.name("end").ty::<Idx>().type_name("Idx"))
+            )
     }
 }
 
@@ -369,7 +374,13 @@ where
 {
     type Identity = Self;
     fn type_info() -> Type {
-        TypeDefRange::new::<Idx>(true).into()
+        Type::builder()
+            .path(Path::prelude("RangeInclusive"))
+            .type_params(type_params![Idx])
+            .composite(Fields::named()
+                .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
+                .field(|f| f.name("end").ty::<Idx>().type_name("Idx"))
+            )
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -361,9 +361,10 @@ where
         Type::builder()
             .path(Path::prelude("Range"))
             .type_params(type_params![Idx])
-            .composite(Fields::named()
-                .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
-                .field(|f| f.name("end").ty::<Idx>().type_name("Idx"))
+            .composite(
+                Fields::named()
+                    .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
+                    .field(|f| f.name("end").ty::<Idx>().type_name("Idx")),
             )
     }
 }
@@ -377,9 +378,10 @@ where
         Type::builder()
             .path(Path::prelude("RangeInclusive"))
             .type_params(type_params![Idx])
-            .composite(Fields::named()
-                .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
-                .field(|f| f.name("end").ty::<Idx>().type_name("Idx"))
+            .composite(
+                Fields::named()
+                    .field(|f| f.name("start").ty::<Idx>().type_name("Idx"))
+                    .field(|f| f.name("end").ty::<Idx>().type_name("Idx")),
             )
     }
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -394,7 +394,18 @@ fn test_ranges() {
             {
                 "id": 1,
                 "type": {
-                    "def": { "range": { "index_type": 2, "inclusive": false} },
+                    "path": ["Range"],
+                    "params": [
+                        { "name": "Idx", "type": 2 }
+                    ],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                { "name": "start", "type": 2, "typeName": "Idx" },
+                                { "name": "end", "type": 2, "typeName": "Idx" },
+                            ],
+                        },
+                    }
                 }
             },
             {
@@ -406,7 +417,18 @@ fn test_ranges() {
             {
                 "id": 3,
                 "type": {
-                    "def": { "range": { "index_type": 4, "inclusive": true} },
+                    "path": ["RangeInclusive"],
+                    "params": [
+                        { "name": "Idx", "type": 4 }
+                    ],
+                    "def": {
+                        "composite": {
+                            "fields": [
+                                { "name": "start", "type": 4, "typeName": "Idx" },
+                                { "name": "end", "type": 4, "typeName": "Idx" },
+                            ],
+                        },
+                    }
                 }
             },
             {


### PR DESCRIPTION
This now describes precisely the encoding of the two range types introduces in https://github.com/paritytech/parity-scale-codec/pull/269.

The extra variant added in https://github.com/paritytech/scale-info/pull/124 would mean that if additional `Range` types were added it would have to be a breaking change. 

Also `Range` type definitions are not general SCALE concepts, they are just another "built-in" type that we can add to the prelude - e.g. `Option`, `Result` etc.

Required for #129 to prevent possible future breaking changes.

/cc @jacogr 