### PR TITLE
Expose `PortableType` as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@ pub use self::{
     portable::{
         PortableRegistry,
         PortableRegistryBuilder,
+        PortableType,
     },
     registry::{
         IntoPortable,

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -238,8 +238,10 @@ impl PortableRegistry {
 #[cfg_attr(any(feature = "std", feature = "decode"), derive(scale::Decode))]
 #[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct PortableType {
+    /// The ID of the portable type.
     #[codec(compact)]
     pub id: u32,
+    /// The portable form of the type.
     #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: Type<PortableForm>,
 }


### PR DESCRIPTION
This PR exposes the `PortableType` to users, similarly to the `MetaType`.

This change is needed by subxt to manually construct extrinsics types when converting from the metadata V15 to V14.

@paritytech/subxt-team 