### PR TITLE
Release `v2.3.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2022-10.27
+## [2.3.0] - 2022-12-09
+
+### Fixed
+- Change NonZero* TypeInfo implementation to not be recursive [(#171)](https://github.com/paritytech/scale-info/pull/171)
+
+## [2.3.0] - 2022-10-27
 
 Implement the missing pieces for constructing `PortableRegistry` dynamically at runtime. This allows languages where static rust types are not available to use it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2022-12-09
+## [2.3.1] - 2022-12-09
 
 ### Fixed
 - Change NonZero* TypeInfo implementation to not be recursive [(#171)](https://github.com/paritytech/scale-info/pull/171)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.3.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.3.1", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -38,7 +38,7 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
     index.map(|i| quote! { #i }).unwrap_or_else(|| {
         v.discriminant
             .as_ref()
-            .map(|&(_, ref expr)| quote! { #expr })
+            .map(|(_, ref expr)| quote! { #expr })
             .unwrap_or_else(|| quote! { #i })
     })
 }


### PR DESCRIPTION
### Fixed
- Change NonZero* TypeInfo implementation to not be recursive [(#171)](https://github.com/paritytech/scale-info/pull/171)