### PR TITLE
chore: release v2.11.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ categories.workspace = true
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.11.3", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.11.4", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "1.0.0", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
-scale-info-derive = { version = "2.11.3", path = "derive" }
+scale-info-derive = { version = "2.11.4", path = "derive" }
 
 [features]
 default = ["std"]
@@ -60,7 +60,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.11.3"
+version = "2.11.4"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",


### PR DESCRIPTION
```markdown
## [2.11.4] - 2024-10-22
- Bump `derive_more` to version 1.0.0.
```

Forgot to bump the versions in the prior PR where I already added the CHANGELOG