### PR TITLE
fix: no-std derive start fn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,4 +61,5 @@ jobs:
     - name: test no-std
       run: |
         cd ./test_suite/derive_tests_no_std
-        cargo run --no-default-features
+        rustup target add x86_64-unknown-none
+        cargo run --target x86_64-unknown-none --no-default-features

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: check test clean
+
+check:
+	cargo clippy --all-targets -- -D warnings
+	cargo clippy --all --all-features -- -D warnings
+	cargo check --no-default-features --features bit-vec
+	cargo check --no-default-features --features docs
+	cargo check --no-default-features --features serde
+	cargo check --no-default-features --features serde,decode
+	cargo check --no-default-features --features schema
+
+test:
+	cargo test --all --all-features
+	cd ./test_suite/derive_tests_no_std; \
+		cargo run --target x86_64-unknown-none --no-default-features
+
+clean:
+	cargo clean
+	cd ./test_suite/derive_tests_no_std; \
+		cargo clean

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.84.1"
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-none"]

--- a/test_suite/derive_tests_no_std/src/main.rs
+++ b/test_suite/derive_tests_no_std/src/main.rs
@@ -12,14 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #![allow(internal_features)]
-#![feature(lang_items, start)]
-#![feature(alloc_error_handler)]
+#![feature(lang_items, alloc_error_handler)]
 #![no_std]
+#![no_main]
 
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
+#[no_mangle]
+pub extern "C" fn _start() {
     test();
-    0
+
+    use core::arch::asm;
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") 60,
+            in("rdi") 0,
+            options(noreturn)
+        );
+    }
 }
 
 #[lang = "eh_personality"]


### PR DESCRIPTION
Closes #219 by switching to the manual `_start` function. It is required to compile the binary targeting a none-linux triple to avoid having it codegen the original `_start` function, which then requires `__libc_start_main`.