### PR TITLE
Change type id to new type id in `PortableRegistry::retain()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2024-03-22
+
+- Fix a bug in the `PortableRegistry::retain()` method, where a type's id field was not adjusted to the new position of the type in the retained `Vec`.
+
 ## [2.11.0] - 2024-03-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info"
-version = "2.11.0"
+version = "2.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.60.0"

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -181,6 +181,7 @@ impl PortableRegistry {
 
             // Retain this type, having updated any inner IDs:
             let new_id = new_types.len() as u32;
+            ty.id = new_id;
             new_types.push(ty);
             retained_mappings.insert(id, new_id);
             new_id


### PR DESCRIPTION
The type's id should be set to the new id to reflect the correct position in the `Vec` holding the types of the `PortableRegistry`.