### PR TITLE
Prep for 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2022-09-14
+
+The minimum Rust version is bumped to 1.60.0 in this release owing to using weak dependency crate features. Otherwise there are no breaking changes.
 
 ### Changed
-- Minimum Rust version is 1.60.0 owing to using weak dependency crate features.
 - Loosen restriction on `TypeDefBitSequence::new()` so that `bitvec` isn't required, and try to avoid pulling in `bitvec` when the `std` feature is enabled [(#168)](https://github.com/paritytech/scale-info/pull/168)
 
 ## [2.1.2] - 2022-05-18

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.1.2"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.1.2", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.2.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "2.1.2"
+version = "2.2.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",


### PR DESCRIPTION
This release ups the MSRV to 1.60 but introduces no other breaking changes.

The main change is to ensure bitvec is no longer present in the tree unless "bit-vec" feature is enabled, and to allow TypeDefBitSequence to be built  without needing bitvec.

I'll publish the crates once this merges (scale-info and scale-info-derive have aligned versions)