### PR TITLE
Implement `TypeInfo` for `Arc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2023-05-15
+
+### Added
+- `TypeInfo` is now implemented for `Arc`
+
 ## [2.6.0] - 2023-04-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -30,6 +30,7 @@ use crate::prelude::{
         RangeInclusive,
     },
     string::String,
+    sync::Arc,
     vec::Vec,
 };
 
@@ -269,6 +270,17 @@ where
 }
 
 impl<T> TypeInfo for Box<T>
+where
+    T: TypeInfo + ?Sized + 'static,
+{
+    type Identity = T;
+
+    fn type_info() -> Type {
+        Self::Identity::type_info()
+    }
+}
+
+impl<T> TypeInfo for Arc<T>
 where
     T: TypeInfo + ?Sized + 'static,
 {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -37,6 +37,7 @@ cfg_if! {
             num,
             ops,
             string,
+            sync,
             vec,
         };
     } else {
@@ -46,6 +47,7 @@ cfg_if! {
             collections,
             format,
             string,
+            sync,
             vec,
         };
 


### PR DESCRIPTION
I'd like to replace a `Box` in one of the structs which implements `TypeInfo` with an `Arc`, but `TypeInfo` is not implemented for `Arc`, so let's make it that it is.