### PR TITLE
chore: bump scale-info derive to v2.11

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-derive"
-version = "2.10.0"
+version = "2.11.0"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",


### PR DESCRIPTION
I missed this in the review #202 and technically it's not needed but nice with unified versions.