### PR TITLE
Schema generation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
         cargo check --no-default-features --features docs
         cargo check --no-default-features --features serde
         cargo check --no-default-features --features serde,decode
+        cargo check --no-default-features --features std,schema
 
     - name: build
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
         cargo check --no-default-features --features docs
         cargo check --no-default-features --features serde
         cargo check --no-default-features --features serde,decode
-        cargo check --no-default-features --features std,schema
+        cargo check --no-default-features --features schema
 
     - name: build
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ bit-vec = [
 ]
 # Enables JSON Schema generation.
 schema = [
+    "std",
     "schemars"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ scale-info-derive = { version = "2.5.0", path = "derive", default-features = fal
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+schemars = { version = "0.8", optional = true }
 
 [features]
 default = ["std"]
@@ -35,13 +36,17 @@ derive = [
 docs = [
     "scale-info-derive/docs"
 ]
-# enables decoding and deserialization of portable scale-info type metadata
+# Enables decoding and deserialization of portable scale-info type metadata.
 decode = [
     "scale/full"
 ]
-# enables type information for bitvec types, matching the name of the parity-scale-codec feature
+# Enables type information for bitvec types, matching the name of the parity-scale-codec feature.
 bit-vec = [
     "bitvec"
+]
+# Enables JSON Schema generation.
+schema = [
+    "schemars"
 ]
 
 [workspace]

--- a/src/form.rs
+++ b/src/form.rs
@@ -39,16 +39,16 @@ use crate::{
     meta_type::MetaType,
 };
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
 /// Trait to support derivation of `JsonSchema` for schema generation.
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 pub trait JsonSchemaMaybe: JsonSchema {}
 /// Trait to support derivation of `JsonSchema` for schema generation.
-#[cfg(not(feature = "schema"))]
+#[cfg(not(all(feature = "std", feature = "schema")))]
 pub trait JsonSchemaMaybe {}
 
 /// Trait to control the internal structures of type definitions.
@@ -74,7 +74,7 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -91,7 +91,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}
@@ -111,7 +111,8 @@ cfg_if::cfg_if! {
     }
 }
 
-// Blanket implementation
-impl JsonSchemaMaybe for &'static str {}
-#[cfg(any(feature = "std", feature = "decode"))]
-impl JsonSchemaMaybe for crate::prelude::string::String {}
+// Blanket implementations
+#[cfg(not(all(feature = "std", feature = "schema")))]
+impl<T> JsonSchemaMaybe for T {}
+#[cfg(all(feature = "std", feature = "schema"))]
+impl<T> JsonSchemaMaybe for T where T: JsonSchema {}

--- a/src/form.rs
+++ b/src/form.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 
 use cfg_if::cfg_if;
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -52,7 +52,7 @@ use serde::Serialize;
 /// interning data structures.
 pub trait Form {
     cfg_if! {
-        if #[cfg(feature = "schema")] {
+        if #[cfg(all(feature = "std", feature = "schema"))] {
             /// The type representing the type.
             type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug + JsonSchema;
             /// The string type.
@@ -128,7 +128,7 @@ impl From<TypeId> for TypeIdDef {
     }
 }
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 impl schemars::JsonSchema for TypeIdDef {
     fn schema_name() -> String {
         "TypeId".into()

--- a/src/form.rs
+++ b/src/form.rs
@@ -70,7 +70,7 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -87,7 +87,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}

--- a/src/form.rs
+++ b/src/form.rs
@@ -40,11 +40,10 @@ use crate::{
 };
 
 use cfg_if::cfg_if;
-#[cfg(feature = "serde")]
-use serde::Serialize;
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
-
+#[cfg(feature = "serde")]
+use serde::Serialize;
 
 /// Trait to control the internal structures of type definitions.
 ///
@@ -112,7 +111,7 @@ cfg_if::cfg_if! {
 /// Required for internal
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct TypeIdDef {
-    type_id: TypeId
+    type_id: TypeId,
 }
 
 impl core::ops::Deref for TypeIdDef {
@@ -125,7 +124,7 @@ impl core::ops::Deref for TypeIdDef {
 
 impl From<TypeId> for TypeIdDef {
     fn from(type_id: TypeId) -> Self {
-        Self {type_id}
+        Self { type_id }
     }
 }
 

--- a/src/form.rs
+++ b/src/form.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 
 use cfg_if::cfg_if;
-#[cfg(feature = "schemars")]
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -52,7 +52,7 @@ use serde::Serialize;
 /// interning data structures.
 pub trait Form {
     cfg_if! {
-        if #[cfg(feature = "schemars")] {
+        if #[cfg(feature = "schema")] {
             /// The type representing the type.
             type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug + JsonSchema;
             /// The string type.
@@ -70,7 +70,7 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -87,7 +87,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}
@@ -128,7 +128,7 @@ impl From<TypeId> for TypeIdDef {
     }
 }
 
-#[cfg(feature = "schemars")]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for TypeIdDef {
     fn schema_name() -> String {
         "TypeId".into()

--- a/src/form.rs
+++ b/src/form.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 
 use cfg_if::cfg_if;
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -52,7 +52,7 @@ use serde::Serialize;
 /// interning data structures.
 pub trait Form {
     cfg_if! {
-        if #[cfg(all(feature = "std", feature = "schema"))] {
+        if #[cfg(feature = "schema")] {
             /// The type representing the type.
             type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug + JsonSchema;
             /// The string type.
@@ -70,7 +70,7 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -87,7 +87,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}
@@ -128,7 +128,7 @@ impl From<TypeId> for TypeIdDef {
     }
 }
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for TypeIdDef {
     fn schema_name() -> String {
         "TypeId".into()

--- a/src/form.rs
+++ b/src/form.rs
@@ -39,6 +39,9 @@ use crate::{
     meta_type::MetaType,
 };
 
+use schemars::JsonSchema;
+
+use cfg_if::cfg_if;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -48,16 +51,26 @@ use serde::Serialize;
 /// instantiated out of the flux and portable forms that require some sort of
 /// interning data structures.
 pub trait Form {
-    /// The type representing the type.
-    type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
-    /// The string type.
-    type String: AsRef<str> + PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+    cfg_if! {
+        if #[cfg(feature = "schemars")] {
+            /// The type representing the type.
+            type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug + JsonSchema;
+            /// The string type.
+            type String: AsRef<str> + PartialEq + Eq + PartialOrd + Ord + Clone + Debug + JsonSchema;
+        } else {
+            /// The type representing the type.
+            type Type: PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+            /// The string type.
+            type String: AsRef<str> + PartialEq + Eq + PartialOrd + Ord + Clone + Debug;
+        }
+    }
 }
 
 /// A meta meta-type.
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -74,6 +87,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}

--- a/src/form.rs
+++ b/src/form.rs
@@ -39,16 +39,16 @@ use crate::{
     meta_type::MetaType,
 };
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
 /// Trait to support derivation of `JsonSchema` for schema generation.
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 pub trait JsonSchemaMaybe: JsonSchema {}
 /// Trait to support derivation of `JsonSchema` for schema generation.
-#[cfg(not(all(feature = "std", feature = "schema")))]
+#[cfg(not(feature = "schema"))]
 pub trait JsonSchemaMaybe {}
 
 /// Trait to control the internal structures of type definitions.
@@ -74,7 +74,7 @@ pub trait Form {
 ///
 /// Allows to be converted into other forms such as portable form
 /// through the registry and `IntoPortable`.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum MetaForm {}
@@ -91,7 +91,7 @@ impl Form for MetaForm {
 /// This resolves some lifetime issues with self-referential structs (such as
 /// the registry itself) but can no longer be used to resolve to the original
 /// underlying data.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub enum PortableForm {}
@@ -112,7 +112,7 @@ cfg_if::cfg_if! {
 }
 
 // Blanket implementations
-#[cfg(not(all(feature = "std", feature = "schema")))]
+#[cfg(not(feature = "schema"))]
 impl<T> JsonSchemaMaybe for T {}
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 impl<T> JsonSchemaMaybe for T where T: JsonSchema {}

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -49,7 +49,7 @@ use schemars::JsonSchema;
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     #[codec(compact)]
@@ -124,7 +124,7 @@ impl<T> Symbol<'_, T> {
 /// This is used in order to quite efficiently cache strings and type
 /// definitions uniquely identified by their associated type identifiers.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Interner<T> {

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -87,12 +87,6 @@ impl<T> JsonSchema for UntrackedSymbol<T> {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Dummy trait for schema generation
-        // #[derive(JsonSchema)]
-        // #[allow(dead_code)]
-        // struct UntrackedSymbol {
-        //     pub id: u32,
-        // }
         gen.subschema_for::<u32>()
     }
 }
@@ -104,6 +98,7 @@ impl<T> JsonSchemaMaybe for UntrackedSymbol<T> {}
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Symbol<'a, T> {
     id: u32,
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -146,6 +141,7 @@ impl<T> Symbol<'_, T> {
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Interner<T> {
     /// A mapping from the interned elements to their respective space-efficient
     /// identifiers.
@@ -230,28 +226,6 @@ where
     /// Returns the ordered sequence of interned elements.
     pub fn elements(&self) -> &[T] {
         &self.vec
-    }
-}
-
-#[cfg(feature = "schema")]
-impl<TypeId> JsonSchema for Interner<TypeId> {
-    fn schema_name() -> String {
-        String::from("Interner")
-    }
-
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // dummy types to generate schema
-        #[derive(schemars::JsonSchema)]
-        #[allow(dead_code)]
-        struct TypeId {
-            t: u64,
-        }
-        #[derive(JsonSchema)]
-        #[allow(dead_code)]
-        struct Interner {
-            vec: Vec<TypeId>,
-        }
-        gen.subschema_for::<Interner>()
     }
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -88,12 +88,12 @@ impl<T> JsonSchema for UntrackedSymbol<T> {
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         // Dummy trait for schema generation
-        #[derive(JsonSchema)]
-        #[allow(dead_code)]
-        struct UntrackedSymbol {
-            pub id: u32,
-        }
-        gen.subschema_for::<UntrackedSymbol>()
+        // #[derive(JsonSchema)]
+        // #[allow(dead_code)]
+        // struct UntrackedSymbol {
+        //     pub id: u32,
+        // }
+        gen.subschema_for::<u32>()
     }
 }
 impl<T> JsonSchemaMaybe for UntrackedSymbol<T> {}

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -37,6 +37,9 @@ use serde::{
     Serialize,
 };
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
 /// A symbol that is not lifetime tracked.
 ///
 /// This can be used by self-referential types but
@@ -46,6 +49,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     #[codec(compact)]
@@ -120,6 +124,7 @@ impl<T> Symbol<'_, T> {
 /// This is used in order to quite efficiently cache strings and type
 /// definitions uniquely identified by their associated type identifiers.
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Interner<T> {

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -37,7 +37,7 @@ use serde::{
     Serialize,
 };
 
-#[cfg(feature = "schemars")]
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 
 /// A symbol that is not lifetime tracked.
@@ -49,7 +49,7 @@ use schemars::JsonSchema;
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct UntrackedSymbol<T> {
     /// The index to the symbol in the interner table.
     #[codec(compact)]
@@ -124,7 +124,7 @@ impl<T> Symbol<'_, T> {
 /// This is used in order to quite efficiently cache strings and type
 /// definitions uniquely identified by their associated type identifiers.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Interner<T> {

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -240,11 +240,16 @@ impl<TypeId> JsonSchema for Interner<TypeId> {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // Dummy trait for schema generation
+        // dummy types to generate schema
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct TypeId {
+            t: u64,
+        }
         #[derive(JsonSchema)]
         #[allow(dead_code)]
         struct Interner {
-            vec: Vec<u64>,
+            vec: Vec<TypeId>,
         }
         gen.subschema_for::<Interner>()
     }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -37,7 +37,7 @@ use serde::{
     Serialize,
 };
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 
 /// A symbol that is not lifetime tracked.
@@ -77,7 +77,7 @@ impl<T> From<u32> for UntrackedSymbol<T> {
     }
 }
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 impl<T> JsonSchema for UntrackedSymbol<T> {
     fn schema_name() -> String {
         String::from("UntrackedSymbol")
@@ -94,7 +94,7 @@ impl<T> JsonSchema for UntrackedSymbol<T> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Symbol<'a, T: 'a> {
     id: u32,
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -137,7 +137,7 @@ impl<T> Symbol<'_, T> {
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Interner<T> {
     /// A mapping from the interned elements to their respective space-efficient
     /// identifiers.

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,16 +22,13 @@
 //! elements and is later used for space-efficient serialization within the
 //! registry.
 
-use crate::{
-    form::JsonSchemaMaybe,
-    prelude::{
-        collections::btree_map::{
-            BTreeMap,
-            Entry,
-        },
-        marker::PhantomData,
-        vec::Vec,
+use crate::prelude::{
+    collections::btree_map::{
+        BTreeMap,
+        Entry,
     },
+    marker::PhantomData,
+    vec::Vec,
 };
 
 #[cfg(feature = "serde")]
@@ -40,7 +37,7 @@ use serde::{
     Serialize,
 };
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 use schemars::JsonSchema;
 
 /// A symbol that is not lifetime tracked.
@@ -80,7 +77,7 @@ impl<T> From<u32> for UntrackedSymbol<T> {
     }
 }
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 impl<T> JsonSchema for UntrackedSymbol<T> {
     fn schema_name() -> String {
         String::from("UntrackedSymbol")
@@ -90,7 +87,6 @@ impl<T> JsonSchema for UntrackedSymbol<T> {
         gen.subschema_for::<u32>()
     }
 }
-impl<T> JsonSchemaMaybe for UntrackedSymbol<T> {}
 
 /// A symbol from an interner.
 ///
@@ -98,8 +94,8 @@ impl<T> JsonSchemaMaybe for UntrackedSymbol<T> {}
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct Symbol<'a, T> {
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
+pub struct Symbol<'a, T: 'a> {
     id: u32,
     #[cfg_attr(feature = "serde", serde(skip))]
     marker: PhantomData<fn() -> &'a T>,
@@ -141,7 +137,7 @@ impl<T> Symbol<'_, T> {
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(JsonSchema))]
 pub struct Interner<T> {
     /// A mapping from the interned elements to their respective space-efficient
     /// identifiers.

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -37,7 +37,7 @@ use serde::{
     Serialize,
 };
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 use schemars::JsonSchema;
 
 /// A symbol that is not lifetime tracked.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,9 +340,6 @@ mod registry;
 mod ty;
 mod utils;
 
-#[cfg(test)]
-mod tests;
-
 #[doc(hidden)]
 pub use scale;
 
@@ -395,3 +392,6 @@ where
 {
     MetaType::new::<T>()
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -115,7 +115,7 @@ impl MetaType {
     }
 }
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for MetaType {
     fn schema_name() -> String {
         "MetaType".into()

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    form::JsonSchemaMaybe,
-    prelude::{
-        any::TypeId,
-        cmp::Ordering,
-        fmt::{
-            Debug,
-            Error as FmtError,
-            Formatter,
-        },
-        hash::{
-            Hash,
-            Hasher,
-        },
+use crate::prelude::{
+    any::TypeId,
+    cmp::Ordering,
+    fmt::{
+        Debug,
+        Error as FmtError,
+        Formatter,
+    },
+    hash::{
+        Hash,
+        Hasher,
     },
 };
 
@@ -115,7 +112,7 @@ impl MetaType {
     }
 }
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 impl schemars::JsonSchema for MetaType {
     fn schema_name() -> String {
         "MetaType".into()
@@ -126,5 +123,3 @@ impl schemars::JsonSchema for MetaType {
         gen.subschema_for::<u64>()
     }
 }
-
-impl JsonSchemaMaybe for MetaType {}

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -115,7 +115,7 @@ impl MetaType {
     }
 }
 
-#[cfg(feature = "schema")]
+#[cfg(all(feature = "std", feature = "schema"))]
 impl schemars::JsonSchema for MetaType {
     fn schema_name() -> String {
         "MetaType".into()

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -17,12 +17,23 @@ use crate::{
     prelude::{
         any::TypeId,
         cmp::Ordering,
-        fmt::{Debug, Error as FmtError, Formatter},
-        hash::{Hash, Hasher},
+        fmt::{
+            Debug,
+            Error as FmtError,
+            Formatter,
+        },
+        hash::{
+            Hash,
+            Hasher,
+        },
     },
 };
 
-use crate::{form::MetaForm, Type, TypeInfo};
+use crate::{
+    form::MetaForm,
+    Type,
+    TypeInfo,
+};
 
 /// A metatype abstraction.
 ///

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -17,23 +17,12 @@ use crate::{
     prelude::{
         any::TypeId,
         cmp::Ordering,
-        fmt::{
-            Debug,
-            Error as FmtError,
-            Formatter,
-        },
-        hash::{
-            Hash,
-            Hasher,
-        },
+        fmt::{Debug, Error as FmtError, Formatter},
+        hash::{Hash, Hasher},
     },
 };
 
-use crate::{
-    form::MetaForm,
-    Type,
-    TypeInfo,
-};
+use crate::{form::MetaForm, Type, TypeInfo};
 
 /// A metatype abstraction.
 ///
@@ -114,13 +103,21 @@ impl MetaType {
         self == &MetaType::new::<crate::impls::PhantomIdentity>()
     }
 }
-#[cfg(feature = "schemars")]
+
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for MetaType {
     fn schema_name() -> String {
         "MetaType".into()
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        //dummy type to generate schema
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct MetaType {
+            fn_type_info: Type<MetaForm>,
+            type_id: TypeIdDef,
+        }
         gen.subschema_for::<MetaType>()
     }
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -122,18 +122,19 @@ impl schemars::JsonSchema for MetaType {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // dummy type to generate schema
+        // dummy types to generate schema
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct TypeId {
+            t: u64,
+        }
         #[derive(schemars::JsonSchema)]
         #[allow(dead_code)]
         struct MetaType {
             fn_type_info: Type<MetaForm>,
-            type_id: u64,
+            type_id: TypeId,
         }
         gen.subschema_for::<MetaType>()
-    }
-
-    fn is_referenceable() -> bool {
-        true
     }
 }
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::{
-    form::TypeIdDef,
+    form::JsonSchemaMaybe,
     prelude::{
         any::TypeId,
         cmp::Ordering,
@@ -49,7 +49,7 @@ pub struct MetaType {
     // The standard type ID (ab)used in order to provide
     // cheap implementations of the standard traits
     // such as `PartialEq`, `PartialOrd`, `Debug` and `Hash`.
-    type_id: TypeIdDef,
+    type_id: TypeId,
 }
 
 impl PartialEq for MetaType {
@@ -95,7 +95,7 @@ impl MetaType {
     {
         Self {
             fn_type_info: <T as TypeInfo>::type_info,
-            type_id: TypeIdDef::from(TypeId::of::<T::Identity>()),
+            type_id: TypeId::of::<T::Identity>(),
         }
     }
 
@@ -105,7 +105,7 @@ impl MetaType {
     }
 
     /// Returns the type identifier provided by `core::any`.
-    pub fn type_id(&self) -> TypeIdDef {
+    pub fn type_id(&self) -> TypeId {
         self.type_id
     }
 
@@ -127,7 +127,7 @@ impl schemars::JsonSchema for MetaType {
         #[allow(dead_code)]
         struct MetaType {
             fn_type_info: Type<MetaForm>,
-            type_id: TypeIdDef,
+            type_id: u64,
         }
         gen.subschema_for::<MetaType>()
     }
@@ -136,3 +136,5 @@ impl schemars::JsonSchema for MetaType {
         true
     }
 }
+
+impl JsonSchemaMaybe for MetaType {}

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -122,19 +122,8 @@ impl schemars::JsonSchema for MetaType {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        // dummy types to generate schema
-        #[derive(schemars::JsonSchema)]
-        #[allow(dead_code)]
-        struct TypeId {
-            t: u64,
-        }
-        #[derive(schemars::JsonSchema)]
-        #[allow(dead_code)]
-        struct MetaType {
-            fn_type_info: Type<MetaForm>,
-            type_id: TypeId,
-        }
-        gen.subschema_for::<MetaType>()
+        // since MetaType does not really get serialized, we don't care about its actual schema
+        gen.subschema_for::<u64>()
     }
 }
 

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -112,7 +112,7 @@ impl MetaType {
     }
 }
 
-#[cfg(all(feature = "std", feature = "schema"))]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for MetaType {
     fn schema_name() -> String {
         "MetaType".into()

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -17,12 +17,23 @@ use crate::{
     prelude::{
         any::TypeId,
         cmp::Ordering,
-        fmt::{Debug, Error as FmtError, Formatter},
-        hash::{Hash, Hasher},
+        fmt::{
+            Debug,
+            Error as FmtError,
+            Formatter,
+        },
+        hash::{
+            Hash,
+            Hasher,
+        },
     },
 };
 
-use crate::{form::MetaForm, Type, TypeInfo};
+use crate::{
+    form::MetaForm,
+    Type,
+    TypeInfo,
+};
 
 /// A metatype abstraction.
 ///
@@ -111,7 +122,7 @@ impl schemars::JsonSchema for MetaType {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        //dummy type to generate schema
+        // dummy type to generate schema
         #[derive(schemars::JsonSchema)]
         #[allow(dead_code)]
         struct MetaType {

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::{
-    any::TypeId,
-    cmp::Ordering,
-    fmt::{
-        Debug,
-        Error as FmtError,
-        Formatter,
-    },
-    hash::{
-        Hash,
-        Hasher,
+use crate::{
+    form::TypeIdDef,
+    prelude::{
+        any::TypeId,
+        cmp::Ordering,
+        fmt::{Debug, Error as FmtError, Formatter},
+        hash::{Hash, Hasher},
     },
 };
 
-use crate::{
-    form::MetaForm,
-    Type,
-    TypeInfo,
-};
+use crate::{form::MetaForm, Type, TypeInfo};
 
 /// A metatype abstraction.
 ///
@@ -46,7 +38,7 @@ pub struct MetaType {
     // The standard type ID (ab)used in order to provide
     // cheap implementations of the standard traits
     // such as `PartialEq`, `PartialOrd`, `Debug` and `Hash`.
-    type_id: TypeId,
+    type_id: TypeIdDef,
 }
 
 impl PartialEq for MetaType {
@@ -92,7 +84,7 @@ impl MetaType {
     {
         Self {
             fn_type_info: <T as TypeInfo>::type_info,
-            type_id: TypeId::of::<T::Identity>(),
+            type_id: TypeIdDef::from(TypeId::of::<T::Identity>()),
         }
     }
 
@@ -102,7 +94,7 @@ impl MetaType {
     }
 
     /// Returns the type identifier provided by `core::any`.
-    pub fn type_id(&self) -> TypeId {
+    pub fn type_id(&self) -> TypeIdDef {
         self.type_id
     }
 
@@ -118,10 +110,10 @@ impl schemars::JsonSchema for MetaType {
     }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        todo!()
+        gen.subschema_for::<MetaType>()
     }
 
     fn is_referenceable() -> bool {
-        todo!()
+        true
     }
 }

--- a/src/meta_type.rs
+++ b/src/meta_type.rs
@@ -111,3 +111,17 @@ impl MetaType {
         self == &MetaType::new::<crate::impls::PhantomIdentity>()
     }
 }
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for MetaType {
+    fn schema_name() -> String {
+        "MetaType".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        todo!()
+    }
+
+    fn is_referenceable() -> bool {
+        todo!()
+    }
+}

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -41,7 +41,7 @@ use crate::{
 use scale::Encode;
 
 /// A read-only registry containing types in their portable form for serialization.
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
@@ -232,7 +232,7 @@ impl PortableRegistry {
 }
 
 /// Represent a type in it's portable form.
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -41,7 +41,7 @@ use crate::{
 use scale::Encode;
 
 /// A read-only registry containing types in their portable form for serialization.
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
@@ -232,7 +232,7 @@ impl PortableRegistry {
 }
 
 /// Represent a type in it's portable form.
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -39,6 +39,7 @@ use crate::{
     TypeDefPrimitive,
 };
 use scale::Encode;
+use schemars::JsonSchema;
 
 /// A read-only registry containing types in their portable form for serialization.
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -231,6 +232,7 @@ impl PortableRegistry {
 }
 
 /// Represent a type in it's portable form.
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -45,7 +45,6 @@ use scale::Encode;
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     /// The types contained by the [`PortableRegistry`].

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -39,12 +39,13 @@ use crate::{
     TypeDefPrimitive,
 };
 use scale::Encode;
-use schemars::JsonSchema;
 
 /// A read-only registry containing types in their portable form for serialization.
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableRegistry {
     /// The types contained by the [`PortableRegistry`].
@@ -232,7 +233,7 @@ impl PortableRegistry {
 }
 
 /// Represent a type in it's portable form.
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -41,7 +41,7 @@ use crate::{
 use scale::Encode;
 
 /// A read-only registry containing types in their portable form for serialization.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
@@ -232,7 +232,7 @@ impl PortableRegistry {
 }
 
 /// Represent a type in it's portable form.
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "decode"), derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -75,7 +75,6 @@ impl IntoPortable for &'static str {
 /// A type can be a sub-type of itself. In this case the registry has a builtin
 /// mechanism to stop recursion and avoid going into an infinite loop.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Registry {
     /// The cache for already registered types.
     ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -23,11 +23,10 @@
 //! namespaces. The normal Rust namespace of a type is used, except for the Rust
 //! prelude types that live in the so-called root namespace which is empty.
 
-use core::any::TypeId;
-
 use crate::{
     form::Form,
     prelude::{
+        any::TypeId,
         collections::BTreeMap,
         fmt::Debug,
         vec::Vec,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -76,7 +76,7 @@ impl IntoPortable for &'static str {
 /// A type can be a sub-type of itself. In this case the registry has a builtin
 /// mechanism to stop recursion and avoid going into an infinite loop.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Registry {
     /// The cache for already registered types.
     ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,13 +24,23 @@
 //! prelude types that live in the so-called root namespace which is empty.
 
 use crate::{
-    form::{Form, TypeIdDef},
-    prelude::{collections::BTreeMap, fmt::Debug, vec::Vec},
+    form::{
+        Form,
+        TypeIdDef,
+    },
+    prelude::{
+        collections::BTreeMap,
+        fmt::Debug,
+        vec::Vec,
+    },
 };
 
 use crate::{
     form::PortableForm,
-    interner::{Interner, UntrackedSymbol},
+    interner::{
+        Interner,
+        UntrackedSymbol,
+    },
     meta_type::MetaType,
     Type,
 };
@@ -104,7 +114,10 @@ impl Registry {
     ///
     /// This is an internal API and should not be called directly from the
     /// outside.
-    fn intern_type_id(&mut self, type_id: TypeIdDef) -> (bool, UntrackedSymbol<TypeIdDef>) {
+    fn intern_type_id(
+        &mut self,
+        type_id: TypeIdDef,
+    ) -> (bool, UntrackedSymbol<TypeIdDef>) {
         let (inserted, symbol) = self.type_table.intern_or_get(type_id);
         (inserted, symbol.into_untracked())
     }
@@ -160,7 +173,13 @@ impl Registry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{build::Fields, meta_type, Path, TypeDef, TypeInfo};
+    use crate::{
+        build::Fields,
+        meta_type,
+        Path,
+        TypeDef,
+        TypeInfo,
+    };
 
     #[test]
     fn recursive_struct_with_references() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -76,7 +76,7 @@ impl IntoPortable for &'static str {
 /// A type can be a sub-type of itself. In this case the registry has a builtin
 /// mechanism to stop recursion and avoid going into an infinite loop.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Registry {
     /// The cache for already registered types.
     ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -76,7 +76,7 @@ impl IntoPortable for &'static str {
 /// A type can be a sub-type of itself. In this case the registry has a builtin
 /// mechanism to stop recursion and avoid going into an infinite loop.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 pub struct Registry {
     /// The cache for already registered types.
     ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -23,11 +23,10 @@
 //! namespaces. The normal Rust namespace of a type is used, except for the Rust
 //! prelude types that live in the so-called root namespace which is empty.
 
+use core::any::TypeId;
+
 use crate::{
-    form::{
-        Form,
-        TypeIdDef,
-    },
+    form::Form,
     prelude::{
         collections::BTreeMap,
         fmt::Debug,
@@ -82,11 +81,11 @@ pub struct Registry {
     ///
     /// This is just an accessor to the actual database
     /// for all types found in the `types` field.
-    type_table: Interner<TypeIdDef>,
+    type_table: Interner<TypeId>,
     /// The database where registered types reside.
     ///
     /// The contents herein is used for serlialization.
-    types: BTreeMap<UntrackedSymbol<TypeIdDef>, Type<PortableForm>>,
+    types: BTreeMap<UntrackedSymbol<TypeId>, Type<PortableForm>>,
 }
 
 impl Default for Registry {
@@ -114,10 +113,7 @@ impl Registry {
     ///
     /// This is an internal API and should not be called directly from the
     /// outside.
-    fn intern_type_id(
-        &mut self,
-        type_id: TypeIdDef,
-    ) -> (bool, UntrackedSymbol<TypeIdDef>) {
+    fn intern_type_id(&mut self, type_id: TypeId) -> (bool, UntrackedSymbol<TypeId>) {
         let (inserted, symbol) = self.type_table.intern_or_get(type_id);
         (inserted, symbol.into_untracked())
     }
@@ -131,7 +127,7 @@ impl Registry {
     /// be used later to resolve back to the associated type definition.
     /// However, since this facility is going to be used for serialization
     /// purposes this functionality isn't needed anyway.
-    pub fn register_type(&mut self, ty: &MetaType) -> UntrackedSymbol<TypeIdDef> {
+    pub fn register_type(&mut self, ty: &MetaType) -> UntrackedSymbol<TypeId> {
         let (inserted, symbol) = self.intern_type_id(ty.type_id());
         if inserted {
             let portable_id = ty.type_info().into_portable(self);
@@ -141,7 +137,7 @@ impl Registry {
     }
 
     /// Calls `register_type` for each `MetaType` in the given `iter`.
-    pub fn register_types<I>(&mut self, iter: I) -> Vec<UntrackedSymbol<TypeIdDef>>
+    pub fn register_types<I>(&mut self, iter: I) -> Vec<UntrackedSymbol<TypeId>>
     where
         I: IntoIterator<Item = MetaType>,
     {
@@ -165,7 +161,7 @@ impl Registry {
     /// Returns an iterator over the types with their keys
     pub fn types(
         &self,
-    ) -> impl Iterator<Item = (&UntrackedSymbol<TypeIdDef>, &Type<PortableForm>)> {
+    ) -> impl Iterator<Item = (&UntrackedSymbol<TypeId>, &Type<PortableForm>)> {
         self.types.iter()
     }
 }

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -69,7 +69,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -69,6 +69,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -69,7 +69,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.

--- a/src/ty/composite.rs
+++ b/src/ty/composite.rs
@@ -69,7 +69,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefComposite<T: Form = MetaForm> {
     /// The fields of the composite type.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -71,7 +71,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -71,7 +71,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -71,7 +71,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.

--- a/src/ty/fields.rs
+++ b/src/ty/fields.rs
@@ -71,6 +71,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Field<T: Form = MetaForm> {
     /// The name of the field. None for unnamed fields.

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -61,7 +61,7 @@ pub use self::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
@@ -208,7 +208,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
@@ -297,7 +297,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -372,7 +372,7 @@ impl IntoPortable for TypeDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -425,7 +425,7 @@ pub enum TypeDefPrimitive {
 /// An array type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -486,7 +486,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -552,7 +552,7 @@ where
 /// A type to refer to a sequence of elements of the same type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
@@ -607,7 +607,7 @@ where
 /// A type wrapped in [`Compact`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
@@ -652,7 +652,7 @@ where
 /// enabled, but can be decoded or deserialized into the `PortableForm` without this feature.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -61,6 +61,7 @@ pub use self::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
@@ -207,6 +208,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
@@ -295,6 +297,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -369,6 +372,7 @@ impl IntoPortable for TypeDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -421,6 +425,7 @@ pub enum TypeDefPrimitive {
 /// An array type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -481,6 +486,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -546,6 +552,7 @@ where
 /// A type to refer to a sequence of elements of the same type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
@@ -600,6 +607,7 @@ where
 /// A type wrapped in [`Compact`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
@@ -644,6 +652,7 @@ where
 /// enabled, but can be decoded or deserialized into the `PortableForm` without this feature.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -61,7 +61,7 @@ pub use self::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
@@ -208,7 +208,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
@@ -297,7 +297,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -372,7 +372,7 @@ impl IntoPortable for TypeDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -425,7 +425,7 @@ pub enum TypeDefPrimitive {
 /// An array type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -486,7 +486,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -552,7 +552,7 @@ where
 /// A type to refer to a sequence of elements of the same type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
@@ -607,7 +607,7 @@ where
 /// A type wrapped in [`Compact`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
@@ -652,7 +652,7 @@ where
 /// enabled, but can be decoded or deserialized into the `PortableForm` without this feature.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].

--- a/src/ty/mod.rs
+++ b/src/ty/mod.rs
@@ -61,7 +61,7 @@ pub use self::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct Type<T: Form = MetaForm> {
     /// The unique path to the type. Can be empty for built-in types
@@ -208,7 +208,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, From, Debug, Encode)]
 pub struct TypeParameter<T: Form = MetaForm> {
     /// The name of the generic type parameter e.g. "T".
@@ -297,7 +297,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub enum TypeDef<T: Form = MetaForm> {
     /// A composite type (e.g. a struct or a tuple)
@@ -372,7 +372,7 @@ impl IntoPortable for TypeDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub enum TypeDefPrimitive {
     /// `bool` type
@@ -425,7 +425,7 @@ pub enum TypeDefPrimitive {
 /// An array type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefArray<T: Form = MetaForm> {
     /// The length of the array type.
@@ -486,7 +486,7 @@ where
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefTuple<T: Form = MetaForm> {
     /// The types of the tuple fields.
@@ -552,7 +552,7 @@ where
 /// A type to refer to a sequence of elements of the same type.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefSequence<T: Form = MetaForm> {
     /// The element type of the sequence type.
@@ -607,7 +607,7 @@ where
 /// A type wrapped in [`Compact`].
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefCompact<T: Form = MetaForm> {
     /// The type wrapped in [`Compact`], i.e. the `T` in `Compact<T>`.
@@ -652,7 +652,7 @@ where
 /// enabled, but can be decoded or deserialized into the `PortableForm` without this feature.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
 pub struct TypeDefBitSequence<T: Form = MetaForm> {
     /// The type implementing [`bitvec::store::BitStore`].

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -56,6 +56,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -56,7 +56,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -56,7 +56,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/path.rs
+++ b/src/ty/path.rs
@@ -56,7 +56,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode)]
 pub struct Path<T: Form = MetaForm> {
     /// The segments of the namespace.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -81,6 +81,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
@@ -154,6 +155,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -81,7 +81,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
@@ -155,7 +155,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -81,7 +81,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
@@ -155,7 +155,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.

--- a/src/ty/variant.rs
+++ b/src/ty/variant.rs
@@ -81,7 +81,7 @@ use serde::{
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, From, Encode)]
 pub struct TypeDefVariant<T: Form = MetaForm> {
     /// The variants of a variant type
@@ -155,7 +155,7 @@ where
     ))
 )]
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(all(feature = "std", feature = "schema"), derive(schemars::JsonSchema))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
 pub struct Variant<T: Form = MetaForm> {
     /// The name of the variant.


### PR DESCRIPTION
This PR adds support for schema generation required for ink! metadata verification. All types are now derive `schemars::JsonSchema` under an optional feature flag `schema`