### PR TITLE
Ensure Cargo.tomls remain aligned and prep to release 2.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories.workspace = true
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.10.0", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.11.1", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "0.99.1", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "scale-info"
-version = "2.11.1"
-authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
-rust-version = "1.60.0"
-
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/paritytech/scale-info"
-documentation = "https://docs.rs/scale-info"
-homepage = "https://www.parity.io/"
 description = "Info about SCALE encodable Rust types"
-categories = ["no-std", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+categories.workspace = true
 
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
@@ -55,3 +55,18 @@ members = [
     "derive",
     "test_suite",
 ]
+
+[workspace.package]
+version = "2.11.1"
+authors = [
+    "Parity Technologies <admin@parity.io>",
+    "Centrality Developers <support@centrality.ai>",
+]
+edition = "2021"
+rust-version = "1.60.0"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/paritytech/scale-info"
+documentation = "https://docs.rs/scale-info"
+homepage = "https://www.parity.io/"
+categories = ["no-std", "encoding"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
 name = "scale-info-derive"
-version = "2.11.0"
-authors = [
-    "Parity Technologies <admin@parity.io>",
-    "Centrality Developers <support@centrality.ai>",
-]
-edition = "2021"
-rust-version = "1.56.1"
-
-license = "Apache-2.0"
-repository = "https://github.com/paritytech/scale-info"
-documentation = "https://docs.rs/scale-info"
-homepage = "https://www.parity.io/"
 description = "Derive type info for SCALE encodable types"
-categories = ["no-std", "encoding"]
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+categories.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Moved some crate properties to a workspace field to ensure that they remain aligned, and set to 2.11.1 everywhere.