### PR TITLE
Allow renaming struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Add `rename` attribute for renaming struct fields [(#209)](https://github.com/paritytech/scale-info/pull/209)
+
 ## [2.11.6] - 2024-11-20
 
 - add `#[allow(deprecated)]` attribute to the generated code.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -184,12 +184,12 @@ impl TypeInfoImpl {
                 } else {
                     quote!(ty)
                 };
-                let name = if let Some(ident) = utils::maybe_renamed(f) {
-                    quote!(.name(#ident))
-                } else if let Some(ident) = ident {
-                    quote!(.name(::core::stringify!(#ident)))
-                } else {
-                    quote!()
+                let name = match utils::maybe_renamed(f) {
+                    Some(ident) => quote!(.name(#ident)),
+                    None => ident
+                        .as_ref()
+                        .map(|ident| quote!(.name(::core::stringify!(#ident))))
+                        .unwrap_or(quote!()),
                 };
                 quote!(
                     .field(|f| f

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -29,7 +29,7 @@ use syn::{
     punctuated::Punctuated,
     token::Comma,
     visit_mut::VisitMut,
-    Data, DataEnum, DataStruct, DeriveInput, Field, Fields, Ident, Lifetime,
+    Data, DataEnum, DataStruct, DeriveInput, Field, Fields, Ident, Lifetime, Lit, Meta,
 };
 
 #[proc_macro_derive(TypeInfo, attributes(scale_info, codec))]
@@ -184,11 +184,22 @@ impl TypeInfoImpl {
                 } else {
                     quote!(ty)
                 };
-                let name = if let Some(ident) = ident {
+                let name = utils::find_meta_item("scale_info", f.attrs.iter(), |meta| {
+                    if let Meta::NameValue(value) = meta {
+                        if value.path.is_ident("rename") {
+                            if let Lit::Str(lit) = &value.lit {
+                                let ident = &lit.value();
+                                return Some(quote!(.name(#ident)));
+                            }
+                        }
+                    }
+                    None
+                })
+                .unwrap_or(if let Some(ident) = ident {
                     quote!(.name(::core::stringify!(#ident)))
                 } else {
                     quote!()
-                };
+                });
                 quote!(
                     .field(|f| f
                         .#type_of_method::<#ty>()

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -103,9 +103,13 @@ pub fn maybe_renamed(field: &syn::Field) -> Option<String> {
         .iter()
         .filter(|attr| attr.style == AttrStyle::Outer);
     scale_info_meta_item(outer_attrs, |meta| {
-        if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
+        if let Meta::NameValue(ref nv) = meta {
             if nv.path.is_ident("rename") {
-                if let Lit::Str(ref v) = nv.lit {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref v),
+                    ..
+                }) = nv.value
+                {
                     return Some(v.value());
                 }
             }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -105,7 +105,7 @@ where
     find_meta_item("codec", itr, pred)
 }
 
-fn find_meta_item<'a, F, R, I, M>(kind: &str, mut itr: I, mut pred: F) -> Option<R>
+pub(crate) fn find_meta_item<'a, F, R, I, M>(kind: &str, mut itr: I, mut pred: F) -> Option<R>
 where
     F: FnMut(M) -> Option<R> + Clone,
     I: Iterator<Item = &'a Attribute>,

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -96,6 +96,25 @@ pub fn should_skip(attrs: &[Attribute]) -> bool {
     .is_some()
 }
 
+/// Look for a `#[scale_info(rename = $str)]` outer attribute on the given `Field`.
+pub fn maybe_renamed(field: &syn::Field) -> Option<String> {
+    let outer_attrs = field
+        .attrs
+        .iter()
+        .filter(|attr| attr.style == AttrStyle::Outer);
+    scale_info_meta_item(outer_attrs, |meta| {
+        if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
+            if nv.path.is_ident("rename") {
+                if let Lit::Str(ref v) = nv.lit {
+                    return Some(v.value());
+                }
+            }
+        }
+
+        None
+    })
+}
+
 fn codec_meta_item<'a, F, R, I, M>(itr: I, pred: F) -> Option<R>
 where
     F: FnMut(M) -> Option<R> + Clone,
@@ -105,7 +124,16 @@ where
     find_meta_item("codec", itr, pred)
 }
 
-pub(crate) fn find_meta_item<'a, F, R, I, M>(kind: &str, mut itr: I, mut pred: F) -> Option<R>
+fn scale_info_meta_item<'a, F, R, I, M>(itr: I, pred: F) -> Option<R>
+where
+    F: FnMut(M) -> Option<R> + Clone,
+    I: Iterator<Item = &'a Attribute>,
+    M: Parse,
+{
+    find_meta_item("scale_info", itr, pred)
+}
+
+fn find_meta_item<'a, F, R, I, M>(kind: &str, mut itr: I, mut pred: F) -> Option<R>
 where
     F: FnMut(M) -> Option<R> + Clone,
     I: Iterator<Item = &'a Attribute>,

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -1,5 +1,4 @@
-// Copyright 2019-2020
-//     Parity Technologies (UK) Ltd. Technologies (UK) Ltd.
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -907,3 +907,19 @@ fn replace_segments_works() {
 
     assert_type!(R, ty);
 }
+
+#[test]
+fn rename_field() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    pub struct S {
+        #[scale_info(rename = "type")]
+        r#type: bool,
+    }
+
+    let ty = Type::builder()
+        .path(Path::new("S", "derive"))
+        .composite(Fields::named().field(|f| f.ty::<bool>().name("type").type_name("bool")));
+
+    assert_type!(S, ty);
+}

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -915,11 +915,17 @@ fn rename_field() {
     pub struct S {
         #[scale_info(rename = "type")]
         r#type: bool,
+        #[scale_info(rename = "bar")]
+        foo: u8,
+        baz: u16,
     }
 
-    let ty = Type::builder()
-        .path(Path::new("S", "derive"))
-        .composite(Fields::named().field(|f| f.ty::<bool>().name("type").type_name("bool")));
+    let ty = Type::builder().path(Path::new("S", "derive")).composite(
+        Fields::named()
+            .field(|f| f.ty::<bool>().name("type").type_name("bool"))
+            .field(|f| f.ty::<u8>().name("bar").type_name("u8"))
+            .field(|f| f.ty::<u16>().name("baz").type_name("u16")),
+    );
 
     assert_type!(S, ty);
 }


### PR DESCRIPTION
This PR introduces an attribute for struct fields to rename the name of a field.

```rs
#[derive(TypeInfo)]
struct S {
  #[scale_info(rename = "type")]
  r#type: bool,
}
```