### PR TITLE
Revert bitvec field order to maintain binary compatiblilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-02-24
+
+## Changed
+- Revert bitvec field order to maintain binary compatiblilty
+
 ## [2.0.0] - 2022-02-07
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.56.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! Enable the `derive` feature of this crate:
 //!
 //! ```toml
-//! scale-info = { version = "0.6.0", features = ["derive"] }
+//! scale-info = { version = "2.0.0", features = ["derive"] }
 //! ```
 //!
 //! ```ignore

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -544,10 +544,10 @@ where
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
-    /// The type implementing [`bitvec::order::BitOrder`].
-    bit_order_type: T::Type,
     /// The type implementing [`bitvec::store::BitStore`].
     bit_store_type: T::Type,
+    /// The type implementing [`bitvec::order::BitOrder`].
+    bit_order_type: T::Type,
 }
 
 impl IntoPortable for TypeDefBitSequence {
@@ -555,8 +555,8 @@ impl IntoPortable for TypeDefBitSequence {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         TypeDefBitSequence {
-            bit_order_type: registry.register_type(&self.bit_order_type),
             bit_store_type: registry.register_type(&self.bit_store_type),
+            bit_order_type: registry.register_type(&self.bit_order_type),
         }
     }
 }


### PR DESCRIPTION
In https://github.com/paritytech/scale-info/pull/137 which updates bitvec to `1.0` the order of the type params changes, but the order of the fields is also changed (unnecessarily) and it breaks binary compatibility with polkadot.js https://github.com/polkadot-js/api/blob/ed2f512cfc2481de8fd2e895038ebdd603a9e1c5/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts#L518.

This PR restores the fields to their original order.