### PR TITLE
Introduce more solid `no_std` testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,10 @@ jobs:
       run: |
         cargo test --all --all-features
 
+    # We cannot do usual rust tests in `no_std`. Instead we perform tests in the main function.
+    # If any assert fails, we get an `Aborted (core dumped)` non-zero exit code.
+    # This should make the CI fail.
     - name: test no-std
       run: |
         cd ./test_suite/derive_tests_no_std
-        cargo build --no-default-features
+        cargo run --no-default-features

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -118,7 +118,7 @@ impl PortableRegistry {
             for param in ty.ty.type_params.iter_mut() {
                 let Some(ty) = &param.ty else { continue };
                 let new_id = retain_type(ty.id, types, new_types, retained_mappings);
-                param.ty = Some(new_id).map(Into::into);
+                param.ty = Some(Into::into(new_id));
             }
 
             // make sure any types inside this type are also retained and update the IDs:

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -10,7 +10,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scale-info = { path = "../..", default-features = false, features = ["derive"] }
+scale-info = { path = "../..", default-features = false, features = ["derive", "bit-vec", "decode"] }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "bit-vec"] }
+bitvec = { version = "1", default-features = false, features = ["alloc"] }
 libc = { version = "0.2", default-features = false }
 libc_alloc = { version = "1.0.6" }
 

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -11,8 +11,13 @@ license = "Apache-2.0"
 
 [dependencies]
 scale-info = { path = "../..", default-features = false, features = ["derive"] }
-scale = { package = "parity-scale-codec", version = "2", features = ["full"] }
-
 libc = { version = "0.2", default-features = false }
+libc_alloc = { version = "1.0.6" }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
 
 [workspace]

--- a/test_suite/derive_tests_no_std/rust-toolchain
+++ b/test_suite/derive_tests_no_std/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -51,24 +51,27 @@ fn test() {
     assert_eq!(E::<CLike>::type_info().type_params.len(), 1);
 }
 
+use bitvec::{order::Lsb0, vec::BitVec};
+use scale::{Decode, Encode};
 use scale_info::TypeInfo;
 
 #[allow(unused)]
-#[derive(TypeInfo)]
+#[derive(TypeInfo, Decode, Encode)]
 struct UnitStruct;
 
 #[allow(unused)]
-#[derive(TypeInfo)]
+#[derive(TypeInfo, Decode, Encode)]
 struct TupleStruct(u128, bool);
 
 #[allow(unused)]
-#[derive(TypeInfo)]
+#[derive(TypeInfo, Decode, Encode)]
 struct Struct<T> {
     t: T,
+    bitvec: BitVec<u16, Lsb0>,
 }
 
 #[allow(unused)]
-#[derive(TypeInfo)]
+#[derive(TypeInfo, Decode, Encode)]
 enum CLike {
     A,
     B,
@@ -76,7 +79,7 @@ enum CLike {
 }
 
 #[allow(unused)]
-#[derive(TypeInfo)]
+#[derive(TypeInfo, Decode, Encode)]
 enum E<T> {
     A(T),
     B { b: T },


### PR DESCRIPTION
The `no_std` tests we had before, did not enforce that our dependencies are all `no_std`. E.g. any dependency could use the standard library and still our `no_std` tests would succeed.

We now circumvent this by defining a custom panic handler and a global allocator such that any dependencies that make use of the standard library will fail to compile, because in that case there would be more than one global allocator and panic handler. Inspiration was taken from [serde's no_std testing](https://github.com/serde-rs/serde/blob/master/test_suite/no_std/src/main.rs) (Thanks for the hint @niklasad1).

Testing in `no_std` is a bit difficult, but one approach I take here is just running a main function, that returns `Aborted (core dumped)` with a non-zero exit code if a panic is encountered (e.g. in an untrue assert). This can run in the CI to make sure the code runs and not only compiles in a `no_std` environment.