### PR TITLE
ty: Make type fields public 

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -303,7 +303,7 @@ impl<F: Form, T> FieldsBuilder<F, T> {
 impl<T> FieldsBuilder<MetaForm, T> {
     fn push_field(mut self, field: Field) -> Self {
         // filter out fields of PhantomData
-        if !field.ty().is_phantom() {
+        if !field.ty.is_phantom() {
             self.fields.push(field);
         }
         self

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -49,13 +49,17 @@ use serde::{
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     #[codec(compact)]
-    id: u32,
+    pub id: u32,
     #[cfg_attr(feature = "serde", serde(skip))]
     marker: PhantomData<fn() -> T>,
 }
 
 impl<T> UntrackedSymbol<T> {
     /// Returns the index to the symbol in the interner table.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn id(&self) -> u32 {
         self.id
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -237,9 +237,9 @@ impl PortableRegistry {
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableType {
     #[codec(compact)]
-    id: u32,
+    pub id: u32,
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    ty: Type<PortableForm>,
+    pub ty: Type<PortableForm>,
 }
 
 impl PortableType {

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -71,6 +71,11 @@ impl PortableRegistry {
         self.types.get(id as usize).map(|ty| ty.ty())
     }
 
+    /// Returns the mutable type definition for the given identifier, `None` if no type found for that ID.
+    pub fn resolve_mut(&mut self, id: u32) -> Option<&mut Type<PortableForm>> {
+        self.types.get_mut(id as usize).map(|ty| ty.ty_mut())
+    }
+
     /// Returns all types with their associated identifiers.
     pub fn types(&self) -> &[PortableType] {
         &self.types
@@ -255,6 +260,11 @@ impl PortableType {
     /// Returns the type of the [`PortableType`].
     pub fn ty(&self) -> &Type<PortableForm> {
         &self.ty
+    }
+
+    /// Returns the mutable type of the [`PortableType`].
+    pub fn ty_mut(&mut self) -> &mut Type<PortableForm> {
+        &mut self.ty
     }
 }
 

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -46,7 +46,8 @@ use scale::Encode;
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
-    types: Vec<PortableType>,
+    /// The types contained by the [`PortableRegistry`].
+    pub types: Vec<PortableType>,
 }
 
 impl From<Registry> for PortableRegistry {
@@ -69,11 +70,6 @@ impl PortableRegistry {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
     pub fn resolve(&self, id: u32) -> Option<&Type<PortableForm>> {
         self.types.get(id as usize).map(|ty| ty.ty())
-    }
-
-    /// Returns the mutable type definition for the given identifier, `None` if no type found for that ID.
-    pub fn resolve_mut(&mut self, id: u32) -> Option<&mut Type<PortableForm>> {
-        self.types.get_mut(id as usize).map(|ty| ty.ty_mut())
     }
 
     /// Returns all types with their associated identifiers.
@@ -260,11 +256,6 @@ impl PortableType {
     /// Returns the type of the [`PortableType`].
     pub fn ty(&self) -> &Type<PortableForm> {
         &self.ty
-    }
-
-    /// Returns the mutable type of the [`PortableType`].
-    pub fn ty_mut(&mut self) -> &mut Type<PortableForm> {
-        &mut self.ty
     }
 }
 

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -73,6 +73,10 @@ impl PortableRegistry {
     }
 
     /// Returns all types with their associated identifiers.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn types(&self) -> &[PortableType] {
         &self.types
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -249,11 +249,19 @@ impl PortableType {
     }
 
     /// Returns the index of the [`PortableType`].
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn id(&self) -> u32 {
         self.id
     }
 
     /// Returns the type of the [`PortableType`].
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn ty(&self) -> &Type<PortableForm> {
         &self.ty
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -57,7 +57,7 @@ impl From<Registry> for PortableRegistry {
                 .types()
                 .map(|(k, v)| {
                     PortableType {
-                        id: k.id(),
+                        id: k.id,
                         ty: v.clone(),
                     }
                 })
@@ -126,10 +126,10 @@ impl PortableRegistry {
 
             // Make sure any type params are also retained:
             for param in ty.ty.type_params.iter_mut() {
-                let Some(ty) = param.ty() else {
+                let Some(ty) = &param.ty else {
                     continue
                 };
-                let new_id = retain_type(ty.id(), types, new_types, retained_mappings);
+                let new_id = retain_type(ty.id, types, new_types, retained_mappings);
                 param.ty = Some(new_id).map(Into::into);
             }
 
@@ -137,12 +137,8 @@ impl PortableRegistry {
             match &mut ty.ty.type_def {
                 TypeDef::Composite(composite) => {
                     for field in composite.fields.iter_mut() {
-                        let new_id = retain_type(
-                            field.ty.id(),
-                            types,
-                            new_types,
-                            retained_mappings,
-                        );
+                        let new_id =
+                            retain_type(field.ty.id, types, new_types, retained_mappings);
                         field.ty = new_id.into();
                     }
                 }
@@ -150,7 +146,7 @@ impl PortableRegistry {
                     for var in variant.variants.iter_mut() {
                         for field in var.fields.iter_mut() {
                             let new_id = retain_type(
-                                field.ty.id(),
+                                field.ty.id,
                                 types,
                                 new_types,
                                 retained_mappings,
@@ -161,7 +157,7 @@ impl PortableRegistry {
                 }
                 TypeDef::Sequence(sequence) => {
                     let new_id = retain_type(
-                        sequence.type_param.id(),
+                        sequence.type_param.id,
                         types,
                         new_types,
                         retained_mappings,
@@ -170,7 +166,7 @@ impl PortableRegistry {
                 }
                 TypeDef::Array(array) => {
                     let new_id = retain_type(
-                        array.type_param.id(),
+                        array.type_param.id,
                         types,
                         new_types,
                         retained_mappings,
@@ -180,14 +176,14 @@ impl PortableRegistry {
                 TypeDef::Tuple(tuple) => {
                     for ty in tuple.fields.iter_mut() {
                         let new_id =
-                            retain_type(ty.id(), types, new_types, retained_mappings);
+                            retain_type(ty.id, types, new_types, retained_mappings);
                         *ty = new_id.into();
                     }
                 }
                 TypeDef::Primitive(_) => (),
                 TypeDef::Compact(compact) => {
                     let new_id = retain_type(
-                        compact.type_param().id(),
+                        compact.type_param.id,
                         types,
                         new_types,
                         retained_mappings,
@@ -196,13 +192,13 @@ impl PortableRegistry {
                 }
                 TypeDef::BitSequence(bit_seq) => {
                     let bit_store_id = retain_type(
-                        bit_seq.bit_store_type().id(),
+                        bit_seq.bit_store_type.id,
                         types,
                         new_types,
                         retained_mappings,
                     );
                     let bit_order_id = retain_type(
-                        bit_seq.bit_order_type().id(),
+                        bit_seq.bit_order_type.id,
                         types,
                         new_types,
                         retained_mappings,
@@ -283,7 +279,7 @@ impl PortableRegistryBuilder {
     ///
     /// If the type is already registered it will return the existing ID.
     pub fn register_type(&mut self, ty: Type<PortableForm>) -> u32 {
-        self.types.intern_or_get(ty).1.into_untracked().id()
+        self.types.intern_or_get(ty).1.into_untracked().id
     }
 
     /// Returns the type id that would be assigned to a newly registered type.
@@ -637,9 +633,9 @@ mod tests {
 
         let readonly: PortableRegistry = registry.into();
 
-        assert_eq!(4, readonly.types().len());
+        assert_eq!(4, readonly.types.len());
 
-        for (expected, ty) in readonly.types().iter().enumerate() {
+        for (expected, ty) in readonly.types.iter().enumerate() {
             assert_eq!(expected as u32, ty.id());
         }
     }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -69,7 +69,7 @@ impl From<Registry> for PortableRegistry {
 impl PortableRegistry {
     /// Returns the type definition for the given identifier, `None` if no type found for that ID.
     pub fn resolve(&self, id: u32) -> Option<&Type<PortableForm>> {
-        self.types.get(id as usize).map(|ty| ty.ty())
+        self.types.get(id as usize).map(|ty| &ty.ty)
     }
 
     /// Returns all types with their associated identifiers.
@@ -644,7 +644,7 @@ mod tests {
         assert_eq!(4, readonly.types.len());
 
         for (expected, ty) in readonly.types.iter().enumerate() {
-            assert_eq!(expected as u32, ty.id());
+            assert_eq!(expected as u32, ty.id);
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -215,9 +215,9 @@ mod tests {
         let type_id = registry.register_type(&meta_type::<RecursiveRefs>());
 
         let recursive = registry.types.get(&type_id).unwrap();
-        if let TypeDef::Composite(composite) = recursive.type_def() {
-            for field in composite.fields() {
-                assert_eq!(*field.ty(), type_id)
+        if let TypeDef::Composite(composite) = &recursive.type_def {
+            for field in &composite.fields {
+                assert_eq!(field.ty, type_id)
             }
         } else {
             panic!("Should be a composite type definition")

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -76,7 +76,7 @@ pub struct TypeDefComposite<T: Form = MetaForm> {
         feature = "serde",
         serde(skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub(crate) fields: Vec<Field<T>>,
+    pub fields: Vec<Field<T>>,
 }
 
 impl IntoPortable for TypeDefComposite {

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -109,6 +109,10 @@ where
     T: Form,
 {
     /// Returns the fields of the composite type.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn fields(&self) -> &[Field<T>] {
         &self.fields
     }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -141,11 +141,19 @@ where
     T: Form,
 {
     /// Returns the name of the field. None for unnamed fields.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn name(&self) -> Option<&T::String> {
         self.name.as_ref()
     }
 
     /// Returns the type of the field.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn ty(&self) -> &T::Type {
         &self.ty
     }
@@ -155,11 +163,19 @@ where
     /// name are not specified, but in practice will be the name of any valid
     /// type for a field. This is intended for informational and diagnostic
     /// purposes only.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_name(&self) -> Option<&T::String> {
         self.type_name.as_ref()
     }
 
     /// Returns the documentation of the field.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn docs(&self) -> &[T::String] {
         &self.docs
     }

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -78,22 +78,22 @@ pub struct Field<T: Form = MetaForm> {
         feature = "serde",
         serde(skip_serializing_if = "Option::is_none", default)
     )]
-    pub(crate) name: Option<T::String>,
+    pub name: Option<T::String>,
     /// The type of the field.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub(crate) ty: T::Type,
+    pub ty: T::Type,
     /// The name of the type of the field as it appears in the source code.
     #[cfg_attr(
         feature = "serde",
         serde(skip_serializing_if = "Option::is_none", default)
     )]
-    pub(crate) type_name: Option<T::String>,
+    pub type_name: Option<T::String>,
     /// Documentation
     #[cfg_attr(
         feature = "serde",
         serde(skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub(crate) docs: Vec<T::String>,
+    pub docs: Vec<T::String>,
 }
 
 impl IntoPortable for Field {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -68,22 +68,22 @@ pub struct Type<T: Form = MetaForm> {
         feature = "serde",
         serde(skip_serializing_if = "Path::is_empty", default)
     )]
-    pub(crate) path: Path<T>,
+    pub path: Path<T>,
     /// The generic type parameters of the type in use. Empty for non generic types
     #[cfg_attr(
         feature = "serde",
         serde(rename = "params", skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub(crate) type_params: Vec<TypeParameter<T>>,
+    pub type_params: Vec<TypeParameter<T>>,
     /// The actual type definition
     #[cfg_attr(feature = "serde", serde(rename = "def"))]
-    pub(crate) type_def: TypeDef<T>,
+    pub type_def: TypeDef<T>,
     /// Documentation
     #[cfg_attr(
         feature = "serde",
         serde(skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub(crate) docs: Vec<T::String>,
+    pub docs: Vec<T::String>,
 }
 
 impl IntoPortable for Type {
@@ -194,12 +194,12 @@ where
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
-    pub(crate) name: T::String,
+    pub name: T::String,
     /// The concrete type for the type parameter.
     ///
     /// `None` if the type parameter is skipped.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub(crate) ty: Option<T::Type>,
+    pub ty: Option<T::Type>,
 }
 
 impl IntoPortable for TypeParameter {
@@ -400,10 +400,10 @@ pub enum TypeDefPrimitive {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
-    pub(crate) len: u32,
+    pub len: u32,
     /// The element type of the array type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub(crate) type_param: T::Type,
+    pub type_param: T::Type,
 }
 
 impl IntoPortable for TypeDefArray {
@@ -452,7 +452,7 @@ where
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
-    pub(crate) fields: Vec<T::Type>,
+    pub fields: Vec<T::Type>,
 }
 
 impl IntoPortable for TypeDefTuple {
@@ -514,7 +514,7 @@ where
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub(crate) type_param: T::Type,
+    pub type_param: T::Type,
 }
 
 impl IntoPortable for TypeDefSequence {
@@ -564,7 +564,7 @@ where
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub(crate) type_param: T::Type,
+    pub type_param: T::Type,
 }
 
 impl IntoPortable for TypeDefCompact {
@@ -603,9 +603,9 @@ where
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].
-    pub(crate) bit_store_type: T::Type,
+    pub bit_store_type: T::Type,
     /// The type implementing [`bitvec::order::BitOrder`].
-    pub(crate) bit_order_type: T::Type,
+    pub bit_order_type: T::Type,
 }
 
 impl IntoPortable for TypeDefBitSequence {

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -161,21 +161,37 @@ where
     T: Form,
 {
     /// Returns the path of the type
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn path(&self) -> &Path<T> {
         &self.path
     }
 
     /// Returns the generic type parameters of the type
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_params(&self) -> &[TypeParameter<T>] {
         &self.type_params
     }
 
     /// Returns the definition of the type
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_def(&self) -> &TypeDef<T> {
         &self.type_def
     }
 
     /// Returns the documentation of the type
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn docs(&self) -> &[T::String] {
         &self.docs
     }
@@ -240,11 +256,19 @@ where
     /// Get the type of the parameter.
     ///
     /// `None` if the parameter is skipped.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn ty(&self) -> Option<&T::Type> {
         self.ty.as_ref()
     }
 
     /// Get the name of the parameter.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn name(&self) -> &T::String {
         &self.name
     }
@@ -428,11 +452,19 @@ where
     }
 
     /// Returns the length of the array type.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn len(&self) -> u32 {
         self.len
     }
 
     /// Returns the element type of the array type.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_param(&self) -> &T::Type {
         &self.type_param
     }
@@ -502,6 +534,10 @@ where
     T: Form,
 {
     /// Returns the types of the tuple fields.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn fields(&self) -> &[T::Type] {
         &self.fields
     }
@@ -552,6 +588,10 @@ where
     }
 
     /// Returns the element type of the sequence type.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_param(&self) -> &T::Type {
         &self.type_param
     }
@@ -587,6 +627,10 @@ where
     }
 
     /// Returns the [`Compact`] wrapped type, i.e. the `T` in `Compact<T>`.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn type_param(&self) -> &T::Type {
         &self.type_param
     }
@@ -624,11 +668,19 @@ where
     T: Form,
 {
     /// Returns the type of the bit ordering of the [`::bitvec::vec::BitVec`].
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn bit_order_type(&self) -> &T::Type {
         &self.bit_order_type
     }
 
     /// Returns underlying type used to store the [`::bitvec::vec::BitVec`].
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn bit_store_type(&self) -> &T::Type {
         &self.bit_store_type
     }

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -59,7 +59,7 @@ use serde::{
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.
-    segments: Vec<T::String>,
+    pub segments: Vec<T::String>,
 }
 
 impl<T> Default for Path<T>
@@ -158,6 +158,10 @@ where
     }
 
     /// Returns the segments of the Path
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn segments(&self) -> &[T::String] {
         &self.segments
     }

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -88,7 +88,7 @@ pub struct TypeDefVariant<T: Form = MetaForm> {
         feature = "serde",
         serde(skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub(crate) variants: Vec<Variant<T>>,
+    pub variants: Vec<Variant<T>>,
 }
 
 impl IntoPortable for TypeDefVariant {

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -121,6 +121,10 @@ where
     T: Form,
 {
     /// Returns the variants of a variant type
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn variants(&self) -> &[Variant<T>] {
         &self.variants
     }
@@ -212,21 +216,37 @@ where
     T: Form,
 {
     /// Returns the name of the variant.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn name(&self) -> &T::String {
         &self.name
     }
 
     /// Returns the fields of the struct variant.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn fields(&self) -> &[Field<T>] {
         &self.fields
     }
 
     /// Returns the index of the variant.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn index(&self) -> u8 {
         self.index
     }
 
     /// Returns the documentation of the variant.
+    #[deprecated(
+        since = "2.5.0",
+        note = "Prefer to access the fields directly; this getter will be removed in the next major version"
+    )]
     pub fn docs(&self) -> &[T::String] {
         &self.docs
     }


### PR DESCRIPTION
Subxt needs access to the types stored in the `PortableRegistry` to create a slim subset of the metadata,
where the generic types of a `Type` are ignored.

To achieve this, subxt will access something similar to:  `registry.types.get(index).ty.type_param`.

While at it, make the other fields public.  The old getters are still left in place for backward compatibility.


cc @paritytech/subxt-team 
