### PR TITLE
chore: mark TypeInfo derived impl as automatically_derived

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -110,6 +110,7 @@ impl TypeInfoImpl {
         });
 
         Ok(quote! {
+            #[automatically_derived]
             impl #impl_generics #scale_info::TypeInfo for #ident #ty_generics #where_clause {
                 type Identity = Self;
                 fn type_info() -> #scale_info::Type {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -121,7 +121,7 @@ fn type_contains_idents(ty: &Type, idents: &[Ident]) -> bool {
         idents: &'a [Ident],
     }
 
-    impl<'a, 'ast> Visit<'ast> for ContainIdents<'a> {
+    impl<'ast> Visit<'ast> for ContainIdents<'_> {
         fn visit_ident(&mut self, i: &'ast Ident) {
             if self.idents.iter().any(|id| id == i) {
                 self.result = true;
@@ -145,7 +145,7 @@ fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
         ident: &'a Ident,
     }
 
-    impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
+    impl<'ast> Visit<'ast> for TypePathStartsWithIdent<'_> {
         fn visit_type_path(&mut self, i: &'ast TypePath) {
             if i.qself.is_none() {
                 if let Some(segment) = i.path.segments.first() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -294,7 +294,7 @@ fn basic_enum_with_index() {
     #[allow(unused)]
     #[derive(Encode)]
     enum IndexedRustEnum {
-        #[codec(index = 3)]
+        #[codec(index = 4)]
         A(bool),
         #[codec(index = 0)]
         B {
@@ -312,7 +312,7 @@ fn basic_enum_with_index() {
                 .variant(
                     Variants::new()
                         .variant("A", |v| {
-                            v.index(3).fields(
+                            v.index(4).fields(
                                 Fields::unnamed().field(|f| f.ty::<bool>().type_name("bool")),
                             )
                         })
@@ -338,7 +338,7 @@ fn basic_enum_with_index() {
         .variant(
             Variants::new()
                 .variant("A", |v| {
-                    v.index(3)
+                    v.index(4)
                         .fields(Fields::unnamed().field(|f| f.ty::<bool>().type_name("bool")))
                 })
                 .variant("B", |v| {

--- a/test_suite/tests/ui/fail_missing_derive.stderr
+++ b/test_suite/tests/ui/fail_missing_derive.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `PawType<u16>: TypeInfo` is not satisfied
   --> tests/ui/fail_missing_derive.rs:19:24
    |
 19 |     assert_type_info::<Cat<bool, u8, u16>>();
-   |                        ^^^^^^^^^^^^^^^^^^ the trait `TypeInfo` is not implemented for `PawType<u16>`, which is required by `Cat<bool, u8, u16>: TypeInfo`
+   |                        ^^^^^^^^^^^^^^^^^^ the trait `TypeInfo` is not implemented for `PawType<u16>`
    |
    = help: the following other types implement trait `TypeInfo`:
              &T


### PR DESCRIPTION
As per rust-lang/rust#120185, functions with their enclosing impl body marked as `#[automatically_derived]` won't be featured in coverage reports.

An example:
<img width="629" alt="Screenshot 2025-02-14 at 08 05 07" src="https://github.com/user-attachments/assets/d110bc8c-a02b-4c4a-80d8-4d2f74da561c" />
