### PR TITLE
add #[allow(deprecated)] for generated code

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -44,7 +44,7 @@ fn generate(input: TokenStream2) -> Result<TokenStream2> {
     let type_info_impl = TypeInfoImpl::parse(input)?;
     let type_info_impl_toks = type_info_impl.expand()?;
     Ok(quote! {
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        #[allow(non_upper_case_globals, deprecated, unused_attributes, unused_qualifications)]
         const _: () = {
             #type_info_impl_toks;
         };


### PR DESCRIPTION
### Description 
Add `allow(deprecated)` to the code generated by scale-info. This removes noisy warnings when deriving on a `enum` types with deprecated variants or variants with deprecated contents.One of the times this happens is when using types marked as deprecated with `frame-support::construct_runtime!` with no way to suppress the noisy warnings from the generated code.