### PR TITLE
Release v2.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.5] - 2024-11-20
+
+- add `#[allow(deprecated)]` attribute to the generated code.
+
 ## [2.11.5] - 2024-10-24
 
 - Bump `syn` to 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.11.5] - 2024-11-20
+## [2.11.6] - 2024-11-20
 
 - add `#[allow(deprecated)]` attribute to the generated code.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ categories.workspace = true
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 cfg-if = "1.0"
-scale-info-derive = { version = "2.11.5", path = "derive", default-features = false, optional = true }
+scale-info-derive = { version = "2.11.6", path = "derive", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
 derive_more = { version = "1.0.0", default-features = false, features = ["from"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
-scale-info-derive = { version = "2.11.4", path = "derive" }
+scale-info-derive = { version = "2.11.6", path = "derive" }
 
 [features]
 default = ["std"]
@@ -60,7 +60,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.11.5"
+version = "2.11.6"
 authors = [
     "Parity Technologies <admin@parity.io>",
     "Centrality Developers <support@centrality.ai>",

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
@@ -10,14 +10,14 @@ error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` an
 14 |     Thing(#[codec(index = 3)] u32),
    |                   ^^^^^
 
-error: expected literal
-  --> tests/ui/fail_with_invalid_codec_attrs.rs:19:21
+error: Invalid attribute on variant, only `#[codec(skip)]` and `#[codec(index = $u8)]` are accepted.
+  --> tests/ui/fail_with_invalid_codec_attrs.rs:19:13
    |
 19 |     #[codec(index = a)]
-   |                     ^
+   |             ^^^^^
 
-error: expected literal
-  --> tests/ui/fail_with_invalid_codec_attrs.rs:25:25
+error: Invalid attribute on variant, only `#[codec(skip)]` and `#[codec(index = $u8)]` are accepted.
+  --> tests/ui/fail_with_invalid_codec_attrs.rs:25:7
    |
 25 |     #[codec(encode_as = u8, compact)]
-   |                         ^^
+   |       ^^^^^

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
@@ -2,13 +2,13 @@ error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` an
  --> tests/ui/fail_with_invalid_codec_attrs.rs:8:7
   |
 8 |     #[codec(skip, compact)]
-  |       ^^^^^
+  |       ^^^^^^^^^^^^^^^^^^^^
 
 error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` and `#[codec(encoded_as = "$EncodeAs")]` are accepted.
   --> tests/ui/fail_with_invalid_codec_attrs.rs:14:19
    |
 14 |     Thing(#[codec(index = 3)] u32),
-   |                   ^^^^^
+   |                   ^^^^^^^^^
 
 error: expected literal
   --> tests/ui/fail_with_invalid_codec_attrs.rs:19:21

--- a/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
+++ b/test_suite/tests/ui/fail_with_invalid_codec_attrs.stderr
@@ -2,13 +2,13 @@ error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` an
  --> tests/ui/fail_with_invalid_codec_attrs.rs:8:7
   |
 8 |     #[codec(skip, compact)]
-  |       ^^^^^^^^^^^^^^^^^^^^
+  |       ^^^^^
 
 error: Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` and `#[codec(encoded_as = "$EncodeAs")]` are accepted.
   --> tests/ui/fail_with_invalid_codec_attrs.rs:14:19
    |
 14 |     Thing(#[codec(index = 3)] u32),
-   |                   ^^^^^^^^^
+   |                   ^^^^^
 
 error: expected literal
   --> tests/ui/fail_with_invalid_codec_attrs.rs:19:21


### PR DESCRIPTION
### Description 

- adds `#[allow(deprecated)]` attribute to the generated code