### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2023-07-03
+
+- Expose `PortableType` as public [(#188)(https://github.com/paritytech/scale-info/pull/188)]
+
 ## [2.8.0] - 2023-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.9.0] - 2023-07-03
 
 ### Changed
-- Expose `PortableType` as public [(#188)(https://github.com/paritytech/scale-info/pull/188)]
+- Expose `PortableType` as public [(#188)](https://github.com/paritytech/scale-info/pull/188)
 
 ## [2.8.0] - 2023-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.9.0] - 2023-07-03
 
+### Changed
 - Expose `PortableType` as public [(#188)(https://github.com/paritytech/scale-info/pull/188)]
 
 ## [2.8.0] - 2023-06-21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.8.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.9.0", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.8.0"
+version = "2.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "2.8.0"
+version = "2.9.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -127,9 +127,7 @@ impl PortableRegistry {
 
             // Make sure any type params are also retained:
             for param in ty.ty.type_params.iter_mut() {
-                let Some(ty) = &param.ty else {
-                    continue
-                };
+                let Some(ty) = &param.ty else { continue };
                 let new_id = retain_type(ty.id, types, new_types, retained_mappings);
                 param.ty = Some(new_id).map(Into::into);
             }


### PR DESCRIPTION
## [2.9.0] - 2023-07-03

### Changed
- Expose `PortableType` as public [(#188)](https://github.com/paritytech/scale-info/pull/188)


@paritytech/subxt-team 