### PR TITLE
Add #[must_use] to builder types

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -150,6 +150,7 @@ pub mod state {
 }
 
 /// Builds a [`Type`](`crate::Type`)
+#[must_use]
 pub struct TypeBuilder<S = state::PathNotAssigned> {
     path: Option<Path>,
     type_params: Vec<TypeParameter>,
@@ -259,6 +260,7 @@ impl Fields {
 }
 
 /// Build a set of either all named (e.g. for a struct) or all unnamed (e.g. for a tuple struct)
+#[must_use]
 pub struct FieldsBuilder<T> {
     fields: Vec<Field>,
     marker: PhantomData<fn() -> T>,
@@ -329,6 +331,7 @@ pub mod field_state {
 }
 
 /// Construct a valid [`Field`].
+#[must_use]
 pub struct FieldBuilder<
     N = field_state::NameNotAssigned,
     T = field_state::TypeNotAssigned,
@@ -460,6 +463,7 @@ impl<N> FieldBuilder<N, field_state::TypeAssigned> {
 
 /// Builds a definition of a variant type i.e an `enum`
 #[derive(Default)]
+#[must_use]
 pub struct Variants {
     variants: Vec<Variant>,
 }
@@ -504,6 +508,7 @@ pub mod variant_state {
 }
 
 /// Build a [`Variant`].
+#[must_use]
 pub struct VariantBuilder<S = variant_state::IndexNotAssigned> {
     name: &'static str,
     index: Option<u8>,

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -16,5 +16,5 @@ scale = { package = "parity-scale-codec", version = "2", default-features = fals
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "0.6.1"
-trybuild = "1"
+trybuild = "1.0.54"
 rustversion = "1"

--- a/test_suite/tests/ui/fail_custom_bounds_missing_skip_type_params.stderr
+++ b/test_suite/tests/ui/fail_custom_bounds_missing_skip_type_params.stderr
@@ -1,7 +1,7 @@
 error: Type parameter requires a `TypeInfo` bound, so either:
- - add it to `#[scale_info(bounds(T: TypeInfo))]`
- - skip it with `#[scale_info(skip_type_params(T))]`
- --> $DIR/fail_custom_bounds_missing_skip_type_params.rs:6:10
+        - add it to `#[scale_info(bounds(T: TypeInfo))]`
+        - skip it with `#[scale_info(skip_type_params(T))]`
+ --> tests/ui/fail_custom_bounds_missing_skip_type_params.rs:6:10
   |
 6 | struct A<T> {
   |          ^


### PR DESCRIPTION
Seems like the CI's Rust version's clippy has return-self-not-must-use enabled. Not sure I'm 100% convinced we need this but it makes some sense that builders be `#[must_use]` I guess.
