### PR TITLE
Change NonZero* TypeInfo implementation to not be recursive

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -133,14 +133,14 @@ impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S
 impl_metadata_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
 
 macro_rules! impl_for_non_zero {
-    ( $( $t: ty ),* $(,)? ) => {
+    ( $( $t: ty: $inner: ty ),* $(,)? ) => {
         $(
             impl TypeInfo for $t {
                 type Identity = Self;
                 fn type_info() -> Type {
                     Type::builder()
                         .path(Path::prelude(stringify!($t)))
-                        .composite(Fields::unnamed().field(|f| f.ty::<$t>()))
+                        .composite(Fields::unnamed().field(|f| f.ty::<$inner>()))
                 }
             }
         )*
@@ -148,16 +148,16 @@ macro_rules! impl_for_non_zero {
 }
 
 impl_for_non_zero!(
-    NonZeroI8,
-    NonZeroI16,
-    NonZeroI32,
-    NonZeroI64,
-    NonZeroI128,
-    NonZeroU8,
-    NonZeroU16,
-    NonZeroU32,
-    NonZeroU64,
-    NonZeroU128
+    NonZeroI8: i8,
+    NonZeroI16: i16,
+    NonZeroI32: i32,
+    NonZeroI64: i64,
+    NonZeroI128: i128,
+    NonZeroU8: u8,
+    NonZeroU16: u16,
+    NonZeroU32: u32,
+    NonZeroU64: u64,
+    NonZeroU128: u128
 );
 
 impl<T> TypeInfo for Vec<T>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -101,7 +101,7 @@ fn prelude_items() {
         NonZeroU32,
         Type::builder()
             .path(Path::prelude("NonZeroU32"))
-            .composite(Fields::unnamed().field(|f| f.ty::<NonZeroU32>()))
+            .composite(Fields::unnamed().field(|f| f.ty::<u32>()))
     )
 }
 


### PR DESCRIPTION
The current `TypeInfo` implementation for the `NonZero*` types is recursive, defining the types as containing a field of itself. This PR fixes the implementation to properly define the inner field as the `NonZero*`'s wrapped type.

I also considered if the `NonZero*` types should be encoded as their wrapped type (i.e. `<NonZeroU64 as TypeInfo>::Identity == u64`), but I'm not sure what implications that would have.

NOTE: I've forked this off of b881bfb94f0df02781c8f523fb96f02ea4ef13bf since our current lockfile contains scale-info = 2.2.