### PR TITLE
Use lookahead.error()

### DIFF
--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -250,8 +250,7 @@ impl Parse for ScaleInfoAttr {
             let capture_docs = input.parse()?;
             Ok(Self::CaptureDocs(capture_docs))
         } else {
-            Err(input
-                .error("Expected one of: `bounds`, `skip_type_params` or `capture_docs"))
+            Err(lookahead.error())
         }
     }
 }

--- a/test_suite/tests/ui/fail_with_invalid_scale_info_attrs.rs
+++ b/test_suite/tests/ui/fail_with_invalid_scale_info_attrs.rs
@@ -1,0 +1,11 @@
+use scale_info::TypeInfo;
+use scale::Encode;
+
+#[derive(TypeInfo, Encode)]
+#[scale_info(foo)]
+struct InvalidKeywordInScaleInfoAttr {
+    a: u8,
+    b: u16,
+}
+
+fn main() {}

--- a/test_suite/tests/ui/fail_with_invalid_scale_info_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_scale_info_attrs.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `bounds`, `skip_type_params`, `capture_docs`
+ --> tests/ui/fail_with_invalid_scale_info_attrs.rs:5:14
+  |
+5 | #[scale_info(foo)]
+  |              ^^^


### PR DESCRIPTION
Spotted this while looking around the code base.