### PR TITLE
chore(deps): Update syn to 2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = { version = "1.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
+syn = { version = "2.0", features = ["derive", "visit", "visit-mut", "extra-traits"] }
 proc-macro2 = "1.0"
 proc-macro-crate = "3"
 

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -48,13 +48,12 @@ impl Attributes {
         let mut replace_segments = Vec::new();
 
         let attributes_parser = |input: &ParseBuffer| {
-            let attrs: Punctuated<ScaleInfoAttr, Token![,]> =
-                input.parse_terminated(ScaleInfoAttr::parse)?;
+            let attrs = input.parse_terminated(ScaleInfoAttr::parse, Token![,])?;
             Ok(attrs)
         };
 
         for attr in &item.attrs {
-            if !attr.path.is_ident(SCALE_INFO) {
+            if !attr.path().is_ident(SCALE_INFO) {
                 continue;
             }
             let scale_info_attrs = attr.parse_args_with(attributes_parser)?;
@@ -177,7 +176,7 @@ impl Parse for BoundsAttr {
         input.parse::<keywords::bounds>()?;
         let content;
         syn::parenthesized!(content in input);
-        let predicates = content.parse_terminated(syn::WherePredicate::parse)?;
+        let predicates = content.parse_terminated(syn::WherePredicate::parse, Token![,])?;
         Ok(Self { predicates })
     }
 }
@@ -215,7 +214,7 @@ impl Parse for SkipTypeParamsAttr {
         input.parse::<keywords::skip_type_params>()?;
         let content;
         syn::parenthesized!(content in input);
-        let type_params = content.parse_terminated(syn::TypeParam::parse)?;
+        let type_params = content.parse_terminated(syn::TypeParam::parse, Token![,])?;
         Ok(Self { type_params })
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -261,22 +261,24 @@ impl TypeInfoImpl {
         let docs = attrs
             .iter()
             .filter_map(|attr| {
-                if let Ok(syn::Meta::NameValue(meta)) = attr.parse_meta() {
-                    if meta.path.get_ident().map_or(false, |ident| ident == "doc") {
-                        if let syn::Lit::Str(lit) = &meta.lit {
-                            let lit_value = lit.value();
-                            let stripped = lit_value.strip_prefix(' ').unwrap_or(&lit_value);
-                            let lit: syn::Lit = parse_quote!(#stripped);
-                            Some(lit)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    None
+                if !attr.path().is_ident("doc") {
+                    return None;
                 }
+                let syn::Meta::NameValue(nv) = &attr.meta else {
+                    return None;
+                };
+                let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = &nv.value
+                else {
+                    return None;
+                };
+
+                let lit_value = s.value();
+                let stripped = lit_value.strip_prefix(' ').unwrap_or(&lit_value);
+                let lit: syn::Lit = parse_quote!(#stripped);
+                Some(lit)
             })
             .collect::<Vec<_>>();
 

--- a/test_suite/tests/codec.rs
+++ b/test_suite/tests/codec.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![no_std]
 #![allow(unused)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use info::{self as scale_info};

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use core::ops::{Range, RangeInclusive};
 

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![no_std]
 #![allow(unused)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 
 use info::{self as scale_info};


### PR DESCRIPTION
Close https://github.com/paritytech/scale-info/issues/213

Note that syn 1 is still currently being bought in by `parity-scale-codec`, so we should update that too:

```
scale-info v2.11.4
├── cfg-if v1.0.0
├── derive_more v1.0.0
│   └── derive_more-impl v1.0.0 (proc-macro)
│       ├── proc-macro2 v1.0.89
│       │   └── unicode-ident v1.0.13
│       ├── quote v1.0.37
│       │   └── proc-macro2 v1.0.89 (*)
│       └── syn v2.0.82
│           ├── proc-macro2 v1.0.89 (*)
│           ├── quote v1.0.37 (*)
│           └── unicode-ident v1.0.13
└── parity-scale-codec v3.6.12
    ├── arrayvec v0.7.6
    ├── byte-slice-cast v1.2.2
    ├── impl-trait-for-tuples v0.2.2 (proc-macro)
    │   ├── proc-macro2 v1.0.89 (*)
    │   ├── quote v1.0.37 (*)
    │   └── syn v1.0.109
    │       ├── proc-macro2 v1.0.89 (*)
    │       ├── quote v1.0.37 (*)
    │       └── unicode-ident v1.0.13
    ├── parity-scale-codec-derive v3.6.12 (proc-macro)
    │   ├── proc-macro-crate v3.2.0
    │   │   └── toml_edit v0.22.22
    │   │       ├── indexmap v2.6.0
    │   │       │   ├── equivalent v1.0.1
    │   │       │   └── hashbrown v0.15.0
    │   │       ├── toml_datetime v0.6.8
    │   │       └── winnow v0.6.20
    │   ├── proc-macro2 v1.0.89 (*)
    │   ├── quote v1.0.37 (*)
    │   └── syn v1.0.109 (*)
    └── serde v1.0.213
```