### PR TITLE
additional support to allow frame-metadata to derive TypeInfo

### DIFF
--- a/src/form.rs
+++ b/src/form.rs
@@ -76,6 +76,7 @@ impl Form for MetaForm {
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
 #[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "dogfood", derive(scale_info_derive::TypeInfo))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,8 @@ mod utils;
 #[cfg(test)]
 mod tests;
 
+use core::any::TypeId;
+
 #[doc(hidden)]
 pub use scale;
 
@@ -390,4 +392,17 @@ where
     T: ?Sized + TypeInfo + 'static,
 {
     MetaType::new::<T>()
+}
+
+impl TypeInfo for TypeId {
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::new("TypeId", "core::any"))
+            // .type_params(vec![MetaType::new::<T>()])
+            .composite(build::Fields::named()
+                 .field(|f| f.ty::<u64>().name("t").type_name("u64"))
+            )
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,6 @@ impl TypeInfo for TypeId {
     fn type_info() -> Type {
         Type::builder()
             .path(Path::new("TypeId", "core::any"))
-            // .type_params(vec![MetaType::new::<T>()])
             .composite(build::Fields::named()
                  .field(|f| f.ty::<u64>().name("t").type_name("u64"))
             )

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -162,6 +162,7 @@ impl Registry {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "dogfood", derive(scale_info_derive::TypeInfo))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     types: Vec<PortableType>,
@@ -199,6 +200,7 @@ impl PortableRegistry {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "dogfood", derive(scale_info_derive::TypeInfo))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableType {
     #[codec(compact)]

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -179,6 +179,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "dogfood", derive(scale_info_derive::TypeInfo))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
@@ -549,6 +550,7 @@ where
 /// enabled, but can be decoded or deserialized into the `PortableForm` without this feature.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "dogfood", derive(scale_info_derive::TypeInfo))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].


### PR DESCRIPTION
I'm trying to see whether I can make frame-metadata have TypeInfos so that I can try decoding it in a no_std context. To do so it looks like these types need type info to get something that compiles.